### PR TITLE
Fix transform composition order

### DIFF
--- a/packages/core/src/transformations/transformations.ts
+++ b/packages/core/src/transformations/transformations.ts
@@ -167,6 +167,16 @@ function rowMajor4x4ToColumnMajor(rows: number[][]): number[] {
   return result;
 }
 
+function composeMatricesInApplicationOrder(matrices: Matrix4[]): Matrix4 {
+  const matrix = new Matrix4().identity();
+  // Matrix products apply right-to-left to points, so we multiply in reverse
+  // to preserve the listed/application order of transformations.
+  for (let i = matrices.length - 1; i >= 0; i--) {
+    matrix.multiplyRight(matrices[i]!);
+  }
+  return matrix;
+}
+
 function buildSpatialMatrixFromAffine(
   affine: number[][],
   inputAxes: Axis[] | undefined,
@@ -417,19 +427,11 @@ export class Sequence extends BaseTransformation {
   }
 
   toArray(): number[] {
-    const matrix = new Matrix4().identity();
-    for (const t of this.transformations) {
-      matrix.multiplyRight(t.toMatrix());
-    }
-    return Array.from(matrix);
+    return Array.from(this.toMatrix());
   }
 
   toMatrix(): Matrix4 {
-    const matrix = new Matrix4().identity();
-    for (const t of this.transformations) {
-      matrix.multiplyRight(t.toMatrix());
-    }
-    return matrix;
+    return composeMatricesInApplicationOrder(this.transformations.map((t) => t.toMatrix()));
   }
 }
 
@@ -545,18 +547,18 @@ export function composeTransforms(
     return undefined;
   }
 
-  const matrix = new Matrix4().identity();
+  const matrices: Matrix4[] = [];
 
   // Apply dataset transforms first (inner), then element transforms (outer)
   // This follows the convention that dataset transforms go from pixel to element space,
-  // then element transforms go from element space to coordinate system
+  // then element transforms go from element space to coordinate system.
   if (datasetTransforms) {
-    matrix.multiplyRight(parseTransforms(datasetTransforms).toMatrix());
+    matrices.push(parseTransforms(datasetTransforms).toMatrix());
   }
 
   if (elementTransforms) {
-    matrix.multiplyRight(parseTransforms(elementTransforms).toMatrix());
+    matrices.push(parseTransforms(elementTransforms).toMatrix());
   }
 
-  return matrix;
+  return composeMatricesInApplicationOrder(matrices);
 }

--- a/packages/core/tests/transformations.spec.ts
+++ b/packages/core/tests/transformations.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { Affine } from '../src/transformations/transformations.js';
+import {
+  Affine,
+  buildMatrix4FromTransforms,
+  composeTransforms,
+} from '../src/transformations/transformations.js';
 
 describe('Affine', () => {
   it('maps full-axis affines onto spatial x/y dimensions by axis name', () => {
@@ -62,5 +66,39 @@ describe('Affine', () => {
     expect(mapped[0]).toBeCloseTo(18);
     expect(mapped[1]).toBeCloseTo(35);
     expect(mapped[2]).toBeCloseTo(0);
+  });
+});
+
+describe('transform composition order', () => {
+  it('applies explicit sequence transformations in listed order', () => {
+    const matrix = buildMatrix4FromTransforms([
+      {
+        type: 'sequence',
+        transformations: [
+          { type: 'scale', scale: [2, 2] },
+          { type: 'translation', translation: [10, 20] },
+        ],
+      },
+    ]);
+
+    expect(matrix.transformPoint([1, 1, 0])).toEqual([12, 22, 0]);
+  });
+
+  it('applies top-level transform arrays in listed order', () => {
+    const matrix = buildMatrix4FromTransforms([
+      { type: 'scale', scale: [2, 2] },
+      { type: 'translation', translation: [10, 20] },
+    ]);
+
+    expect(matrix.transformPoint([1, 1, 0])).toEqual([12, 22, 0]);
+  });
+
+  it('applies dataset transforms before element transforms', () => {
+    const matrix = composeTransforms(
+      [{ type: 'translation', translation: [10, 20] }],
+      [{ type: 'scale', scale: [2, 2] }]
+    );
+
+    expect(matrix?.transformPoint([1, 1, 0])).toEqual([12, 22, 0]);
   });
 });


### PR DESCRIPTION
## Summary
- Compose sequence and top-level transforms in application order instead of reversing the intended order.
- Keep dataset-level transforms applied before element-level transforms in the combined matrix helper.
- Add regression tests covering sequence, array composition, and dataset/element ordering.

## Testing
- `vitest` unit tests for transformation order scenarios