### PR TITLE
Add table association helpers and shapes tooltips from obs

### DIFF
--- a/docs/docs/core/elements.mdx
+++ b/docs/docs/core/elements.mdx
@@ -193,8 +193,8 @@ AnnData access.
 Planned API evolution:
 the current `loadObsColumns()` helper is optimized for association / tooltip
 lookups and should be treated as a convenience API. We expect to add a more
-explicit typed dataframe-column API later, rather than baking string-normalized
-column reads into every table workflow.
+explicit typed dataframe-column API later, while keeping value-to-string
+formatting at the rendering boundary rather than in the query layer.
 
 ### Attributes Schema
 

--- a/docs/docs/core/elements.mdx
+++ b/docs/docs/core/elements.mdx
@@ -99,6 +99,11 @@ type RasterAttrs = {
 
 Labels are segmentation masks stored as OME-NGFF multiscale rasters, identical in structure to images.
 
+Conceptually, labels and shapes are both ways of encoding spatial features. For
+labels, the picked feature identity will come from raster values such as
+`ObjectID`-style segment ids. For shapes, feature identity comes from the
+element's index / instance ids.
+
 ```ts
 const labels = sdata.labels?.['my_segmentation'];
 
@@ -118,13 +123,16 @@ const shapes = sdata.shapes?.['cell_boundaries'];
 // Load geometry data
 const polygons = await shapes.loadPolygonShapes();  // For polygon geometries
 const circles = await shapes.loadCircleShapes();    // For circle/point geometries
-const indices = await shapes.loadShapesIndex();
+const featureIds = await shapes.loadFeatureIds();
 
 // Access metadata
 shapes.attrs.axes;                    // e.g., ['x', 'y']
 shapes.attrs['encoding-type'];        // e.g., 'ngff:shapes'
 shapes.attrs.coordinateTransformations;
 ```
+
+`loadFeatureIds()` is the method to use when you want to associate picked
+shapes with table rows.
 
 ### Attributes Schema
 
@@ -161,7 +169,7 @@ const table = sdata.tables?.['annotations'];
 const adata = await table.getAnnDataJS();
 
 // Access region annotation metadata
-table.attrs.instance_key;   // Column name for instance IDs
+table.attrs.instance_key;   // Column name for feature IDs / instance IDs
 table.attrs.region;         // Element(s) this table annotates
 table.attrs.region_key;     // Column name linking to region
 ```
@@ -208,4 +216,3 @@ for (const [csName, transform] of allTransforms) {
   console.log(`${csName}:`, transform.toMatrix());
 }
 ```
-

--- a/docs/docs/core/elements.mdx
+++ b/docs/docs/core/elements.mdx
@@ -134,6 +134,12 @@ shapes.attrs.coordinateTransformations;
 `loadFeatureIds()` is the method to use when you want to associate picked
 shapes with table rows.
 
+Implementation note:
+`ShapesElement.loadFeatureIds()` currently relies on a lightly adapted
+Vitessce-derived loader under the hood. We intentionally allow newer
+`ngff:shapes` metadata revisions to use the same parquet-backed feature-id path
+rather than keying support to one exact version string.
+
 ### Attributes Schema
 
 ```ts
@@ -168,11 +174,27 @@ const table = sdata.tables?.['annotations'];
 // Get as AnnData.js object for full access
 const adata = await table.getAnnDataJS();
 
+// Load row ids / selected obs columns through SpatialData.js loaders
+const rowIds = await table.loadObsIndex();
+const regionColumns = await table.loadObsColumns(['region']);
+
 // Access region annotation metadata
 table.attrs.instance_key;   // Column name for feature IDs / instance IDs
 table.attrs.region;         // Element(s) this table annotates
 table.attrs.region_key;     // Column name linking to region
 ```
+
+Implementation note:
+`loadObsIndex()` and `loadObsColumns()` are used by the feature-association
+helpers and currently stay on the direct zarr/parquet loader path rather than
+depending on `anndata.js`. `getAnnDataJS()` remains available for higher-level
+AnnData access.
+
+Planned API evolution:
+the current `loadObsColumns()` helper is optimized for association / tooltip
+lookups and should be treated as a convenience API. We expect to add a more
+explicit typed dataframe-column API later, rather than baking string-normalized
+column reads into every table workflow.
 
 ### Attributes Schema
 

--- a/docs/docs/core/internals.mdx
+++ b/docs/docs/core/internals.mdx
@@ -34,6 +34,52 @@ The package is organized into these internal modules:
 └── types.ts        # Core type definitions
 ```
 
+## Documented Divergences
+
+Some internal loaders started from upstream Vitessce implementations but have
+already diverged in a few deliberate ways. We try to keep those divergences
+small, documented, and tied to higher-level API goals rather than ad hoc fixes.
+
+### `VShapesSource.ts`
+
+`VShapesSource.ts` began as a Vitessce-derived shapes loader. The current
+intentional divergences are:
+
+- TypeScript cleanup and normalization.
+- Modern `ngff:shapes` metadata revisions are routed through the same
+  parquet-backed path as the older supported modern format, instead of requiring
+  one exact version string.
+
+Why this exists:
+- `ShapesElement.loadFeatureIds()` is part of the high-level feature-association
+  story used by vis tooltip / picked-feature workflows.
+- In practice, stable feature-id loading is the behavior we need to preserve,
+  even when upstream metadata version strings move forward.
+
+Planned evolution:
+- keep `VShapesSource.ts` narrowly scoped to geometry / feature-id loading
+- review how that relates to use of e.g. https://github.com/geoarrow/deck.gl-layers/ in future
+- avoid pushing more vis policy into this file
+- if the divergence grows, prefer moving compatibility logic into a more
+  explicitly SpatialData.js-owned layer rather than silently accumulating it
+  here
+
+### Table Access Helpers
+
+`TableElement.getAnnDataJS()` is still exposed, but feature-association helpers
+such as `loadObsIndex()` and `loadObsColumns()` now prefer the direct
+zarr/parquet loader path in `VTableSource.ts`.
+
+Why this exists:
+- these reads sit on the hot path for table-to-spatial-feature association
+- we want them to remain usable even when wrapper libraries lag behind the
+  relevant zarr/string-dtype support
+
+Planned evolution:
+- add clearer typed dataframe-column accessors for general table use
+- keep the current convenience helpers focused on association / tooltip use
+- continue feeding capability gaps back upstream to `anndata.js`
+
 ## Element Factory (Internal)
 
 Elements are created internally when loading stores. These functions are not intended for application use:
@@ -194,4 +240,3 @@ You can import `Result` and its utilities from either `@spatialdata/core` or `@s
 This is currently a custom implementation for simplicity and to avoid dependencies. We may review using an existing Result library (such as `neverthrow` or `ts-result`) in the future, but for now this provides a lightweight, dependency-free solution.
 
 :::
-

--- a/packages/core/src/models/VAnnDataSource.ts
+++ b/packages/core/src/models/VAnnDataSource.ts
@@ -2,7 +2,7 @@ import { open as zarrOpen, get as zarrGet } from 'zarrita';
 import { dirname } from '../Vutils';
 import ZarrDataSource from './VZarrDataSource';
 import type { DataSourceParams } from '../Vutils';
-
+import type { TableColumnData } from '../types';
 
 
 function prependSlash(path: string) {
@@ -21,9 +21,9 @@ function prependSlash(path: string) {
  * like loading cell names and ids. It inherits from AbstractLoader.
  */
 export default class AnnDataSource extends ZarrDataSource {
-  promises: Map<string, Promise<string[] | string[][] | undefined>>;
-  obsIndex?: Promise<string[]>;
-  varIndex?: Promise<string[]>;
+  promises: Map<string, Promise<TableColumnData | TableColumnData[] | undefined>>;
+  obsIndex?: Promise<TableColumnData>;
+  varIndex?: Promise<TableColumnData>;
   varAlias?: string[];
   constructor(params: DataSourceParams) {
     super(params);
@@ -32,9 +32,9 @@ export default class AnnDataSource extends ZarrDataSource {
 
   /**
    *
-   * @param paths Paths to multiple string-valued columns
+   * @param paths Paths to multiple dataframe columns
    * within the obs dataframe.
-   * @returns each column as an array of strings, ordered the same as the paths.
+   * @returns each column as an array of primitive values, ordered the same as the paths.
    */
   loadObsColumns(paths: string[] | string[][]) {
     return this._loadColumns(paths);
@@ -42,9 +42,9 @@ export default class AnnDataSource extends ZarrDataSource {
 
   /**
    *
-   * @param paths Paths to multiple string-valued columns
+   * @param paths Paths to multiple dataframe columns
    * within the var dataframe.
-   * @returns each column as an array of strings, ordered the same as the paths.
+   * @returns each column as an array of primitive values, ordered the same as the paths.
    */
   loadVarColumns(paths: string[] | string[][]) {
     return this._loadColumns(paths);
@@ -56,12 +56,12 @@ export default class AnnDataSource extends ZarrDataSource {
    * which have different ways of specifying location.
    * @param {string[] | string[][]} paths An array of strings like
    * "obs/leiden" or "obs/bulk_labels."
-   * @returns {Promise<(undefined | string[] | string[][])[]>} A promise
+   * @returns {Promise<(undefined | TableColumnData | TableColumnData[])[]>} A promise
    * for an array of ids with one per cell.
    */
   _loadColumns(paths: string[] | string[][]) {
     const promises = paths.map((path) => {
-      const getCol = (col: string): Promise<string[]> => {
+      const getCol = (col: string): Promise<TableColumnData> => {
         if (!this.promises.has(col)) {
           const obsPromise = this._loadColumn(col).catch((err) => {
             // clear from cache if promise rejects
@@ -71,7 +71,7 @@ export default class AnnDataSource extends ZarrDataSource {
           });
           this.promises.set(col, obsPromise);
         }
-        return this.promises.get(col) as Promise<string[]>;
+        return this.promises.get(col) as Promise<TableColumnData>;
       };
       if (!path) {
         return Promise.resolve(undefined);
@@ -131,10 +131,10 @@ export default class AnnDataSource extends ZarrDataSource {
     );
     const values = await zarrGet(arr, [null]);
     const { data } = values;
-    const mappedValues = Array.from(data).map(
-      i => (!categoriesValues ? String(i) : categoriesValues[i as number]),
-    );
-    return mappedValues;
+    if (!categoriesValues) {
+      return data as TableColumnData;
+    }
+    return Array.from(data, (i) => categoriesValues[i as number]);
   }
 
   /**
@@ -199,7 +199,7 @@ export default class AnnDataSource extends ZarrDataSource {
   /**
    * Class method for loading the obs index.
    * @param {string|undefined} path Used by subclasses.
-   * @returns {Promise<string[]>} An promise for a zarr array
+   * @returns {Promise<TableColumnData>} An promise for a zarr array
    * containing the indices.
    */
   loadObsIndex(path?: string) {
@@ -214,7 +214,7 @@ export default class AnnDataSource extends ZarrDataSource {
   /**
    * Class method for loading the obs index.
    * @param {string|undefined} path Used by subclasses.
-   * @returns {Promise<string[]>} An promise for a zarr array
+   * @returns {Promise<TableColumnData>} An promise for a zarr array
    * containing the indices.
    */
   loadDataFrameIndex(
@@ -229,7 +229,7 @@ export default class AnnDataSource extends ZarrDataSource {
   /**
    * Class method for loading the var index.
    * @param {string|undefined} path Used by subclasses.
-   * @returns {Promise<string[]>} An promise for a zarr array containing the indices.
+   * @returns {Promise<TableColumnData>} An promise for a zarr array containing the indices.
    */
   loadVarIndex(
     // eslint-disable-next-line no-unused-vars
@@ -256,14 +256,22 @@ export default class AnnDataSource extends ZarrDataSource {
     if (this.varAlias) {
       return this.varAlias;
     }
-    //@ts-expect-error what is this??
-    [this.varAlias] = await this.loadVarColumns([varPath]);
-    if (!this.varAlias) {
+    const [varAliasData] = await this.loadVarColumns([varPath]) as [TableColumnData | undefined];
+    if (!varAliasData) {
       throw new Error('Failed to load var alias');
     }
+    this.varAlias = Array.from(
+      varAliasData,
+      (value) => (value === null || value === undefined ? '' : String(value)),
+    );
     const index = await this.loadVarIndex();
-    this.varAlias = this.varAlias.map(
-      (val, ind) => (val ? val.concat(` (${index[ind]})`) : index[ind]),
+    this.varAlias = Array.from(
+      this.varAlias,
+      (val, ind) => {
+        const indexValue = index[ind];
+        const suffix = indexValue === null || indexValue === undefined ? '' : String(indexValue);
+        return val ? val.concat(` (${suffix})`) : suffix;
+      },
     );
     return this.varAlias;
   }

--- a/packages/core/src/models/VAnnDataSource.ts
+++ b/packages/core/src/models/VAnnDataSource.ts
@@ -22,8 +22,8 @@ function prependSlash(path: string) {
  */
 export default class AnnDataSource extends ZarrDataSource {
   promises: Map<string, Promise<TableColumnData | TableColumnData[] | undefined>>;
-  obsIndex?: Promise<TableColumnData>;
-  varIndex?: Promise<TableColumnData>;
+  obsIndex?: Promise<string[]>;
+  varIndex?: Promise<string[]>;
   varAlias?: string[];
   constructor(params: DataSourceParams) {
     super(params);
@@ -199,7 +199,7 @@ export default class AnnDataSource extends ZarrDataSource {
   /**
    * Class method for loading the obs index.
    * @param {string|undefined} path Used by subclasses.
-   * @returns {Promise<TableColumnData>} An promise for a zarr array
+   * @returns {Promise<string[]>} An promise for a zarr array
    * containing the indices.
    */
   loadObsIndex(path?: string) {
@@ -207,14 +207,15 @@ export default class AnnDataSource extends ZarrDataSource {
       return this.obsIndex;
     }
     this.obsIndex = this.getJson('obs/.zattrs')
-      .then(({ _index }) => this._loadColumn(`/obs/${_index}`));
+      .then(({ _index }) => this._loadColumn(`/obs/${_index}`))
+      .then(normalizeIndexData);
     return this.obsIndex;
   }
 
   /**
    * Class method for loading the obs index.
    * @param {string|undefined} path Used by subclasses.
-   * @returns {Promise<TableColumnData>} An promise for a zarr array
+   * @returns {Promise<string[]>} An promise for a zarr array
    * containing the indices.
    */
   loadDataFrameIndex(
@@ -223,13 +224,14 @@ export default class AnnDataSource extends ZarrDataSource {
   ) {
     const dfPath = path ? dirname(path) : '';
     return this.getJson(`${dfPath}/.zattrs`)
-      .then(({ _index }) => this._loadColumn(`${dfPath.length > 0 ? '/' : ''}${dfPath}/${_index}`));
+      .then(({ _index }) => this._loadColumn(`${dfPath.length > 0 ? '/' : ''}${dfPath}/${_index}`))
+      .then(normalizeIndexData);
   }
 
   /**
    * Class method for loading the var index.
    * @param {string|undefined} path Used by subclasses.
-   * @returns {Promise<TableColumnData>} An promise for a zarr array containing the indices.
+   * @returns {Promise<string[]>} An promise for a zarr array containing the indices.
    */
   loadVarIndex(
     // eslint-disable-next-line no-unused-vars
@@ -239,7 +241,8 @@ export default class AnnDataSource extends ZarrDataSource {
       return this.varIndex;
     }
     this.varIndex = this.getJson('var/.zattrs')
-      .then(({ _index }) => this._loadColumn(`/var/${_index}`));
+      .then(({ _index }) => this._loadColumn(`/var/${_index}`))
+      .then(normalizeIndexData);
     return this.varIndex;
   }
 
@@ -378,4 +381,11 @@ export default class AnnDataSource extends ZarrDataSource {
     }
     throw new Error('Keys for encoding-type or encoding-version not found in AnnDataSource._loadString');
   }
+}
+
+function normalizeIndexData(column: TableColumnData): string[] {
+  return Array.from(
+    column,
+    (value) => (value === null || value === undefined ? '' : String(value)),
+  );
 }

--- a/packages/core/src/models/VShapesSource.ts
+++ b/packages/core/src/models/VShapesSource.ts
@@ -1,5 +1,20 @@
-// This is a direct copy of the Vitessce implementation, with changes mostly to make it more normal TypeScript.
+// This started as a direct copy of the Vitessce implementation, with changes
+// mostly to make it more normal TypeScript.
 // ref: https://github.com/vitessce/vitessce/blob/main/packages/file-types/spatial-zarr/src/SpatialDataShapesSource.js
+//
+// Divergences from upstream are intentional and should stay easy to audit:
+// - TypeScript normalization / typing cleanup throughout.
+// - `getShapesFormatVersion()` treats modern `ngff:shapes` metadata revisions
+//   as compatible with the parquet-backed code path rather than hard-coding a
+//   single post-0.1 version string. This is currently needed so high-level
+//   feature-id loading (`ShapesElement.loadFeatureIds()`) works for newer
+//   SpatialData stores.
+//
+// Planned evolution:
+// - keep this file narrowly focused on geometry / feature-id loading
+// - avoid growing more app-facing policy here
+// - if we continue diverging from Vitessce, document each change explicitly in
+//   `docs/docs/core/internals.mdx`
 
 import WKB from 'ol/format/WKB.js';
 import { basename } from '../Vutils';
@@ -83,22 +98,37 @@ export default class SpatialDataShapesSource extends SpatialDataTableSource {
   /**
    *
    * @param path A path to within shapes.
-   * @returns The format version.
+   * @returns The format version / compatibility mode used for this shapes element.
    */
   async getShapesFormatVersion(path: string): Promise<'0.1' | '0.2'> {
     const zattrs = await this.loadSpatialDataElementAttrs(path);
     const formatVersion = zattrs.spatialdata_attrs?.version;
     const geos = zattrs.spatialdata_attrs.geos || {}; // Used only by v0.1
     const encodingType = zattrs['encoding-type'];
-    if (encodingType !== 'ngff:shapes' || !(
-      (formatVersion === '0.1' && (geos.name === 'POINT' && geos.type === 0))
-      || formatVersion === '0.2'
-    )) {
+    if (encodingType !== 'ngff:shapes') {
       throw new Error(
         `Unexpected encoding type or version for shapes spatialdata_attrs: ${encodingType} ${formatVersion}`,
       );
     }
-    return formatVersion;
+
+    if (formatVersion === '0.1') {
+      if (geos.name === 'POINT' && geos.type === 0) {
+        return '0.1';
+      }
+      throw new Error(
+        `Unexpected encoding type or version for shapes spatialdata_attrs: ${encodingType} ${formatVersion}`,
+      );
+    }
+
+    // Modern shapes elements are parquet-backed. Historically we only matched
+    // one specific version string here, but tooltip/feature-id lookup should
+    // work across newer ngff:shapes metadata revisions as long as the parquet
+    // layout is present. Route them through the same code path as 0.2.
+    //
+    // This is a deliberate divergence from the original Vitessce helper. The
+    // high-level API contract we care about is "can we load stable feature
+    // ids?", not "does the metadata version string equal one exact value?".
+    return '0.2';
   }
 
   /**

--- a/packages/core/src/models/VTableSource.ts
+++ b/packages/core/src/models/VTableSource.ts
@@ -129,8 +129,8 @@ export default class SpatialDataTableSource extends AnnDataSource {
   // biome-ignore lint/suspicious/noExplicitAny: elementAttrs type should be a tree-ish thing
   elementAttrs: Record<string, any>;
   parquetTableBytes: Record<string, Uint8Array>;
-  obsIndices: Record<string, Promise<TableColumnData>>;
-  varIndices: Record<string, Promise<TableColumnData>>;
+  obsIndices: Record<string, Promise<string[]>>;
+  varIndices: Record<string, Promise<string[]>>;
   varAliases: Record<string, string[]>;
   constructor(params: DataSourceParams) {
     super(params);
@@ -440,7 +440,10 @@ export default class SpatialDataTableSource extends AnnDataSource {
     if (!indexPath) {
       throw new Error(`No index path found for obs index at ${path}`);
     }
-    this.obsIndices[indexPath] = this._loadColumn(indexPath);
+    this.obsIndices[indexPath] = this._loadColumn(indexPath).then((values) => (
+      // not clear this extra pass is useful... does it exist just to satisfy types?
+      Array.from(values, (value) => (value === null || value === undefined ? '' : String(value)))
+    ));
     return this.obsIndices[indexPath];
   }
 
@@ -456,7 +459,8 @@ export default class SpatialDataTableSource extends AnnDataSource {
       return this.varIndices[varPath];
     }
     this.varIndices[varPath] = this.getJson(`${varPath}/.zattrs`)
-      .then(({ _index }) => this.getFlatArrDecompressed(`${varPath}/${_index}`));
+      .then(({ _index }) => this.getFlatArrDecompressed(`${varPath}/${_index}`))
+      .then((values) => Array.from(values, (value) => (value === null || value === undefined ? '' : String(value))));
     return this.varIndices[varPath];
   }
 

--- a/packages/core/src/models/VTableSource.ts
+++ b/packages/core/src/models/VTableSource.ts
@@ -2,6 +2,7 @@
 
 import { tableFromIPC, type Table as ArrowTable } from 'apache-arrow';
 import type { DataSourceParams } from '../Vutils';
+import type { TableColumnData } from '../types';
 import AnnDataSource from './VAnnDataSource';
 
 // Note: This file also serves as the parent for
@@ -128,8 +129,8 @@ export default class SpatialDataTableSource extends AnnDataSource {
   // biome-ignore lint/suspicious/noExplicitAny: elementAttrs type should be a tree-ish thing
   elementAttrs: Record<string, any>;
   parquetTableBytes: Record<string, Uint8Array>;
-  obsIndices: Record<string, Promise<string[]>>;
-  varIndices: Record<string, Promise<string[]>>;
+  obsIndices: Record<string, Promise<TableColumnData>>;
+  varIndices: Record<string, Promise<TableColumnData>>;
   varAliases: Record<string, string[]>;
   constructor(params: DataSourceParams) {
     super(params);
@@ -469,11 +470,22 @@ export default class SpatialDataTableSource extends AnnDataSource {
     if (varPath in this.varAliases) {
       return this.varAliases[varPath];
     }
-    const [varAliasData] = await this.loadVarColumns([varPath]);
-    this.varAliases[varPath] = varAliasData as string[];
+    const [varAliasData] = await this.loadVarColumns([varPath]) as [TableColumnData | undefined];
+    if (!varAliasData) {
+      throw new Error(`Failed to load var alias at ${varPath}`);
+    }
+    this.varAliases[varPath] = Array.from(
+      varAliasData,
+      (value) => (value === null || value === undefined ? '' : String(value)),
+    );
     const index = await this.loadVarIndex(matrixPath);
-    this.varAliases[varPath] = this.varAliases[varPath].map(
-      (val, ind) => (val ? val.concat(` (${index[ind]})`) : index[ind]),
+    this.varAliases[varPath] = Array.from(
+      this.varAliases[varPath],
+      (val, ind) => {
+        const indexValue = index[ind];
+        const suffix = indexValue === null || indexValue === undefined ? '' : String(indexValue);
+        return val ? val.concat(` (${suffix})`) : suffix;
+      },
     );
     return this.varAliases[varPath];
   }

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -4,6 +4,7 @@ import { Ok, Err } from '../types';
 import * as ad from 'anndata.js'
 import * as zarr from 'zarrita';
 import SpatialDataShapesSource from './VShapesSource';
+import SpatialDataTableSource from './VTableSource';
 import { 
   rasterAttrsSchema, 
   shapesAttrsSchema, 
@@ -227,6 +228,7 @@ export function getTableKeys(input: TableKeysInput): TableKeys {
 export class TableElement extends AbstractElement<'tables'> {
   readonly attrs: TableAttrs;
   private anndataPromise?: Promise<ad.AnnData<zarr.Readable<unknown>, zarr.NumberDataType, zarr.Uint32>>;
+  private readonly tableSource: SpatialDataTableSource;
   
   constructor(params: ElementParams<'tables'>) {
     super(params);
@@ -236,6 +238,10 @@ export class TableElement extends AbstractElement<'tables'> {
       throw result.error;
     } 
     this.attrs = result.data;
+    this.tableSource = new SpatialDataTableSource({
+      store: params.sdata.rootStore.zarritaStore,
+      fileType: '.zarr',
+    });
   }
   
   /**
@@ -269,38 +275,26 @@ export class TableElement extends AbstractElement<'tables'> {
 
   /**
    * Load the effective row ids for this table, respecting `instance_key`.
+   *
+   * This stays on our zarr-backed loader path rather than depending on
+   * `anndata.js`, since tooltip/association reads should work even when the
+   * AnnData wrapper lags behind newer string dtype support.
    */
   async loadObsIndex(): Promise<string[]> {
-    const adata = await this.getAnnDataJS();
-    const { instanceKey } = this.getTableKeys();
-    if (await adata.obs.has(instanceKey)) {
-      const instanceColumn = await adata.obs.get(instanceKey);
-      return backedArrayToStrings(instanceColumn);
-    }
-    return backedArrayToStrings(await adata.obsNames());
+    return this.tableSource.loadObsIndex(`tables/${this.key}`);
   }
 
   /**
    * Load specific obs columns by column name.
+   *
+   * Column-level reads use the same direct zarr/parquet path as `loadObsIndex`
+   * so feature-association helpers are not blocked on `anndata.js`.
    */
   async loadObsColumns(columnNames: string[]): Promise<Array<string[] | undefined>> {
-    const adata = await this.getAnnDataJS();
-    return Promise.all(columnNames.map(async (columnName) => {
-      if (!(await adata.obs.has(columnName))) {
-        return undefined;
-      }
-      const column = await adata.obs.get(columnName);
-      return backedArrayToStrings(column);
-    }));
+    return this.tableSource.loadObsColumns(
+      columnNames.map((columnName) => `tables/${this.key}/obs/${columnName}`),
+    ) as Promise<Array<string[] | undefined>>;
   }
-}
-
-async function backedArrayToStrings(array: unknown): Promise<string[]> {
-  const chunk = await ad.get(array as never, [null]);
-  if (chunk instanceof Object && 'data' in chunk) {
-    return Array.from(chunk.data as Iterable<unknown>, (value) => String(value));
-  }
-  return [String(chunk)];
 }
 
 // ============================================

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -395,10 +395,15 @@ export class ImageElement extends RasterElement<'images'> {
 
 /**
  * Labels element - raster data representing segmentation labels.
+ *
+ * Conceptually, labels and shapes both expose spatial "features" that can be
+ * associated with table rows. For labels this will eventually come from picked
+ * raster values (for example ObjectID-style segment ids), whereas shapes expose
+ * feature identity via their row/index arrays.
  */
 export class LabelsElement extends RasterElement<'labels'> {
   // Labels-specific methods can be added here
-  // e.g., colormap, associated table lookup, etc.
+  // e.g., colormap, picked-feature identity / table association helpers, etc.
 }
 
 // ============================================
@@ -451,9 +456,13 @@ export class ShapesElement extends AbstractSpatialElement<'shapes', ShapesAttrs>
   }
   
   /**
-   * Load the shapes index.
+   * Load stable feature ids for this shapes element.
+   *
+   * This is the preferred high-level API when the caller wants to associate a
+   * picked shape with table rows. It corresponds to the same conceptual role
+   * that picked label values will play for segmentation rasters.
    */
-  async loadShapesIndex() {
+  async loadFeatureIds() {
     return this.vShapes.loadShapesIndex(`shapes/${this.key}`);
   }
 }

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -226,6 +226,7 @@ export function getTableKeys(input: TableKeysInput): TableKeys {
  */
 export class TableElement extends AbstractElement<'tables'> {
   readonly attrs: TableAttrs;
+  private anndataPromise?: Promise<ad.AnnData<zarr.Readable<unknown>, zarr.NumberDataType, zarr.Uint32>>;
   
   constructor(params: ElementParams<'tables'>) {
     super(params);
@@ -241,7 +242,10 @@ export class TableElement extends AbstractElement<'tables'> {
    * Load the table as an AnnData.js object.
    */
   async getAnnDataJS(): Promise<ad.AnnData<zarr.Readable<unknown>, zarr.NumberDataType, zarr.Uint32>> {
-    return await ad.readZarr(new zarr.FetchStore(this.url));
+    if (!this.anndataPromise) {
+      this.anndataPromise = ad.readZarr(new zarr.FetchStore(this.url));
+    }
+    return await this.anndataPromise;
   }
 
   /**
@@ -250,6 +254,53 @@ export class TableElement extends AbstractElement<'tables'> {
   getTableKeys(): TableKeys {
     return getTableKeys(this);
   }
+
+  /**
+   * Get available obs column names from the parsed tree.
+   */
+  getObsColumnNames(): string[] {
+    const node = this.parsed as ZarrTree;
+    const obsNode = node.obs as ZarrTree | undefined;
+    if (!obsNode || typeof obsNode !== 'object') {
+      return [];
+    }
+    return Object.keys(obsNode);
+  }
+
+  /**
+   * Load the effective row ids for this table, respecting `instance_key`.
+   */
+  async loadObsIndex(): Promise<string[]> {
+    const adata = await this.getAnnDataJS();
+    const { instanceKey } = this.getTableKeys();
+    if (await adata.obs.has(instanceKey)) {
+      const instanceColumn = await adata.obs.get(instanceKey);
+      return backedArrayToStrings(instanceColumn);
+    }
+    return backedArrayToStrings(await adata.obsNames());
+  }
+
+  /**
+   * Load specific obs columns by column name.
+   */
+  async loadObsColumns(columnNames: string[]): Promise<Array<string[] | undefined>> {
+    const adata = await this.getAnnDataJS();
+    return Promise.all(columnNames.map(async (columnName) => {
+      if (!(await adata.obs.has(columnName))) {
+        return undefined;
+      }
+      const column = await adata.obs.get(columnName);
+      return backedArrayToStrings(column);
+    }));
+  }
+}
+
+async function backedArrayToStrings(array: unknown): Promise<string[]> {
+  const chunk = await ad.get(array as never, [null]);
+  if (chunk instanceof Object && 'data' in chunk) {
+    return Array.from(chunk.data as Iterable<unknown>, (value) => String(value));
+  }
+  return [String(chunk)];
 }
 
 // ============================================

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -189,6 +189,33 @@ abstract class AbstractSpatialElement<
   }
 }
 
+export type TableKeys = {
+  region: string[];
+  regionKey: string;
+  instanceKey: string;
+};
+
+type TableKeysInput = TableAttrs | { attrs: TableAttrs };
+
+function getTableAttrs(input: TableKeysInput): TableAttrs {
+  const attrs = (input as { attrs?: TableAttrs }).attrs;
+  return attrs ?? (input as TableAttrs);
+}
+
+/**
+ * Equivalent of SpatialData's Python-side `get_table_keys()`.
+ * Returns normalized table association metadata, always exposing `region`
+ * as an array for easier downstream matching.
+ */
+export function getTableKeys(input: TableKeysInput): TableKeys {
+  const attrs = getTableAttrs(input);
+  return {
+    region: Array.isArray(attrs.region) ? attrs.region : [attrs.region],
+    regionKey: attrs.region_key,
+    instanceKey: attrs.instance_key,
+  };
+}
+
 // ============================================
 // Table Element (non-spatial)
 // ============================================
@@ -215,6 +242,13 @@ export class TableElement extends AbstractElement<'tables'> {
    */
   async getAnnDataJS(): Promise<ad.AnnData<zarr.Readable<unknown>, zarr.NumberDataType, zarr.Uint32>> {
     return await ad.readZarr(new zarr.FetchStore(this.url));
+  }
+
+  /**
+   * Return the normalized association keys for this table.
+   */
+  getTableKeys(): TableKeys {
+    return getTableKeys(this);
   }
 }
 

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,4 +1,4 @@
-import type { ElementName, BadFileHandler, SDataProps, ZarrTree, LazyZarrArray, ZAttrsAny, Result } from '../types';
+import type { ElementName, BadFileHandler, SDataProps, ZarrTree, LazyZarrArray, ZAttrsAny, Result, TableColumnData } from '../types';
 import { ATTRS_KEY } from '../types';
 import { Ok, Err } from '../types';
 import * as ad from 'anndata.js'
@@ -280,7 +280,7 @@ export class TableElement extends AbstractElement<'tables'> {
    * `anndata.js`, since tooltip/association reads should work even when the
    * AnnData wrapper lags behind newer string dtype support.
    */
-  async loadObsIndex(): Promise<string[]> {
+  async loadObsIndex(): Promise<TableColumnData> {
     return this.tableSource.loadObsIndex(`tables/${this.key}`);
   }
 
@@ -290,10 +290,10 @@ export class TableElement extends AbstractElement<'tables'> {
    * Column-level reads use the same direct zarr/parquet path as `loadObsIndex`
    * so feature-association helpers are not blocked on `anndata.js`.
    */
-  async loadObsColumns(columnNames: string[]): Promise<Array<string[] | undefined>> {
+  async loadObsColumns(columnNames: string[]): Promise<Array<TableColumnData | undefined>> {
     return this.tableSource.loadObsColumns(
       columnNames.map((columnName) => `tables/${this.key}/obs/${columnName}`),
-    ) as Promise<Array<string[] | undefined>>;
+    ) as Promise<Array<TableColumnData | undefined>>;
   }
 }
 

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -280,7 +280,7 @@ export class TableElement extends AbstractElement<'tables'> {
    * `anndata.js`, since tooltip/association reads should work even when the
    * AnnData wrapper lags behind newer string dtype support.
    */
-  async loadObsIndex(): Promise<TableColumnData> {
+  async loadObsIndex(): Promise<string[]> {
     return this.tableSource.loadObsIndex(`tables/${this.key}`);
   }
 

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -5,7 +5,7 @@
 import type * as zarr from 'zarrita';
 import { getTransformation } from '../transformations';
 import {type ConsolidatedStore, openExtraConsolidated, serializeZarrTree } from '@spatialdata/zarrextra';
-import { loadElements, type ElementInstanceMap, type SpatialElement } from '../models';
+import { getTableKeys, loadElements, type ElementInstanceMap, type SpatialElement, type TableElement } from '../models';
 import type { 
   ElementName, 
   StoreLocation, 
@@ -19,6 +19,10 @@ import { SpatialElementNames, ElementNames } from '../types';
  * Type alias for element collections - maps element keys to element instances
  */
 type Elements<T extends ElementName> = Record<string, ElementInstanceMap[T]>;
+
+function elementPathCandidates(kind: Exclude<ElementName, 'tables'>, key: string) {
+  return new Set([key, `${kind}/${key}`]);
+}
 
 // Re-export SpatialElement from models
 export type { SpatialElement, AnyElement } from '../models';
@@ -116,6 +120,29 @@ export class SpatialData {
   toJSON() {
     if (!this.rootStore.tree) return this;
     return serializeZarrTree(this.rootStore.tree);
+  }
+
+  /**
+   * Get all tables that annotate a given spatial element.
+   * Matches both bare element keys such as "cell_circles" and
+   * qualified paths such as "shapes/cell_circles".
+   */
+  getAssociatedTables(kind: Exclude<ElementName, 'tables'>, key: string): Array<[string, TableElement]> {
+    if (!this.tables) {
+      return [];
+    }
+    const candidates = elementPathCandidates(kind, key);
+    return Object.entries(this.tables).filter(([, table]) => {
+      const { region } = getTableKeys(table);
+      return region.some(regionName => candidates.has(regionName));
+    });
+  }
+
+  /**
+   * Convenience helper for the common case where at most one table is expected.
+   */
+  getAssociatedTable(kind: Exclude<ElementName, 'tables'>, key: string): [string, TableElement] | undefined {
+    return this.getAssociatedTables(kind, key)[0];
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,8 @@ export type ElementName = typeof ElementNames[number];
  * loader implementations in models/index.ts.
  */
 export type Table = ad.AnnData<zarr.Readable<unknown>, zarr.NumberDataType, zarr.Uint32>;
+export type TableValue = string | number | boolean | bigint | null | undefined;
+export type TableColumnData = ArrayLike<TableValue> & Iterable<TableValue>;
 // export type Shapes = {
 //   attrs: Record<string, unknown>;
 //   loadPolygonShapes: () => Promise<Array<Array<Array<[number, number]>>>>;

--- a/packages/core/tests/tableAssociations.spec.ts
+++ b/packages/core/tests/tableAssociations.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { ATTRS_KEY } from '@spatialdata/zarrextra';
+import { getTableKeys } from '../src/models/index.js';
+import { SpatialData } from '../src/store/index.js';
+
+function createMockSpatialData() {
+  const rootStore = {
+    tree: {
+      shapes: {
+        cells: {
+          [ATTRS_KEY]: {
+            'encoding-type': 'ngff:shapes',
+          },
+        },
+        nuclei: {
+          [ATTRS_KEY]: {
+            'encoding-type': 'ngff:shapes',
+          },
+        },
+      },
+      tables: {
+        cells_table: {
+          [ATTRS_KEY]: {
+            instance_key: 'cell_id',
+            region: 'cells',
+            region_key: 'region',
+            'spatialdata-encoding-type': 'ngff:regions_table',
+          },
+        },
+        path_table: {
+          [ATTRS_KEY]: {
+            instance_key: 'cell_id',
+            region: 'shapes/cells',
+            region_key: 'region',
+            'spatialdata-encoding-type': 'ngff:regions_table',
+          },
+        },
+        multi_region_table: {
+          [ATTRS_KEY]: {
+            instance_key: 'cell_id',
+            region: ['cells', 'nuclei'],
+            region_key: 'region',
+            'spatialdata-encoding-type': 'ngff:regions_table',
+          },
+        },
+      },
+    },
+    zarritaStore: {},
+  };
+
+  return new SpatialData(
+    'https://example.com/mock.zarr',
+    rootStore as any,
+    ['shapes', 'tables'],
+  );
+}
+
+describe('getTableKeys', () => {
+  it('normalizes a single region to an array', () => {
+    expect(getTableKeys({
+      instance_key: 'cell_id',
+      region: 'cells',
+      region_key: 'region',
+      'spatialdata-encoding-type': 'ngff:regions_table',
+    })).toEqual({
+      instanceKey: 'cell_id',
+      region: ['cells'],
+      regionKey: 'region',
+    });
+  });
+
+  it('preserves multiple regions', () => {
+    expect(getTableKeys({
+      instance_key: 'cell_id',
+      region: ['cells', 'nuclei'],
+      region_key: 'region',
+      'spatialdata-encoding-type': 'ngff:regions_table',
+    })).toEqual({
+      instanceKey: 'cell_id',
+      region: ['cells', 'nuclei'],
+      regionKey: 'region',
+    });
+  });
+});
+
+describe('SpatialData table associations', () => {
+  it('finds tables associated with a shape key', () => {
+    const sdata = createMockSpatialData();
+    const matches = sdata.getAssociatedTables('shapes', 'cells');
+
+    expect(matches.map(([name]) => name)).toEqual([
+      'cells_table',
+      'path_table',
+      'multi_region_table',
+    ]);
+  });
+
+  it('returns the first associated table as a convenience lookup', () => {
+    const sdata = createMockSpatialData();
+    const match = sdata.getAssociatedTable('shapes', 'cells');
+
+    expect(match?.[0]).toBe('cells_table');
+    expect(match?.[1].getTableKeys()).toEqual({
+      instanceKey: 'cell_id',
+      region: ['cells'],
+      regionKey: 'region',
+    });
+  });
+
+  it('returns an empty list when no tables annotate an element', () => {
+    const sdata = createMockSpatialData();
+    expect(sdata.getAssociatedTables('shapes', 'missing')).toEqual([]);
+  });
+});

--- a/packages/core/tests/tableElement.spec.ts
+++ b/packages/core/tests/tableElement.spec.ts
@@ -1,0 +1,64 @@
+import { assert, describe, expect, it, vi } from 'vitest';
+import { ATTRS_KEY } from '@spatialdata/zarrextra';
+import { SpatialData } from '../src/store/index.js';
+
+function createMockSpatialData() {
+  const rootStore = {
+    tree: {
+      tables: {
+        cells_table: {
+          [ATTRS_KEY]: {
+            instance_key: 'cell_id',
+            region: 'cells',
+            region_key: 'region',
+            'spatialdata-encoding-type': 'ngff:regions_table',
+          },
+          obs: {},
+        },
+      },
+    },
+    zarritaStore: {},
+  };
+
+  return new SpatialData(
+    'https://example.com/mock.zarr',
+    rootStore as any,
+    ['tables'],
+  );
+}
+
+describe('TableElement direct table reads', () => {
+  it('loads obs indices via the direct table source without touching anndata.js', async () => {
+    const sdata = createMockSpatialData();
+    assert(sdata.tables, "sdata.tables on mock object should be truthy");
+    const table = sdata.tables.cells_table;
+
+    const getAnnDataSpy = vi.spyOn(table, 'getAnnDataJS');
+
+    const loadObsIndex = vi.fn().mockResolvedValue(['cell-1', 'cell-2']);
+    (table as any).tableSource = {
+      loadObsIndex,
+    };
+
+    await expect(table.loadObsIndex()).resolves.toEqual(['cell-1', 'cell-2']);
+    expect(loadObsIndex).toHaveBeenCalledWith('tables/cells_table');
+    expect(getAnnDataSpy).not.toHaveBeenCalled();
+  });
+
+  it('loads obs columns via the direct table source without touching anndata.js', async () => {
+    const sdata = createMockSpatialData();
+    assert(sdata.tables, "sdata.tables on mock object should be truthy");
+    const table = sdata.tables.cells_table;
+
+    const getAnnDataSpy = vi.spyOn(table, 'getAnnDataJS');
+
+    const loadObsColumns = vi.fn().mockResolvedValue([['cells', 'cells']]);
+    (table as any).tableSource = {
+      loadObsColumns,
+    };
+
+    await expect(table.loadObsColumns(['region'])).resolves.toEqual([['cells', 'cells']]);
+    expect(loadObsColumns).toHaveBeenCalledWith(['tables/cells_table/obs/region']);
+    expect(getAnnDataSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/tableElement.spec.ts
+++ b/packages/core/tests/tableElement.spec.ts
@@ -61,4 +61,17 @@ describe('TableElement direct table reads', () => {
     expect(loadObsColumns).toHaveBeenCalledWith(['tables/cells_table/obs/region']);
     expect(getAnnDataSpy).not.toHaveBeenCalled();
   });
+
+  it('preserves non-string obs column values until the consumer formats them', async () => {
+    const sdata = createMockSpatialData();
+    assert(sdata.tables, "sdata.tables on mock object should be truthy");
+    const table = sdata.tables.cells_table;
+
+    const loadObsColumns = vi.fn().mockResolvedValue([[1, 2, 3]]);
+    (table as any).tableSource = {
+      loadObsColumns,
+    };
+
+    await expect(table.loadObsColumns(['score'])).resolves.toEqual([[1, 2, 3]]);
+  });
 });

--- a/packages/core/tests/vshapes.spec.ts
+++ b/packages/core/tests/vshapes.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import SpatialDataShapesSource from '../src/models/VShapesSource.js';
+
+describe('SpatialDataShapesSource', () => {
+  it('loads feature ids from parquet for ngff:shapes 0.3 metadata', async () => {
+    const source = new SpatialDataShapesSource({
+      store: {} as any,
+      fileType: '.zarr',
+    });
+
+    vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:shapes',
+      spatialdata_attrs: {
+        version: '0.3',
+      },
+    });
+
+    vi.spyOn(source, 'loadParquetTableIndex').mockResolvedValue({
+      toArray: () => ['cell-1', 'cell-2'],
+    } as any);
+
+    await expect(source.loadShapesIndex('shapes/cells')).resolves.toEqual(['cell-1', 'cell-2']);
+  });
+
+  it('keeps using the legacy zarr path for 0.1 point-style shapes', async () => {
+    const source = new SpatialDataShapesSource({
+      store: {} as any,
+      fileType: '.zarr',
+    });
+
+    vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:shapes',
+      spatialdata_attrs: {
+        version: '0.1',
+        geos: {
+          name: 'POINT',
+          type: 0,
+        },
+      },
+    });
+
+    const loadColumnSpy = vi.spyOn(source, '_loadColumn').mockResolvedValue(['legacy-1']);
+    const loadParquetTableIndexSpy = vi.spyOn(source, 'loadParquetTableIndex');
+
+    await expect(source.loadShapesIndex('shapes/cells')).resolves.toEqual(['legacy-1']);
+    expect(loadColumnSpy).toHaveBeenCalledWith('shapes/cells/Index');
+    expect(loadParquetTableIndexSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/layers/src/spatialLayerProps.ts
+++ b/packages/layers/src/spatialLayerProps.ts
@@ -20,6 +20,7 @@ export const spatialScatterSublayerSchema = sublayerBase.extend({
 
 export const spatialShapesSublayerSchema = sublayerBase.extend({
   kind: z.literal('shapes'),
+  tooltipFields: z.array(z.string()).optional(),
 });
 
 export const spatialSublayerSchema = z.discriminatedUnion('kind', [

--- a/packages/vis/src/SpatialCanvas/ShapesTooltip.tsx
+++ b/packages/vis/src/SpatialCanvas/ShapesTooltip.tsx
@@ -1,0 +1,83 @@
+import type { CSSProperties } from 'react';
+
+type TooltipItem = {
+  label: string;
+  value: string;
+};
+
+type TooltipData = {
+  title?: string;
+  items: TooltipItem[];
+};
+
+const tooltipStyle: CSSProperties = {
+  position: 'absolute',
+  maxWidth: 260,
+  borderRadius: 6,
+  border: '1px solid rgba(255,255,255,0.1)',
+  backgroundColor: 'rgba(10, 10, 10, 0.9)',
+  padding: '8px 10px',
+  fontSize: 12,
+  color: '#f5f5f5',
+  pointerEvents: 'none',
+  boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+};
+
+const titleStyle: CSSProperties = {
+  marginBottom: 6,
+  fontWeight: 600,
+  color: '#fafafa',
+};
+
+const itemsWrapStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+};
+
+const itemRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: 8,
+};
+
+const itemLabelStyle: CSSProperties = {
+  minWidth: 72,
+  color: '#cbd5e1',
+};
+
+const itemValueStyle: CSSProperties = {
+  color: '#ffffff',
+  overflowWrap: 'anywhere',
+};
+
+export interface ShapesTooltipProps {
+  x: number;
+  y: number;
+  tooltip: TooltipData;
+}
+
+export function ShapesTooltip({ x, y, tooltip }: ShapesTooltipProps) {
+  return (
+    <div
+      style={{
+        ...tooltipStyle,
+        left: x + 12,
+        top: y + 12,
+      }}
+    >
+      {tooltip.title && (
+        <div style={titleStyle}>
+          {tooltip.title}
+        </div>
+      )}
+      <div style={itemsWrapStyle}>
+        {tooltip.items.map((item) => (
+          <div key={item.label} style={itemRowStyle}>
+            <span style={itemLabelStyle}>{item.label}</span>
+            <span style={itemValueStyle}>{item.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/vis/src/SpatialCanvas/ShapesTooltip.tsx
+++ b/packages/vis/src/SpatialCanvas/ShapesTooltip.tsx
@@ -1,17 +1,24 @@
 import type { CSSProperties } from 'react';
 
-type TooltipItem = {
+export type ShapesTooltipItem = {
   label: string;
   value: string;
 };
 
-type TooltipData = {
+/** Serializable payload for shape hover tooltips (library-owned contract). */
+export type ShapesTooltipData = {
   title?: string;
-  items: TooltipItem[];
+  items: ShapesTooltipItem[];
 };
 
-const tooltipStyle: CSSProperties = {
-  position: 'absolute',
+/** Props for optional `renderTooltip` on SpatialCanvas (client = viewport coordinates). */
+export type SpatialCanvasTooltipRenderProps = {
+  clientX: number;
+  clientY: number;
+  tooltip: ShapesTooltipData;
+};
+
+const tooltipBaseStyle: CSSProperties = {
   maxWidth: 260,
   borderRadius: 6,
   border: '1px solid rgba(255,255,255,0.1)',
@@ -50,21 +57,40 @@ const itemValueStyle: CSSProperties = {
   overflowWrap: 'anywhere',
 };
 
+const TOOLTIP_OFFSET = 12;
+
 export interface ShapesTooltipProps {
+  /** Viewport X of the pick point (deck.gl `info.x` + viewer origin). */
   x: number;
+  /** Viewport Y of the pick point (deck.gl `info.y` + viewer origin). */
   y: number;
-  tooltip: TooltipData;
+  tooltip: ShapesTooltipData;
+  /**
+   * `fixed` — viewport coordinates (use with a portal). Default.
+   * `absolute` — coordinates relative to the offset parent.
+   */
+  position?: 'absolute' | 'fixed';
+  /** Stacking order when `position` is `fixed` (above SpatialCanvas fullscreen overlay). */
+  zIndex?: number;
 }
 
-export function ShapesTooltip({ x, y, tooltip }: ShapesTooltipProps) {
+export function ShapesTooltip({
+  x,
+  y,
+  tooltip,
+  position = 'fixed',
+  zIndex = 10001,
+}: ShapesTooltipProps) {
+  const tooltipStyle: CSSProperties = {
+    ...tooltipBaseStyle,
+    position,
+    left: x + TOOLTIP_OFFSET,
+    top: y + TOOLTIP_OFFSET,
+    ...(position === 'fixed' ? { zIndex } : {}),
+  };
+
   return (
-    <div
-      style={{
-        ...tooltipStyle,
-        left: x + 12,
-        top: y + 12,
-      }}
-    >
+    <div style={tooltipStyle}>
       {tooltip.title && (
         <div style={titleStyle}>
           {tooltip.title}

--- a/packages/vis/src/SpatialCanvas/SpatialFeatureTooltip.tsx
+++ b/packages/vis/src/SpatialCanvas/SpatialFeatureTooltip.tsx
@@ -1,21 +1,21 @@
 import type { CSSProperties } from 'react';
 
-export type ShapesTooltipItem = {
+export type SpatialFeatureTooltipItem = {
   label: string;
   value: string;
 };
 
-/** Serializable payload for shape hover tooltips (library-owned contract). */
-export type ShapesTooltipData = {
+/** Serializable payload for picked spatial feature hover tooltips (library-owned contract). */
+export type SpatialFeatureTooltipData = {
   title?: string;
-  items: ShapesTooltipItem[];
+  items: SpatialFeatureTooltipItem[];
 };
 
 /** Props for optional `renderTooltip` on SpatialCanvas (client = viewport coordinates). */
 export type SpatialCanvasTooltipRenderProps = {
   clientX: number;
   clientY: number;
-  tooltip: ShapesTooltipData;
+  tooltip: SpatialFeatureTooltipData;
 };
 
 const tooltipBaseStyle: CSSProperties = {
@@ -59,12 +59,12 @@ const itemValueStyle: CSSProperties = {
 
 const TOOLTIP_OFFSET = 12;
 
-export interface ShapesTooltipProps {
-  /** Viewport X of the pick point (deck.gl `info.x` + viewer origin). */
+export interface SpatialFeatureTooltipProps {
+  /** Viewport X of the picked feature (deck.gl `info.x` + viewer origin). */
   x: number;
-  /** Viewport Y of the pick point (deck.gl `info.y` + viewer origin). */
+  /** Viewport Y of the picked feature (deck.gl `info.y` + viewer origin). */
   y: number;
-  tooltip: ShapesTooltipData;
+  tooltip: SpatialFeatureTooltipData;
   /**
    * `fixed` — viewport coordinates (use with a portal). Default.
    * `absolute` — coordinates relative to the offset parent.
@@ -74,13 +74,13 @@ export interface ShapesTooltipProps {
   zIndex?: number;
 }
 
-export function ShapesTooltip({
+export function SpatialFeatureTooltip({
   x,
   y,
   tooltip,
   position = 'fixed',
   zIndex = 10001,
-}: ShapesTooltipProps) {
+}: SpatialFeatureTooltipProps) {
   const tooltipStyle: CSSProperties = {
     ...tooltipBaseStyle,
     position,

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -340,8 +340,9 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
     selectedConfig?.type === 'shapes'
       ? spatialData?.getAssociatedTable('shapes', selectedConfig.elementKey)?.[1]
       : undefined;
-  const selectedLayerLoadState =
-    selectedConfig ? getLayerLoadState(selectedConfig.id) : undefined;
+  const selectedLayerLoadState = getLayerLoadState(selectedConfig?.id);
+  // we probably want to see more than obs columns here... but I also don't understand what subset of those we end up with.
+  // why not allow instanceKey & regionKey...
   const availableTooltipFields =
     associatedTable?.getObsColumnNames().filter((columnName) => {
       const tableKeys = associatedTable.getTableKeys();

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -7,7 +7,8 @@
  * - Viewing overlaid spatial data with pan/zoom
  */
 
-import { useEffect, useMemo, useCallback, useState, useRef, type CSSProperties } from 'react';
+import { useEffect, useMemo, useCallback, useState, useRef, type CSSProperties, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { useMeasure } from '@uidotdev/usehooks';
 import { useSpatialData } from '@spatialdata/react';
 import type { PickingInfo } from 'deck.gl';
@@ -33,7 +34,19 @@ import type {
 import type { SpatialCanvasStoreApi } from './stores';
 import { useLayerData } from './useLayerData';
 import { SpatialViewer } from './SpatialViewer';
-import { ShapesTooltip } from './ShapesTooltip';
+import {
+  ShapesTooltip,
+  type ShapesTooltipData,
+  type SpatialCanvasTooltipRenderProps,
+} from './ShapesTooltip';
+
+export {
+  ShapesTooltip,
+  type ShapesTooltipData,
+  type ShapesTooltipItem,
+  type SpatialCanvasTooltipRenderProps,
+  type ShapesTooltipProps,
+} from './ShapesTooltip';
 
 // Re-export for external use
 export { 
@@ -204,7 +217,14 @@ function LayerSelector({ elements, enabledLayerIds, onToggleLayer }: LayerSelect
 // Inner Canvas (connected to store)
 // ============================================
 
-function SpatialCanvasInner() {
+interface SpatialCanvasInnerProps {
+  /** Portal mount node for hover tooltips; defaults to `document.body`. */
+  tooltipContainer?: HTMLElement | null;
+  /** Override default tooltip UI; receives pick position in viewport coordinates. */
+  renderTooltip?: (props: SpatialCanvasTooltipRenderProps) => ReactNode;
+}
+
+function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasInnerProps) {
   const { spatialData, loading: sdLoading } = useSpatialData();
   const [measureRef, { width, height }] = useMeasure();
   const shellRef = useRef<HTMLDivElement | null>(null);
@@ -376,13 +396,13 @@ function SpatialCanvasInner() {
 
   const hasElements = Object.values(availableElements).some((arr) => arr.length > 0);
   const hasEnabledLayers = enabledLayerIds.size > 0;
-  const shellRect = shellRef.current?.getBoundingClientRect();
   const viewerRect = viewerContainerRef.current?.getBoundingClientRect();
-  const tooltipPosition =
-    hoverTooltip && shellRect && viewerRect
+  /** Viewport coordinates of the deck.gl pick (for portaled `position: fixed` tooltip). */
+  const tooltipClientPosition =
+    hoverTooltip && viewerRect
       ? {
-          x: viewerRect.left - shellRect.left + hoverTooltip.x,
-          y: viewerRect.top - shellRect.top + hoverTooltip.y,
+          x: viewerRect.left + hoverTooltip.x,
+          y: viewerRect.top + hoverTooltip.y,
         }
       : null;
 
@@ -390,9 +410,42 @@ function SpatialCanvasInner() {
     ? { ...containerStyle, ...fullscreenOverlayStyle, position: 'fixed' }
     : { ...containerStyle, position: 'relative' };
 
+  const tooltipPayload: ShapesTooltipData | null =
+    hoverTooltip && tooltipClientPosition
+      ? {
+          title: hoverTooltip.title,
+          items: hoverTooltip.items,
+        }
+      : null;
+
+  const portalTarget =
+    typeof document !== 'undefined' ? (tooltipContainer ?? document.body) : null;
+
+  const tooltipPortal =
+    tooltipPayload &&
+    tooltipClientPosition &&
+    portalTarget &&
+    createPortal(
+      renderTooltip ? (
+        renderTooltip({
+          clientX: tooltipClientPosition.x,
+          clientY: tooltipClientPosition.y,
+          tooltip: tooltipPayload,
+        })
+      ) : (
+        <ShapesTooltip
+          x={tooltipClientPosition.x}
+          y={tooltipClientPosition.y}
+          tooltip={tooltipPayload}
+          position="fixed"
+        />
+      ),
+      portalTarget,
+    );
 
   return (
-    <div ref={shellRef} style={shellStyle}>
+    <>
+      <div ref={shellRef} style={shellStyle}>
       <div style={controlsStyle}>
         <div style={{ ...rowStyle, flexWrap: 'wrap' }}>
           <span style={labelStyle}>Coordinate System:</span>
@@ -626,17 +679,9 @@ function SpatialCanvasInner() {
           )}
         </aside>
       </div>
-      {hoverTooltip && tooltipPosition && (
-        <ShapesTooltip
-          x={tooltipPosition.x}
-          y={tooltipPosition.y}
-          tooltip={{
-            title: hoverTooltip.title,
-            items: hoverTooltip.items,
-          }}
-        />
-      )}
-    </div>
+      </div>
+      {tooltipPortal}
+    </>
   );
 }
 
@@ -650,6 +695,16 @@ export interface SpatialCanvasProps {
    * If not provided, an internal store will be created.
    */
   store?: SpatialCanvasStoreApi;
+  /**
+   * DOM node to mount shape hover tooltips (React portal target).
+   * Defaults to `document.body` when omitted.
+   */
+  tooltipContainer?: HTMLElement | null;
+  /**
+   * Custom tooltip UI for shape hovers. Receives viewport coordinates and the
+   * library-built payload; omit to use the default `ShapesTooltip` styling.
+   */
+  renderTooltip?: (props: SpatialCanvasTooltipRenderProps) => ReactNode;
 }
 
 /**
@@ -700,11 +755,18 @@ export interface SpatialCanvasProps {
  * });
  * ```
  */
-export default function SpatialCanvas({ store }: SpatialCanvasProps) {
+export default function SpatialCanvas({
+  store,
+  tooltipContainer,
+  renderTooltip,
+}: SpatialCanvasProps) {
   return (
     <VivLoaderRegistryProvider>
       <SpatialCanvasProvider store={store}>
-        <SpatialCanvasInner />
+        <SpatialCanvasInner
+          tooltipContainer={tooltipContainer}
+          renderTooltip={renderTooltip}
+        />
       </SpatialCanvasProvider>
     </VivLoaderRegistryProvider>
   );

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -35,18 +35,18 @@ import type { SpatialCanvasStoreApi } from './stores';
 import { useLayerData } from './useLayerData';
 import { SpatialViewer } from './SpatialViewer';
 import {
-  ShapesTooltip,
-  type ShapesTooltipData,
+  SpatialFeatureTooltip,
+  type SpatialFeatureTooltipData,
   type SpatialCanvasTooltipRenderProps,
-} from './ShapesTooltip';
+} from './SpatialFeatureTooltip';
 
 export {
-  ShapesTooltip,
-  type ShapesTooltipData,
-  type ShapesTooltipItem,
+  SpatialFeatureTooltip,
+  type SpatialFeatureTooltipData,
+  type SpatialFeatureTooltipItem,
   type SpatialCanvasTooltipRenderProps,
-  type ShapesTooltipProps,
-} from './ShapesTooltip';
+  type SpatialFeatureTooltipProps,
+} from './SpatialFeatureTooltip';
 
 // Re-export for external use
 export { 
@@ -218,7 +218,7 @@ function LayerSelector({ elements, enabledLayerIds, onToggleLayer }: LayerSelect
 // ============================================
 
 interface SpatialCanvasInnerProps {
-  /** Portal mount node for hover tooltips; defaults to `document.body`. */
+  /** Portal mount node for picked-feature hover tooltips; defaults to `document.body`. */
   tooltipContainer?: HTMLElement | null;
   /** Override default tooltip UI; receives pick position in viewport coordinates. */
   renderTooltip?: (props: SpatialCanvasTooltipRenderProps) => ReactNode;
@@ -263,7 +263,7 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
     getImageLayerLoadedData,
     getLayerLoadState,
     hasRenderableLayerData,
-    getShapeTooltip,
+    getFeatureTooltip,
     isLoading,
     isBlocking,
   } = useLayerData(
@@ -361,7 +361,7 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
       setHoverTooltip(null);
       return;
     }
-    const tooltip = getShapeTooltip(normalizedLayerId, info.index);
+    const tooltip = getFeatureTooltip(normalizedLayerId, info.index);
     if (!tooltip) {
       setHoverTooltip(null);
       return;
@@ -371,7 +371,7 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
       y: info.y,
       ...tooltip,
     });
-  }, [getShapeTooltip]);
+  }, [getFeatureTooltip]);
 
   const handleViewerRef = useCallback((node: HTMLDivElement | null) => {
     viewerContainerRef.current = node;
@@ -410,7 +410,7 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
     ? { ...containerStyle, ...fullscreenOverlayStyle, position: 'fixed' }
     : { ...containerStyle, position: 'relative' };
 
-  const tooltipPayload: ShapesTooltipData | null =
+  const tooltipPayload: SpatialFeatureTooltipData | null =
     hoverTooltip && tooltipClientPosition
       ? {
           title: hoverTooltip.title,
@@ -433,7 +433,7 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
           tooltip: tooltipPayload,
         })
       ) : (
-        <ShapesTooltip
+        <SpatialFeatureTooltip
           x={tooltipClientPosition.x}
           y={tooltipClientPosition.y}
           tooltip={tooltipPayload}
@@ -696,13 +696,14 @@ export interface SpatialCanvasProps {
    */
   store?: SpatialCanvasStoreApi;
   /**
-   * DOM node to mount shape hover tooltips (React portal target).
+   * DOM node to mount picked-feature hover tooltips (React portal target).
    * Defaults to `document.body` when omitted.
    */
   tooltipContainer?: HTMLElement | null;
   /**
-   * Custom tooltip UI for shape hovers. Receives viewport coordinates and the
-   * library-built payload; omit to use the default `ShapesTooltip` styling.
+   * Custom tooltip UI for picked-feature hovers. Receives viewport coordinates
+   * and the library-built payload; omit to use the default `SpatialFeatureTooltip`
+   * styling.
    */
   renderTooltip?: (props: SpatialCanvasTooltipRenderProps) => ReactNode;
 }

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -7,7 +7,7 @@
  * - Viewing overlaid spatial data with pan/zoom
  */
 
-import { useEffect, useMemo, useCallback, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useCallback, useState, useRef, type CSSProperties } from 'react';
 import { useMeasure } from '@uidotdev/usehooks';
 import { useSpatialData } from '@spatialdata/react';
 import type { PickingInfo } from 'deck.gl';
@@ -206,7 +206,9 @@ function LayerSelector({ elements, enabledLayerIds, onToggleLayer }: LayerSelect
 
 function SpatialCanvasInner() {
   const { spatialData, loading: sdLoading } = useSpatialData();
-  const [viewerRef, { width, height }] = useMeasure();
+  const [measureRef, { width, height }] = useMeasure();
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const viewerContainerRef = useRef<HTMLDivElement | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const [hoverTooltip, setHoverTooltip] = useState<{
     x: number;
@@ -235,7 +237,16 @@ function SpatialCanvasInner() {
     return getAvailableElements(spatialData, coordinateSystem);
   }, [spatialData, coordinateSystem]);
 
-  const { getLayers, getVivLayerProps, getImageLayerLoadedData, getShapeTooltip, isLoading } = useLayerData(
+  const {
+    getLayers,
+    getVivLayerProps,
+    getImageLayerLoadedData,
+    getLayerLoadState,
+    hasRenderableLayerData,
+    getShapeTooltip,
+    isLoading,
+    isBlocking,
+  } = useLayerData(
     layers,
     layerOrder,
     availableElements,
@@ -309,6 +320,8 @@ function SpatialCanvasInner() {
     selectedConfig?.type === 'shapes'
       ? spatialData?.getAssociatedTable('shapes', selectedConfig.elementKey)?.[1]
       : undefined;
+  const selectedLayerLoadState =
+    selectedConfig ? getLayerLoadState(selectedConfig.id) : undefined;
   const availableTooltipFields =
     associatedTable?.getObsColumnNames().filter((columnName) => {
       const tableKeys = associatedTable.getTableKeys();
@@ -340,6 +353,11 @@ function SpatialCanvasInner() {
     });
   }, [getShapeTooltip]);
 
+  const handleViewerRef = useCallback((node: HTMLDivElement | null) => {
+    viewerContainerRef.current = node;
+    measureRef(node);
+  }, [measureRef]);
+  
   if (sdLoading) {
     return (
       <div style={containerStyle}>
@@ -358,13 +376,23 @@ function SpatialCanvasInner() {
 
   const hasElements = Object.values(availableElements).some((arr) => arr.length > 0);
   const hasEnabledLayers = enabledLayerIds.size > 0;
+  const shellRect = shellRef.current?.getBoundingClientRect();
+  const viewerRect = viewerContainerRef.current?.getBoundingClientRect();
+  const tooltipPosition =
+    hoverTooltip && shellRect && viewerRect
+      ? {
+          x: viewerRect.left - shellRect.left + hoverTooltip.x,
+          y: viewerRect.top - shellRect.top + hoverTooltip.y,
+        }
+      : null;
 
   const shellStyle: CSSProperties = fullscreen
-    ? { ...containerStyle, ...fullscreenOverlayStyle }
-    : containerStyle;
+    ? { ...containerStyle, ...fullscreenOverlayStyle, position: 'fixed' }
+    : { ...containerStyle, position: 'relative' };
+
 
   return (
-    <div style={shellStyle}>
+    <div ref={shellRef} style={shellStyle}>
       <div style={controlsStyle}>
         <div style={{ ...rowStyle, flexWrap: 'wrap' }}>
           <span style={labelStyle}>Coordinate System:</span>
@@ -412,7 +440,7 @@ function SpatialCanvasInner() {
           />
         </aside>
 
-        <div ref={viewerRef} style={viewerContainerStyle}>
+        <div ref={handleViewerRef} style={viewerContainerStyle}>
           {hasEnabledLayers ? (
             <div style={{ width: vw, height: vh, position: 'relative' }}>
               <SpatialViewer
@@ -424,17 +452,7 @@ function SpatialCanvasInner() {
                 vivLayerProps={vivLayerProps.length > 0 ? vivLayerProps : undefined}
                 onHover={handleHover}
               />
-              {hoverTooltip && (
-                <ShapesTooltip
-                  x={hoverTooltip.x}
-                  y={hoverTooltip.y}
-                  tooltip={{
-                    title: hoverTooltip.title,
-                    items: hoverTooltip.items,
-                  }}
-                />
-              )}
-              {isLoading && (
+              {isBlocking && (
                 <div
                   style={{
                     position: 'absolute',
@@ -447,10 +465,26 @@ function SpatialCanvasInner() {
                     borderRadius: 4,
                   }}
                 >
-                  Loading...
+                  Loading layer data...
                 </div>
               )}
-              {!hasLayersDrawn && !isLoading && (
+              {isLoading && !isBlocking && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 8,
+                    right: 8,
+                    padding: '4px 8px',
+                    backgroundColor: 'rgba(20,20,20,0.78)',
+                    color: '#d5d5d5',
+                    fontSize: '11px',
+                    borderRadius: 4,
+                  }}
+                >
+                  Refreshing layer metadata...
+                </div>
+              )}
+              {!hasLayersDrawn && !isBlocking && (
                 <div
                   style={{
                     position: 'absolute',
@@ -505,6 +539,29 @@ function SpatialCanvasInner() {
                   }
                 />
               </label>
+              {selectedLayerLoadState && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, color: '#888', fontSize: '11px' }}>
+                  {selectedConfig.type !== 'image' && selectedLayerLoadState.geometry && (
+                    <div>
+                      Geometry: {selectedLayerLoadState.geometry}
+                      {!hasRenderableLayerData(selectedConfig.id) && selectedLayerLoadState.geometry === 'loading'
+                        ? ' (blocking)'
+                        : ''}
+                    </div>
+                  )}
+                  {selectedConfig.type === 'image' && selectedLayerLoadState.image && (
+                    <div>
+                      Image: {selectedLayerLoadState.image}
+                      {!hasRenderableLayerData(selectedConfig.id) && selectedLayerLoadState.image === 'loading'
+                        ? ' (blocking)'
+                        : ''}
+                    </div>
+                  )}
+                  {selectedConfig.type === 'shapes' && selectedLayerLoadState.tooltip && (
+                    <div>Tooltip metadata: {selectedLayerLoadState.tooltip}</div>
+                  )}
+                </div>
+              )}
               {selectedConfig.type === 'image' && (
                 <ImageChannelPanel
                   layerId={selectedConfig.id}
@@ -569,6 +626,16 @@ function SpatialCanvasInner() {
           )}
         </aside>
       </div>
+      {hoverTooltip && tooltipPosition && (
+        <ShapesTooltip
+          x={tooltipPosition.x}
+          y={tooltipPosition.y}
+          tooltip={{
+            title: hoverTooltip.title,
+            items: hoverTooltip.items,
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useMemo, useCallback, useState, type CSSProperties } from 'react';
 import { useMeasure } from '@uidotdev/usehooks';
 import { useSpatialData } from '@spatialdata/react';
+import type { PickingInfo } from 'deck.gl';
 import { 
   SpatialCanvasProvider, 
   useSpatialCanvasStore, 
@@ -32,6 +33,7 @@ import type {
 import type { SpatialCanvasStoreApi } from './stores';
 import { useLayerData } from './useLayerData';
 import { SpatialViewer } from './SpatialViewer';
+import { ShapesTooltip } from './ShapesTooltip';
 
 // Re-export for external use
 export { 
@@ -206,6 +208,12 @@ function SpatialCanvasInner() {
   const { spatialData, loading: sdLoading } = useSpatialData();
   const [viewerRef, { width, height }] = useMeasure();
   const [fullscreen, setFullscreen] = useState(false);
+  const [hoverTooltip, setHoverTooltip] = useState<{
+    x: number;
+    y: number;
+    title?: string;
+    items: Array<{ label: string; value: string }>;
+  } | null>(null);
 
   const coordinateSystem = useSpatialCanvasStore((s) => s.coordinateSystem);
   const layers = useSpatialCanvasStore((s) => s.layers);
@@ -227,11 +235,12 @@ function SpatialCanvasInner() {
     return getAvailableElements(spatialData, coordinateSystem);
   }, [spatialData, coordinateSystem]);
 
-  const { getLayers, getVivLayerProps, getImageLayerLoadedData, isLoading } = useLayerData(
+  const { getLayers, getVivLayerProps, getImageLayerLoadedData, getShapeTooltip, isLoading } = useLayerData(
     layers,
     layerOrder,
     availableElements,
     coordinateSystem,
+    spatialData ?? undefined,
   );
 
   const deckLayers = getLayers();
@@ -296,8 +305,40 @@ function SpatialCanvasInner() {
 
   const hasLayersDrawn = deckLayers.length > 0 || vivLayerProps.length > 0;
   const selectedConfig = selectedLayerId ? layers[selectedLayerId] : undefined;
+  const associatedTable =
+    selectedConfig?.type === 'shapes'
+      ? spatialData?.getAssociatedTable('shapes', selectedConfig.elementKey)?.[1]
+      : undefined;
+  const availableTooltipFields =
+    associatedTable?.getObsColumnNames().filter((columnName) => {
+      const tableKeys = associatedTable.getTableKeys();
+      return columnName !== tableKeys.instanceKey && columnName !== tableKeys.regionKey;
+    }) ?? [];
   const vw = width ?? 0;
   const vh = height ?? 0;
+
+  const handleHover = useCallback((info: PickingInfo) => {
+    if (!info.picked || typeof info.x !== 'number' || typeof info.y !== 'number') {
+      setHoverTooltip(null);
+      return;
+    }
+    const rawLayerId = typeof info.layer?.id === 'string' ? info.layer.id : '';
+    const normalizedLayerId = rawLayerId.replace(/-#.*#$/, '');
+    if (typeof info.index !== 'number' || info.index < 0) {
+      setHoverTooltip(null);
+      return;
+    }
+    const tooltip = getShapeTooltip(normalizedLayerId, info.index);
+    if (!tooltip) {
+      setHoverTooltip(null);
+      return;
+    }
+    setHoverTooltip({
+      x: info.x,
+      y: info.y,
+      ...tooltip,
+    });
+  }, [getShapeTooltip]);
 
   if (sdLoading) {
     return (
@@ -381,7 +422,18 @@ function SpatialCanvasInner() {
                 onViewStateChange={handleViewStateChange}
                 layers={deckLayers}
                 vivLayerProps={vivLayerProps.length > 0 ? vivLayerProps : undefined}
+                onHover={handleHover}
               />
+              {hoverTooltip && (
+                <ShapesTooltip
+                  x={hoverTooltip.x}
+                  y={hoverTooltip.y}
+                  tooltip={{
+                    title: hoverTooltip.title,
+                    items: hoverTooltip.items,
+                  }}
+                />
+              )}
               {isLoading && (
                 <div
                   style={{
@@ -461,6 +513,58 @@ function SpatialCanvasInner() {
                   updateLayer={actions.updateLayer}
                 />
               )}
+              {selectedConfig.type === 'shapes' && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <div>
+                    <div style={{ color: '#ccc', fontSize: '12px', marginBottom: 4 }}>Tooltip fields</div>
+                    {associatedTable ? (
+                      <>
+                        <div style={{ color: '#888', fontSize: '11px', marginBottom: 8 }}>
+                          Table: {associatedTable.key}
+                        </div>
+                        {availableTooltipFields.length > 0 ? (
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                            {availableTooltipFields.map((field) => {
+                              const checked = selectedConfig.tooltipFields?.includes(field) ?? false;
+                              return (
+                                <label
+                                  key={field}
+                                  style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#ccc', fontSize: '12px' }}
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={checked}
+                                    onChange={() => {
+                                      const current = new Set(selectedConfig.tooltipFields ?? []);
+                                      if (checked) {
+                                        current.delete(field);
+                                      } else {
+                                        current.add(field);
+                                      }
+                                      actions.updateLayer(selectedConfig.id, {
+                                        tooltipFields: Array.from(current),
+                                      });
+                                    }}
+                                  />
+                                  {field}
+                                </label>
+                              );
+                            })}
+                          </div>
+                        ) : (
+                          <div style={{ color: '#666', fontSize: '12px' }}>
+                            No eligible obs columns found on the associated table
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <div style={{ color: '#666', fontSize: '12px' }}>
+                        No associated table found for this shapes layer
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </aside>
@@ -538,4 +642,3 @@ export default function SpatialCanvas({ store }: SpatialCanvasProps) {
     </VivLoaderRegistryProvider>
   );
 }
-

--- a/packages/vis/src/SpatialCanvas/renderers/shapesRenderer.ts
+++ b/packages/vis/src/SpatialCanvas/renderers/shapesRenderer.ts
@@ -9,6 +9,11 @@ import type { Matrix4 } from '@math.gl/core';
 import type { ShapesElement } from '@spatialdata/core';
 import type { Layer } from 'deck.gl';
 
+export interface ShapeTooltipDatum {
+  title?: string;
+  items: Array<{ label: string; value: string }>;
+}
+
 export interface ShapesLayerRenderConfig {
   /** The shapes element to render */
   element: ShapesElement;
@@ -60,7 +65,6 @@ export function renderShapesLayer(config: ShapesLayerRenderConfig): Layer | null
   return new PolygonLayer({
     id,
     data: polygonData,
-    // Each item in polygonData is a polygon (array of rings, each ring is array of [x, y])
     getPolygon: (d: Array<Array<[number, number]>>) => d,
     getFillColor: fillColor,
     getLineColor: strokeColor,
@@ -94,4 +98,3 @@ export async function loadShapesData(
     return [];
   }
 }
-

--- a/packages/vis/src/SpatialCanvas/types.ts
+++ b/packages/vis/src/SpatialCanvas/types.ts
@@ -67,6 +67,8 @@ export interface ShapesLayerConfig extends BaseLayerConfig {
   fillColor?: [number, number, number, number];
   strokeColor?: [number, number, number, number];
   strokeWidth?: number;
+  /** Table obs columns to display in hover tooltips for this shapes layer. */
+  tooltipFields?: string[];
 }
 
 export interface PointsLayerConfig extends BaseLayerConfig {
@@ -159,4 +161,3 @@ export interface SpatialCanvasActions {
 }
 
 export type SpatialCanvasStore = SpatialCanvasState & SpatialCanvasActions;
-

--- a/packages/vis/src/SpatialCanvas/types.ts
+++ b/packages/vis/src/SpatialCanvas/types.ts
@@ -63,11 +63,11 @@ export interface ImageLayerConfig extends BaseLayerConfig {
 export interface ShapesLayerConfig extends BaseLayerConfig {
   type: 'shapes';
   // Shapes-specific settings
-  // TODO: these should be accessors for getFillColor etc based on EntityID
+  // TODO: these should be accessors for getFillColor etc based on picked feature identity
   fillColor?: [number, number, number, number];
   strokeColor?: [number, number, number, number];
   strokeWidth?: number;
-  /** Table obs columns to display in hover tooltips for this shapes layer. */
+  /** Table obs columns to display for a picked feature in this shapes layer. */
   tooltipFields?: string[];
 }
 
@@ -83,8 +83,9 @@ export interface PointsLayerConfig extends BaseLayerConfig {
 export interface LabelsLayerConfig extends BaseLayerConfig {
   type: 'labels';
   // Labels-specific settings (colormap, etc.)
-  // should also be able to associate with EntityID 
-  // - so we'll need some kind of buffer lookup for color/filter/etc
+  // should also be able to associate with picked feature identity
+  // (for example ObjectID-style raster values), so we'll need some kind of
+  // buffer lookup for color/filter/etc
 }
 
 export type LayerConfig = ImageLayerConfig | ShapesLayerConfig | PointsLayerConfig | LabelsLayerConfig;

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -131,19 +131,51 @@ async function loadShapeTooltipData(
     'featureIds' | 'tooltipSignature' | 'tooltipFields' | 'tooltipColumns' | 'tooltipRowIndices'
   >
 > {
-  const tooltipSignature = tooltipFields.join('\u0001');
   const featureIdsRaw = await element.loadFeatureIds();
   const featureIds = featureIdsRaw ? Array.from(featureIdsRaw, (value: unknown) => String(value)) : undefined;
 
-  if (!featureIds || !spatialData || tooltipFields.length === 0) {
-    return { featureIds, tooltipSignature, tooltipFields };
+  if (tooltipFields.length === 0) {
+    return {
+      featureIds,
+      tooltipSignature: '',
+      tooltipFields: [],
+      tooltipColumns: undefined,
+      tooltipRowIndices: undefined,
+    };
+  }
+
+  if (!featureIds) {
+    return {
+      featureIds,
+      tooltipSignature: undefined,
+      tooltipFields,
+      tooltipColumns: undefined,
+      tooltipRowIndices: undefined,
+    };
+  }
+
+  if (!spatialData) {
+    return {
+      featureIds,
+      tooltipSignature: undefined,
+      tooltipFields,
+      tooltipColumns: undefined,
+      tooltipRowIndices: undefined,
+    };
   }
 
   const associated = spatialData.getAssociatedTable('shapes', element.key);
   if (!associated) {
-    return { featureIds, tooltipSignature };
+    return {
+      featureIds,
+      tooltipSignature: undefined,
+      tooltipFields,
+      tooltipColumns: undefined,
+      tooltipRowIndices: undefined,
+    };
   }
 
+  const tooltipSignature = tooltipFields.join('\u0001');
   const [, table] = associated;
   const { regionKey } = table.getTableKeys();
   const requestedColumns = Array.from(new Set([regionKey, ...tooltipFields]));
@@ -353,7 +385,11 @@ export function useLayerData(
                   ...current,
                   ...tooltipData,
                 } as LoadedShapesData);
-                setLayerResourceStatus(layerId, 'tooltip', 'ready');
+                setLayerResourceStatus(
+                  layerId,
+                  'tooltip',
+                  tooltipData.tooltipSignature === undefined ? 'idle' : 'ready',
+                );
               } else {
                 const current = loadedDataRef.current.shapes.get(element.key);
                 loadedDataRef.current.shapes.set(element.key, {

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -5,7 +5,7 @@
  * loading state for each layer.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { Matrix4 } from '@math.gl/core';
 import type { Layer } from 'deck.gl';
 import type { ShapesElement, PointsElement, ImageElement, SpatialData } from '@spatialdata/core';
@@ -64,6 +64,14 @@ interface LoadedData {
   images: Map<string, ImageLoaderData>; // Viv loaders with computed channel data
 }
 
+type ResourceLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface LayerLoadState {
+  geometry?: ResourceLoadStatus;
+  image?: ResourceLoadStatus;
+  tooltip?: ResourceLoadStatus;
+}
+
 export interface ImageLayerConfig {
   loader: unknown; // Viv PixelSource
   colors: [number, number, number][];
@@ -82,10 +90,16 @@ interface UseLayerDataResult {
   getVivLayerProps: () => ImageLayerConfig[];
   /** Raw loaded image pipeline data (defaults) for the properties UI */
   getImageLayerLoadedData: (layerId: string) => ImageLoaderData | undefined;
+  /** Current load state for a given layer. */
+  getLayerLoadState: (layerId: string) => LayerLoadState | undefined;
+  /** Whether a layer already has enough data to render. */
+  hasRenderableLayerData: (layerId: string) => boolean;
   /** Resolve a shapes tooltip lazily from the picked row index. */
   getShapeTooltip: (layerId: string, objectIndex: number) => ShapeTooltipDatum | undefined;
   /** Whether any layers are currently loading */
   isLoading: boolean;
+  /** Whether any visible layer is still waiting on its first renderable resource. */
+  isBlocking: boolean;
   /** Trigger a reload of data for a specific element */
   reloadElement: (type: string, key: string) => void;
 }
@@ -180,20 +194,10 @@ async function loadShapeTooltipData(
 }
 
 async function loadShapesLayerData(
-  spatialData: SpatialData | undefined,
   element: ShapesElement,
-  config: LayerConfig | undefined,
-): Promise<LoadedShapesData> {
+): Promise<Pick<LoadedShapesData, 'polygons'>> {
   const polygons = await loadShapesData(element);
-  const tooltipFields =
-    config?.type === 'shapes'
-      ? config.tooltipFields ?? []
-      : [];
-  const tooltipData = await loadShapeTooltipData(spatialData, element, tooltipFields);
-  return {
-    polygons,
-    ...tooltipData,
-  };
+  return { polygons };
 }
 
 /**
@@ -221,8 +225,7 @@ export function useLayerData(
     images: new Map(),
   });
 
-  // Track which elements are currently loading
-  const [loadingKeys, setLoadingKeys] = useState<Set<string>>(new Set());
+  const [layerLoadStates, setLayerLoadStates] = useState<Record<string, LayerLoadState>>({});
 
   // Build a map of element key -> AvailableElement for quick lookup
   const elementMap = useRef<Map<string, AvailableElement>>(new Map());
@@ -237,10 +240,37 @@ export function useLayerData(
     elementMap.current = map;
   }, [availableElements]);
 
+  const setLayerResourceStatus = useCallback((
+    layerId: string,
+    resource: keyof LayerLoadState,
+    status: ResourceLoadStatus,
+  ) => {
+    setLayerLoadStates((prev) => {
+      const existing = prev[layerId] ?? {};
+      if (existing[resource] === status) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [layerId]: {
+          ...existing,
+          [resource]: status,
+        },
+      };
+    });
+  }, []);
+
   // Load data for enabled layers that don't have data yet
   useEffect(() => {
     const loadData = async () => {
-      const toLoad: Array<{ layerId: string; element: AvailableElement }> = [];
+      const toLoad: Array<{
+        layerId: string;
+        element: AvailableElement;
+        loadGeometry: boolean;
+        loadTooltip: boolean;
+        loadImage: boolean;
+        loadPoints: boolean;
+      }> = [];
       
       for (const layerId of layerOrder) {
         const config = layers[layerId];
@@ -254,41 +284,97 @@ export function useLayerData(
         if (config.type === 'shapes') {
           const loadedShapes = loaded.shapes.get(elem.key);
           const tooltipSignature = getTooltipSignature(config);
-          if (!loadedShapes || loadedShapes.tooltipSignature !== tooltipSignature) {
-            toLoad.push({ layerId, element: elem });
+          const loadGeometry = !loadedShapes;
+          const loadTooltip = !loadedShapes || loadedShapes.tooltipSignature !== tooltipSignature;
+          if (loadGeometry || loadTooltip) {
+            toLoad.push({
+              layerId,
+              element: elem,
+              loadGeometry,
+              loadTooltip,
+              loadImage: false,
+              loadPoints: false,
+            });
           }
         } else if (config.type === 'points' && !loaded.points.has(elem.key)) {
-          toLoad.push({ layerId, element: elem });
+          toLoad.push({
+            layerId,
+            element: elem,
+            loadGeometry: false,
+            loadTooltip: false,
+            loadImage: false,
+            loadPoints: true,
+          });
         } else if (config.type === 'image' && !loaded.images.has(elem.key)) {
-          toLoad.push({ layerId, element: elem });
+          toLoad.push({
+            layerId,
+            element: elem,
+            loadGeometry: false,
+            loadTooltip: false,
+            loadImage: true,
+            loadPoints: false,
+          });
         }
       }
       
       if (toLoad.length === 0) return;
-      
-      // Mark as loading
-      setLoadingKeys(prev => {
-        const next = new Set(prev);
-        for (const { layerId } of toLoad) next.add(layerId);
-        return next;
-      });
-      
+
       // Load in parallel
-      await Promise.all(toLoad.map(async ({ layerId, element }) => {
+      await Promise.all(toLoad.map(async ({ layerId, element, loadGeometry, loadTooltip, loadImage, loadPoints }) => {
         try {
           if (element.type === 'shapes') {
-            const data = await loadShapesLayerData(
-              spatialData,
-              element.element as ShapesElement,
-              layers[layerId],
-            );
-            loadedDataRef.current.shapes.set(element.key, data);
-          } else if (element.type === 'points') {
+            const existing = loadedDataRef.current.shapes.get(element.key);
+            if (loadGeometry) {
+              setLayerResourceStatus(layerId, 'geometry', 'loading');
+              const geometryData = await loadShapesLayerData(element.element as ShapesElement);
+              loadedDataRef.current.shapes.set(element.key, {
+                ...existing,
+                ...geometryData,
+              });
+              setLayerResourceStatus(layerId, 'geometry', 'ready');
+            } else {
+              setLayerResourceStatus(layerId, 'geometry', existing ? 'ready' : 'idle');
+            }
+
+            if (loadTooltip) {
+              const tooltipFields =
+                layers[layerId]?.type === 'shapes'
+                  ? layers[layerId].tooltipFields ?? []
+                  : [];
+              if (tooltipFields.length > 0) {
+                setLayerResourceStatus(layerId, 'tooltip', 'loading');
+                const current = loadedDataRef.current.shapes.get(element.key);
+                const tooltipData = await loadShapeTooltipData(
+                  spatialData,
+                  element.element as ShapesElement,
+                  tooltipFields,
+                );
+                loadedDataRef.current.shapes.set(element.key, {
+                  ...current,
+                  ...tooltipData,
+                } as LoadedShapesData);
+                setLayerResourceStatus(layerId, 'tooltip', 'ready');
+              } else {
+                const current = loadedDataRef.current.shapes.get(element.key);
+                loadedDataRef.current.shapes.set(element.key, {
+                  ...current,
+                  tooltipSignature: '',
+                  tooltipFields: [],
+                  tooltipColumns: undefined,
+                  tooltipRowIndices: undefined,
+                } as LoadedShapesData);
+                setLayerResourceStatus(layerId, 'tooltip', 'idle');
+              }
+            }
+          } else if (element.type === 'points' && loadPoints) {
+            setLayerResourceStatus(layerId, 'geometry', 'loading');
             // todo better type-guards etc here.
             const e = element.element as PointsElement;
             const data = await e.loadPoints();
             loadedDataRef.current.points.set(element.key, data);
-          } else if (element.type === 'image') {
+            setLayerResourceStatus(layerId, 'geometry', 'ready');
+          } else if (element.type === 'image' && loadImage) {
+            setLayerResourceStatus(layerId, 'image', 'loading');
             const loader = await createImageLoader(
               element.element as ImageElement,
               getOmeZarrMultiscalesData,
@@ -387,21 +473,25 @@ export function useLayerData(
             }
             
             loadedDataRef.current.images.set(element.key, imageData);
+            setLayerResourceStatus(layerId, 'image', 'ready');
           }
         } catch (error) {
+          if (loadGeometry || loadPoints) {
+            setLayerResourceStatus(layerId, 'geometry', 'error');
+          }
+          if (loadTooltip) {
+            setLayerResourceStatus(layerId, 'tooltip', 'error');
+          }
+          if (loadImage) {
+            setLayerResourceStatus(layerId, 'image', 'error');
+          }
           console.error(`Failed to load data for ${layerId}:`, error);
-        } finally {
-          setLoadingKeys(prev => {
-            const next = new Set(prev);
-            next.delete(layerId);
-            return next;
-          });
         }
       }));
     };
     
     loadData();
-  }, [layers, layerOrder, getOmeZarrMultiscalesData, spatialData]);
+  }, [layers, layerOrder, getOmeZarrMultiscalesData, spatialData, setLayerResourceStatus]);
 
   const reloadElement = useCallback((type: string, key: string) => {
     const loaded = loadedDataRef.current;
@@ -413,6 +503,21 @@ export function useLayerData(
       loaded.images.delete(key);
     }
     // The useEffect will pick up the missing data and reload
+  }, []);
+
+  const hasRenderableLayerData = useCallback((layerId: string): boolean => {
+    const elem = elementMap.current.get(layerId);
+    if (!elem) return false;
+    if (elem.type === 'shapes') {
+      return loadedDataRef.current.shapes.has(elem.key);
+    }
+    if (elem.type === 'points') {
+      return loadedDataRef.current.points.has(elem.key);
+    }
+    if (elem.type === 'image') {
+      return loadedDataRef.current.images.has(elem.key);
+    }
+    return false;
   }, []);
 
   const getLayers = useCallback((): Layer[] => {
@@ -469,6 +574,10 @@ export function useLayerData(
     if (!elem || elem.type !== 'image') return undefined;
     return loadedDataRef.current.images.get(elem.key);
   }, []);
+
+  const getLayerLoadState = useCallback((layerId: string): LayerLoadState | undefined => {
+    return layerLoadStates[layerId];
+  }, [layerLoadStates]);
 
   const getShapeTooltip = useCallback((layerId: string, objectIndex: number): ShapeTooltipDatum | undefined => {
     const elem = elementMap.current.get(layerId);
@@ -562,12 +671,39 @@ export function useLayerData(
     return vivProps;
   }, [layers, layerOrder]);
 
+  const isLoading = useMemo(
+    () => Object.values(layerLoadStates).some((state) =>
+      Object.values(state).some((status) => status === 'loading')
+    ),
+    [layerLoadStates],
+  );
+
+  const isBlocking = useMemo(
+    () => layerOrder.some((layerId) => {
+      const config = layers[layerId];
+      if (!config?.visible) return false;
+      const state = layerLoadStates[layerId];
+      if (!state) return false;
+      if (config.type === 'image') {
+        return state.image === 'loading' && !hasRenderableLayerData(layerId);
+      }
+      if (config.type === 'shapes' || config.type === 'points') {
+        return state.geometry === 'loading' && !hasRenderableLayerData(layerId);
+      }
+      return false;
+    }),
+    [layerLoadStates, layerOrder, layers, hasRenderableLayerData],
+  );
+
   return {
     getLayers,
     getVivLayerProps,
     getImageLayerLoadedData,
+    getLayerLoadState,
+    hasRenderableLayerData,
     getShapeTooltip,
-    isLoading: loadingKeys.size > 0,
+    isLoading,
+    isBlocking,
     reloadElement,
   };
 }

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -8,7 +8,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { Matrix4 } from '@math.gl/core';
 import type { Layer } from 'deck.gl';
-import type { ShapesElement, PointsElement, ImageElement, SpatialData } from '@spatialdata/core';
+import type { ShapesElement, PointsElement, ImageElement, SpatialData, TableColumnData } from '@spatialdata/core';
 import {
   buildDefaultSelection,
   clampVivSelectionsToAxes,
@@ -49,7 +49,7 @@ interface LoadedShapesData {
   featureIds?: string[];
   tooltipSignature?: string;
   tooltipFields?: string[];
-  tooltipColumns?: Array<string[] | undefined>;
+  tooltipColumns?: Array<TableColumnData | undefined>;
   /**
    * Optional row-index lookup aligned to picked feature order.
    * When omitted, picked feature index and tooltip row index are assumed to be identical.
@@ -111,10 +111,11 @@ function getTooltipSignature(config: LayerConfig | undefined): string {
   return (config.tooltipFields ?? []).join('\u0001');
 }
 
-function normalizeTooltipValue(value: string[] | undefined, rowIndex: number): string {
+function normalizeTooltipValue(value: TableColumnData | undefined, rowIndex: number): string {
   if (!value) return '';
   const row = value[rowIndex];
-  return row ?? '';
+  if (row === null || row === undefined) return '';
+  return String(row);
 }
 
 function tableRegionMatches(regionValue: string, shapeKey: string) {
@@ -186,7 +187,8 @@ async function loadShapeTooltipData(
   const filteredRowIds: string[] = [];
   const filteredRowIndices: number[] = [];
 
-  for (const [rowIndex, rowId] of rowIds.entries()) {
+  for (let rowIndex = 0; rowIndex < rowIds.length; rowIndex++) {
+    const rowId = rowIds[rowIndex];
     const regionValue = normalizeTooltipValue(regionColumn, rowIndex);
     if (regionValue && !tableRegionMatches(regionValue, element.key)) {
       continue;

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -356,10 +356,10 @@ export function useLayerData(
 
       // Load in parallel
       await Promise.all(toLoad.map(async ({ layerId, element, loadGeometry, loadTooltip, loadImage, loadPoints }) => {
-        try {
-          if (element.type === 'shapes') {
-            const existing = loadedDataRef.current.shapes.get(element.key);
-            if (loadGeometry) {
+        if (element.type === 'shapes') {
+          const existing = loadedDataRef.current.shapes.get(element.key);
+          if (loadGeometry) {
+            try {
               setLayerResourceStatus(layerId, 'geometry', 'loading');
               const geometryData = await loadShapesLayerData(element.element as ShapesElement);
               loadedDataRef.current.shapes.set(element.key, {
@@ -367,11 +367,17 @@ export function useLayerData(
                 ...geometryData,
               });
               setLayerResourceStatus(layerId, 'geometry', 'ready');
-            } else {
-              setLayerResourceStatus(layerId, 'geometry', existing ? 'ready' : 'idle');
+            } catch (error) {
+              setLayerResourceStatus(layerId, 'geometry', 'error');
+              console.error(`Failed to load shapes geometry for ${layerId}:`, error);
+              return;
             }
+          } else {
+            setLayerResourceStatus(layerId, 'geometry', existing ? 'ready' : 'idle');
+          }
 
-            if (loadTooltip) {
+          if (loadTooltip) {
+            try {
               const shapeLayerConfig =
                 layersRef.current[layerId]?.type === 'shapes'
                   ? layersRef.current[layerId]
@@ -414,15 +420,25 @@ export function useLayerData(
                 } as LoadedShapesData);
                 setLayerResourceStatus(layerId, 'tooltip', 'idle');
               }
+            } catch (error) {
+              setLayerResourceStatus(layerId, 'tooltip', 'error');
+              console.error(`Failed to load shapes tooltip for ${layerId}:`, error);
             }
-          } else if (element.type === 'points' && loadPoints) {
+          }
+        } else if (element.type === 'points' && loadPoints) {
+          try {
             setLayerResourceStatus(layerId, 'geometry', 'loading');
             // todo better type-guards etc here.
             const e = element.element as PointsElement;
             const data = await e.loadPoints();
             loadedDataRef.current.points.set(element.key, data);
             setLayerResourceStatus(layerId, 'geometry', 'ready');
-          } else if (element.type === 'image' && loadImage) {
+          } catch (error) {
+            setLayerResourceStatus(layerId, 'geometry', 'error');
+            console.error(`Failed to load points for ${layerId}:`, error);
+          }
+        } else if (element.type === 'image' && loadImage) {
+          try {
             setLayerResourceStatus(layerId, 'image', 'loading');
             const loader = await createImageLoader(
               element.element as ImageElement,
@@ -431,9 +447,9 @@ export function useLayerData(
             // Compute channel defaults from loader metadata
             const imageElement = element.element as ImageElement;
             const loaderToCheck = Array.isArray(loader) ? loader[0] : loader;
-            
+
             const imageData: ImageLoaderData = { loader };
-            
+
             try {
               if (loaderToCheck && typeof loaderToCheck === 'object' && 'labels' in loaderToCheck && 'shape' in loaderToCheck) {
                 const loaderObj = loaderToCheck as VivLoaderMetadata;
@@ -520,21 +536,13 @@ export function useLayerData(
                 imageData.selections = [{}];
               }
             }
-            
+
             loadedDataRef.current.images.set(element.key, imageData);
             setLayerResourceStatus(layerId, 'image', 'ready');
-          }
-        } catch (error) {
-          if (loadGeometry || loadPoints) {
-            setLayerResourceStatus(layerId, 'geometry', 'error');
-          }
-          if (loadTooltip) {
-            setLayerResourceStatus(layerId, 'tooltip', 'error');
-          }
-          if (loadImage) {
+          } catch (error) {
             setLayerResourceStatus(layerId, 'image', 'error');
+            console.error(`Failed to load image for ${layerId}:`, error);
           }
-          console.error(`Failed to load data for ${layerId}:`, error);
         }
       }));
     };

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -91,7 +91,7 @@ interface UseLayerDataResult {
   /** Raw loaded image pipeline data (defaults) for the properties UI */
   getImageLayerLoadedData: (layerId: string) => ImageLoaderData | undefined;
   /** Current load state for a given layer. */
-  getLayerLoadState: (layerId: string) => LayerLoadState | undefined;
+  getLayerLoadState: (layerId?: string) => LayerLoadState | undefined;
   /** Whether a layer already has enough data to render. */
   hasRenderableLayerData: (layerId: string) => boolean;
   /** Resolve a feature tooltip lazily from the picked row index. */
@@ -184,6 +184,7 @@ async function loadShapeTooltipData(
   const columns = await table.loadObsColumns(requestedColumns);
   const regionColumn = columns[0];
   const tooltipColumns = columns.slice(1);
+  // I don't like the look of this... creating 0-length arrays then pushing data...
   const filteredRowIds: string[] = [];
   const filteredRowIndices: number[] = [];
 
@@ -196,8 +197,8 @@ async function loadShapeTooltipData(
     filteredRowIds.push(String(rowId));
     filteredRowIndices.push(rowIndex);
   }
-
   let tooltipRowIndices: Int32Array | undefined;
+  // this looks costly?
   const isDirectlyAligned =
     filteredRowIds.length === featureIds.length
     && filteredRowIds.every((rowId, index) => rowId === featureIds[index]);
@@ -634,7 +635,8 @@ export function useLayerData(
     return loadedDataRef.current.images.get(elem.key);
   }, []);
 
-  const getLayerLoadState = useCallback((layerId: string): LayerLoadState | undefined => {
+  const getLayerLoadState = useCallback((layerId?: string): LayerLoadState | undefined => {
+    if (layerId === undefined) return undefined;
     return layerLoadStates[layerId];
   }, [layerLoadStates]);
 

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -8,7 +8,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Matrix4 } from '@math.gl/core';
 import type { Layer } from 'deck.gl';
-import type { ShapesElement, PointsElement, ImageElement } from '@spatialdata/core';
+import type { ShapesElement, PointsElement, ImageElement, SpatialData } from '@spatialdata/core';
 import {
   buildDefaultSelection,
   clampVivSelectionsToAxes,
@@ -23,7 +23,7 @@ import type { LayerConfig, ElementsByType, AvailableElement } from './types';
 import { 
   renderShapesLayer, 
   loadShapesData,
-  type ShapesLayerRenderConfig,
+  type ShapeTooltipDatum,
 } from './renderers/shapesRenderer';
 import { 
   renderPointsLayer, 
@@ -44,8 +44,22 @@ export interface ImageLoaderData {
   selectionAxisSizes?: Partial<Record<'z' | 'c' | 't', number>>;
 }
 
+interface LoadedShapesData {
+  polygons: Array<Array<Array<[number, number]>>>;
+  shapeIds?: string[];
+  tooltipSignature?: string;
+  tooltipFields?: string[];
+  tooltipColumns?: Array<string[] | undefined>;
+  /**
+   * Optional row-index lookup aligned to polygon order.
+   * When omitted, polygon index and tooltip row index are assumed to be identical.
+   * A value of -1 indicates no matching tooltip row for that shape.
+   */
+  tooltipRowIndices?: Int32Array;
+}
+
 interface LoadedData {
-  shapes: Map<string, Array<Array<Array<[number, number]>>>>;
+  shapes: Map<string, LoadedShapesData>;
   points: Map<string, PointData>;
   images: Map<string, ImageLoaderData>; // Viv loaders with computed channel data
 }
@@ -68,10 +82,118 @@ interface UseLayerDataResult {
   getVivLayerProps: () => ImageLayerConfig[];
   /** Raw loaded image pipeline data (defaults) for the properties UI */
   getImageLayerLoadedData: (layerId: string) => ImageLoaderData | undefined;
+  /** Resolve a shapes tooltip lazily from the picked row index. */
+  getShapeTooltip: (layerId: string, objectIndex: number) => ShapeTooltipDatum | undefined;
   /** Whether any layers are currently loading */
   isLoading: boolean;
   /** Trigger a reload of data for a specific element */
   reloadElement: (type: string, key: string) => void;
+}
+
+function getTooltipSignature(config: LayerConfig | undefined): string {
+  if (!config || config.type !== 'shapes') {
+    return '';
+  }
+  return (config.tooltipFields ?? []).join('\u0001');
+}
+
+function normalizeTooltipValue(value: string[] | undefined, rowIndex: number): string {
+  if (!value) return '';
+  const row = value[rowIndex];
+  return row ?? '';
+}
+
+function tableRegionMatches(regionValue: string, shapeKey: string) {
+  return regionValue === shapeKey || regionValue === `shapes/${shapeKey}`;
+}
+
+async function loadShapeTooltipData(
+  spatialData: SpatialData | undefined,
+  element: ShapesElement,
+  tooltipFields: string[],
+): Promise<
+  Pick<
+    LoadedShapesData,
+    'shapeIds' | 'tooltipSignature' | 'tooltipFields' | 'tooltipColumns' | 'tooltipRowIndices'
+  >
+> {
+  const tooltipSignature = tooltipFields.join('\u0001');
+  const shapeIdsRaw = await element.loadShapesIndex();
+  const shapeIds = shapeIdsRaw ? Array.from(shapeIdsRaw, (value: unknown) => String(value)) : undefined;
+
+  if (!shapeIds || !spatialData || tooltipFields.length === 0) {
+    return { shapeIds, tooltipSignature, tooltipFields };
+  }
+
+  const associated = spatialData.getAssociatedTable('shapes', element.key);
+  if (!associated) {
+    return { shapeIds, tooltipSignature };
+  }
+
+  const [, table] = associated;
+  const { regionKey } = table.getTableKeys();
+  const requestedColumns = Array.from(new Set([regionKey, ...tooltipFields]));
+  const rowIds = await table.loadObsIndex();
+  const columns = await table.loadObsColumns(requestedColumns);
+  const regionColumn = columns[0];
+  const tooltipColumns = columns.slice(1);
+  const filteredRowIds: string[] = [];
+  const filteredRowIndices: number[] = [];
+
+  for (const [rowIndex, rowId] of rowIds.entries()) {
+    const regionValue = normalizeTooltipValue(regionColumn, rowIndex);
+    if (regionValue && !tableRegionMatches(regionValue, element.key)) {
+      continue;
+    }
+    filteredRowIds.push(String(rowId));
+    filteredRowIndices.push(rowIndex);
+  }
+
+  let tooltipRowIndices: Int32Array | undefined;
+  const isDirectlyAligned =
+    filteredRowIds.length === shapeIds.length
+    && filteredRowIds.every((rowId, index) => rowId === shapeIds[index]);
+
+  if (!isDirectlyAligned) {
+    const rowIndexByShapeId = new Map<string, number>();
+    for (const [index, rowId] of filteredRowIds.entries()) {
+      rowIndexByShapeId.set(rowId, filteredRowIndices[index]);
+    }
+
+    tooltipRowIndices = new Int32Array(shapeIds.length);
+    tooltipRowIndices.fill(-1);
+    for (const [shapeIndex, shapeId] of shapeIds.entries()) {
+      const matchedRowIndex = rowIndexByShapeId.get(shapeId);
+      if (matchedRowIndex !== undefined) {
+        tooltipRowIndices[shapeIndex] = matchedRowIndex;
+      }
+    }
+  }
+
+  return {
+    shapeIds,
+    tooltipSignature,
+    tooltipFields,
+    tooltipColumns,
+    tooltipRowIndices,
+  };
+}
+
+async function loadShapesLayerData(
+  spatialData: SpatialData | undefined,
+  element: ShapesElement,
+  config: LayerConfig | undefined,
+): Promise<LoadedShapesData> {
+  const polygons = await loadShapesData(element);
+  const tooltipFields =
+    config?.type === 'shapes'
+      ? config.tooltipFields ?? []
+      : [];
+  const tooltipData = await loadShapeTooltipData(spatialData, element, tooltipFields);
+  return {
+    polygons,
+    ...tooltipData,
+  };
 }
 
 /**
@@ -88,6 +210,7 @@ export function useLayerData(
   layerOrder: string[],
   availableElements: ElementsByType,
   coordinateSystem: string | null,
+  spatialData?: SpatialData,
 ): UseLayerDataResult {
   const { getOmeZarrMultiscalesData } = useVivLoaderRegistry();
 
@@ -128,8 +251,12 @@ export function useLayerData(
         
         // Check if we need to load data
         const loaded = loadedDataRef.current;
-        if (config.type === 'shapes' && !loaded.shapes.has(elem.key)) {
-          toLoad.push({ layerId, element: elem });
+        if (config.type === 'shapes') {
+          const loadedShapes = loaded.shapes.get(elem.key);
+          const tooltipSignature = getTooltipSignature(config);
+          if (!loadedShapes || loadedShapes.tooltipSignature !== tooltipSignature) {
+            toLoad.push({ layerId, element: elem });
+          }
         } else if (config.type === 'points' && !loaded.points.has(elem.key)) {
           toLoad.push({ layerId, element: elem });
         } else if (config.type === 'image' && !loaded.images.has(elem.key)) {
@@ -150,7 +277,11 @@ export function useLayerData(
       await Promise.all(toLoad.map(async ({ layerId, element }) => {
         try {
           if (element.type === 'shapes') {
-            const data = await loadShapesData(element.element as ShapesElement);
+            const data = await loadShapesLayerData(
+              spatialData,
+              element.element as ShapesElement,
+              layers[layerId],
+            );
             loadedDataRef.current.shapes.set(element.key, data);
           } else if (element.type === 'points') {
             // todo better type-guards etc here.
@@ -270,7 +401,7 @@ export function useLayerData(
     };
     
     loadData();
-  }, [layers, layerOrder, getOmeZarrMultiscalesData]);
+  }, [layers, layerOrder, getOmeZarrMultiscalesData, spatialData]);
 
   const reloadElement = useCallback((type: string, key: string) => {
     const loaded = loadedDataRef.current;
@@ -296,8 +427,8 @@ export function useLayerData(
       if (!elem) continue;
       
       if (config.type === 'shapes') {
-        const polygonData = loaded.shapes.get(elem.key);
-        if (polygonData) {
+        const shapeData = loaded.shapes.get(elem.key);
+        if (shapeData) {
           const layer = renderShapesLayer({
             element: elem.element as ShapesElement,
             id: layerId,
@@ -307,7 +438,7 @@ export function useLayerData(
             fillColor: config.fillColor,
             strokeColor: config.strokeColor,
             strokeWidth: config.strokeWidth,
-            polygonData,
+            polygonData: shapeData.polygons,
           });
           if (layer) deckLayers.push(layer);
         }
@@ -337,6 +468,46 @@ export function useLayerData(
     const elem = elementMap.current.get(layerId);
     if (!elem || elem.type !== 'image') return undefined;
     return loadedDataRef.current.images.get(elem.key);
+  }, []);
+
+  const getShapeTooltip = useCallback((layerId: string, objectIndex: number): ShapeTooltipDatum | undefined => {
+    const elem = elementMap.current.get(layerId);
+    if (!elem || elem.type !== 'shapes') {
+      return undefined;
+    }
+
+    const loadedShapeData = loadedDataRef.current.shapes.get(elem.key);
+    if (!loadedShapeData?.shapeIds || !loadedShapeData.tooltipFields || !loadedShapeData.tooltipColumns) {
+      return undefined;
+    }
+
+    const shapeId = loadedShapeData.shapeIds[objectIndex];
+    if (!shapeId) {
+      return undefined;
+    }
+
+    const rowIndex = loadedShapeData.tooltipRowIndices
+      ? loadedShapeData.tooltipRowIndices[objectIndex]
+      : objectIndex;
+    if (rowIndex === undefined || rowIndex < 0) {
+      return undefined;
+    }
+
+    const items = loadedShapeData.tooltipFields
+      .map((field, fieldIndex) => ({
+        label: field,
+        value: normalizeTooltipValue(loadedShapeData.tooltipColumns?.[fieldIndex], rowIndex),
+      }))
+      .filter((item) => item.value !== '');
+
+    if (items.length === 0) {
+      return undefined;
+    }
+
+    return {
+      title: shapeId,
+      items,
+    };
   }, []);
 
   const getVivLayerProps = useCallback((): ImageLayerConfig[] => {
@@ -395,8 +566,8 @@ export function useLayerData(
     getLayers,
     getVivLayerProps,
     getImageLayerLoadedData,
+    getShapeTooltip,
     isLoading: loadingKeys.size > 0,
     reloadElement,
   };
 }
-

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -257,6 +257,9 @@ export function useLayerData(
     images: new Map(),
   });
 
+  const layersRef = useRef(layers);
+  layersRef.current = layers;
+
   const [layerLoadStates, setLayerLoadStates] = useState<Record<string, LayerLoadState>>({});
 
   // Build a map of element key -> AvailableElement for quick lookup
@@ -369,10 +372,12 @@ export function useLayerData(
             }
 
             if (loadTooltip) {
-              const tooltipFields =
-                layers[layerId]?.type === 'shapes'
-                  ? layers[layerId].tooltipFields ?? []
-                  : [];
+              const shapeLayerConfig =
+                layersRef.current[layerId]?.type === 'shapes'
+                  ? layersRef.current[layerId]
+                  : undefined;
+              const tooltipFields = shapeLayerConfig?.tooltipFields ?? [];
+              const requestedSignature = getTooltipSignature(shapeLayerConfig);
               if (tooltipFields.length > 0) {
                 setLayerResourceStatus(layerId, 'tooltip', 'loading');
                 const current = loadedDataRef.current.shapes.get(element.key);
@@ -381,6 +386,14 @@ export function useLayerData(
                   element.element as ShapesElement,
                   tooltipFields,
                 );
+                const latestDesired = getTooltipSignature(
+                  layersRef.current[layerId]?.type === 'shapes'
+                    ? layersRef.current[layerId]
+                    : undefined,
+                );
+                if (latestDesired !== requestedSignature) {
+                  return;
+                }
                 loadedDataRef.current.shapes.set(element.key, {
                   ...current,
                   ...tooltipData,
@@ -623,6 +636,11 @@ export function useLayerData(
 
     const loadedShapeData = loadedDataRef.current.shapes.get(elem.key);
     if (!loadedShapeData?.featureIds || !loadedShapeData.tooltipFields || !loadedShapeData.tooltipColumns) {
+      return undefined;
+    }
+
+    const config = layersRef.current[layerId];
+    if (getTooltipSignature(config) !== (loadedShapeData.tooltipSignature ?? '')) {
       return undefined;
     }
 

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -46,14 +46,14 @@ export interface ImageLoaderData {
 
 interface LoadedShapesData {
   polygons: Array<Array<Array<[number, number]>>>;
-  shapeIds?: string[];
+  featureIds?: string[];
   tooltipSignature?: string;
   tooltipFields?: string[];
   tooltipColumns?: Array<string[] | undefined>;
   /**
-   * Optional row-index lookup aligned to polygon order.
-   * When omitted, polygon index and tooltip row index are assumed to be identical.
-   * A value of -1 indicates no matching tooltip row for that shape.
+   * Optional row-index lookup aligned to picked feature order.
+   * When omitted, picked feature index and tooltip row index are assumed to be identical.
+   * A value of -1 indicates no matching tooltip row for that feature.
    */
   tooltipRowIndices?: Int32Array;
 }
@@ -94,8 +94,8 @@ interface UseLayerDataResult {
   getLayerLoadState: (layerId: string) => LayerLoadState | undefined;
   /** Whether a layer already has enough data to render. */
   hasRenderableLayerData: (layerId: string) => boolean;
-  /** Resolve a shapes tooltip lazily from the picked row index. */
-  getShapeTooltip: (layerId: string, objectIndex: number) => ShapeTooltipDatum | undefined;
+  /** Resolve a feature tooltip lazily from the picked row index. */
+  getFeatureTooltip: (layerId: string, objectIndex: number) => ShapeTooltipDatum | undefined;
   /** Whether any layers are currently loading */
   isLoading: boolean;
   /** Whether any visible layer is still waiting on its first renderable resource. */
@@ -128,20 +128,20 @@ async function loadShapeTooltipData(
 ): Promise<
   Pick<
     LoadedShapesData,
-    'shapeIds' | 'tooltipSignature' | 'tooltipFields' | 'tooltipColumns' | 'tooltipRowIndices'
+    'featureIds' | 'tooltipSignature' | 'tooltipFields' | 'tooltipColumns' | 'tooltipRowIndices'
   >
 > {
   const tooltipSignature = tooltipFields.join('\u0001');
-  const shapeIdsRaw = await element.loadShapesIndex();
-  const shapeIds = shapeIdsRaw ? Array.from(shapeIdsRaw, (value: unknown) => String(value)) : undefined;
+  const featureIdsRaw = await element.loadFeatureIds();
+  const featureIds = featureIdsRaw ? Array.from(featureIdsRaw, (value: unknown) => String(value)) : undefined;
 
-  if (!shapeIds || !spatialData || tooltipFields.length === 0) {
-    return { shapeIds, tooltipSignature, tooltipFields };
+  if (!featureIds || !spatialData || tooltipFields.length === 0) {
+    return { featureIds, tooltipSignature, tooltipFields };
   }
 
   const associated = spatialData.getAssociatedTable('shapes', element.key);
   if (!associated) {
-    return { shapeIds, tooltipSignature };
+    return { featureIds, tooltipSignature };
   }
 
   const [, table] = associated;
@@ -165,27 +165,27 @@ async function loadShapeTooltipData(
 
   let tooltipRowIndices: Int32Array | undefined;
   const isDirectlyAligned =
-    filteredRowIds.length === shapeIds.length
-    && filteredRowIds.every((rowId, index) => rowId === shapeIds[index]);
+    filteredRowIds.length === featureIds.length
+    && filteredRowIds.every((rowId, index) => rowId === featureIds[index]);
 
   if (!isDirectlyAligned) {
-    const rowIndexByShapeId = new Map<string, number>();
+    const rowIndexByFeatureId = new Map<string, number>();
     for (const [index, rowId] of filteredRowIds.entries()) {
-      rowIndexByShapeId.set(rowId, filteredRowIndices[index]);
+      rowIndexByFeatureId.set(rowId, filteredRowIndices[index]);
     }
 
-    tooltipRowIndices = new Int32Array(shapeIds.length);
+    tooltipRowIndices = new Int32Array(featureIds.length);
     tooltipRowIndices.fill(-1);
-    for (const [shapeIndex, shapeId] of shapeIds.entries()) {
-      const matchedRowIndex = rowIndexByShapeId.get(shapeId);
+    for (const [featureIndex, featureId] of featureIds.entries()) {
+      const matchedRowIndex = rowIndexByFeatureId.get(featureId);
       if (matchedRowIndex !== undefined) {
-        tooltipRowIndices[shapeIndex] = matchedRowIndex;
+        tooltipRowIndices[featureIndex] = matchedRowIndex;
       }
     }
   }
 
   return {
-    shapeIds,
+    featureIds,
     tooltipSignature,
     tooltipFields,
     tooltipColumns,
@@ -579,19 +579,19 @@ export function useLayerData(
     return layerLoadStates[layerId];
   }, [layerLoadStates]);
 
-  const getShapeTooltip = useCallback((layerId: string, objectIndex: number): ShapeTooltipDatum | undefined => {
+  const getFeatureTooltip = useCallback((layerId: string, objectIndex: number): ShapeTooltipDatum | undefined => {
     const elem = elementMap.current.get(layerId);
     if (!elem || elem.type !== 'shapes') {
       return undefined;
     }
 
     const loadedShapeData = loadedDataRef.current.shapes.get(elem.key);
-    if (!loadedShapeData?.shapeIds || !loadedShapeData.tooltipFields || !loadedShapeData.tooltipColumns) {
+    if (!loadedShapeData?.featureIds || !loadedShapeData.tooltipFields || !loadedShapeData.tooltipColumns) {
       return undefined;
     }
 
-    const shapeId = loadedShapeData.shapeIds[objectIndex];
-    if (!shapeId) {
+    const featureId = loadedShapeData.featureIds[objectIndex];
+    if (!featureId) {
       return undefined;
     }
 
@@ -614,7 +614,7 @@ export function useLayerData(
     }
 
     return {
-      title: shapeId,
+      title: featureId,
       items,
     };
   }, []);
@@ -701,7 +701,7 @@ export function useLayerData(
     getImageLayerLoadedData,
     getLayerLoadState,
     hasRenderableLayerData,
-    getShapeTooltip,
+    getFeatureTooltip,
     isLoading,
     isBlocking,
     reloadElement,

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -29,4 +29,10 @@ export type {
   LayerType,
   AvailableElement,
   ElementsByType,
+  SpatialCanvasProps,
+  ShapesTooltipData,
+  ShapesTooltipItem,
+  SpatialCanvasTooltipRenderProps,
+  ShapesTooltipProps,
 } from './SpatialCanvas';
+export { ShapesTooltip } from './SpatialCanvas';

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -30,9 +30,9 @@ export type {
   AvailableElement,
   ElementsByType,
   SpatialCanvasProps,
-  ShapesTooltipData,
-  ShapesTooltipItem,
+  SpatialFeatureTooltipData,
+  SpatialFeatureTooltipItem,
   SpatialCanvasTooltipRenderProps,
-  ShapesTooltipProps,
+  SpatialFeatureTooltipProps,
 } from './SpatialCanvas';
-export { ShapesTooltip } from './SpatialCanvas';
+export { SpatialFeatureTooltip } from './SpatialCanvas';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ catalogs:
       specifier: ^3.1.4
       version: 3.2.4
     zarrita:
-      specifier: ^0.5.4
-      version: 0.5.4
+      specifier: ^0.6.1
+      version: 0.6.1
     zod:
       specifier: ^4.1.13
       version: 4.1.13
@@ -216,7 +216,7 @@ importers:
         version: 0.6.1
       zarrita:
         specifier: 'catalog:'
-        version: 0.5.4
+        version: 0.6.1
       zod:
         specifier: 'catalog:'
         version: 4.1.13
@@ -287,7 +287,7 @@ importers:
         version: 19.2.0(react@19.2.0)
       zarrita:
         specifier: 'catalog:'
-        version: 0.5.4
+        version: 0.6.1
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -369,7 +369,7 @@ importers:
         version: 19.2.0(react@19.2.0)
       zarrita:
         specifier: 'catalog:'
-        version: 0.5.4
+        version: 0.6.1
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -406,7 +406,7 @@ importers:
     dependencies:
       zarrita:
         specifier: 'catalog:'
-        version: 0.5.4
+        version: 0.6.1
       zod:
         specifier: 'catalog:'
         version: 4.1.13
@@ -3170,6 +3170,9 @@ packages:
 
   '@zarrita/storage@0.1.3':
     resolution: {integrity: sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==}
+
+  '@zarrita/storage@0.1.4':
+    resolution: {integrity: sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==}
 
   '@zip.js/zip.js@2.8.11':
     resolution: {integrity: sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==}
@@ -7568,6 +7571,9 @@ packages:
   zarrita@0.5.4:
     resolution: {integrity: sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==}
 
+  zarrita@0.6.1:
+    resolution: {integrity: sha512-YOMTW8FT55Rz+vadTIZeOFZ/F2h4svKizyldvPtMYSxPgSNcRkOzkxCsWpIWlWzB1I/LmISmi0bEekOhLlI+Zw==}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -11686,6 +11692,11 @@ snapshots:
   '@xtuc/long@4.2.2': {}
 
   '@zarrita/storage@0.1.3':
+    dependencies:
+      reference-spec-reader: 0.2.0
+      unzipit: 1.4.3
+
+  '@zarrita/storage@0.1.4':
     dependencies:
       reference-spec-reader: 0.2.0
       unzipit: 1.4.3
@@ -16746,12 +16757,17 @@ snapshots:
 
   zarrita@0.5.1:
     dependencies:
-      '@zarrita/storage': 0.1.3
+      '@zarrita/storage': 0.1.4
       numcodecs: 0.3.2
 
   zarrita@0.5.4:
     dependencies:
-      '@zarrita/storage': 0.1.3
+      '@zarrita/storage': 0.1.4
+      numcodecs: 0.3.2
+
+  zarrita@0.6.1:
+    dependencies:
+      '@zarrita/storage': 0.1.4
       numcodecs: 0.3.2
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,6 @@ catalog:
   vite: ^7.2.7
   vite-plugin-dts: ^4.5.0
   vitest: ^3.1.4
-  zarrita: ^0.5.4
+  zarrita: ^0.6.1
   zod: ^4.1.13
   jsdom: ^27.4.0


### PR DESCRIPTION
## Summary
- add `getTableKeys` and `SpatialData` helpers to resolve table-to-element associations
- extend `TableElement` with obs column/index loading utilities for associated table lookups
- add configurable `tooltipFields` for shapes layers and render hover tooltips from associated table data
- add tests covering table key normalization and shape/table association behavior

## Testing
- `pnpm --filter @spatialdata/core build`
- `pnpm vitest run packages/core/tests/tableAssociations.spec.ts packages/vis/tests/index.spec.tsx`
- `pnpm --filter @spatialdata/vis build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive hover tooltips for shapes with configurable tooltip fields and render/container overrides; per-layer load-state APIs and non-blocking vs blocking load behavior; helpers to discover and load tables associated with shapes and to lazily load selected observation columns.
* **Documentation**
  * Clarified feature identity, shape/table association guidance, and documented loader/compatibility notes.
* **Tests**
  * Added coverage for table associations, direct table reads, and shapes feature-indexing.
* **Chores**
  * Workspace dependency version updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->