### PR TITLE
Update Viv and DeckGL versions

### DIFF
--- a/packages/vis/package.json
+++ b/packages/vis/package.json
@@ -34,6 +34,7 @@
     "@spatialdata/layers": "workspace:*",
     "@spatialdata/core": "workspace:*",
     "@spatialdata/react": "workspace:*",
+    "@vivjs/views": "catalog:",
     "@uidotdev/usehooks": "^2.4.1",
     "@uiw/react-json-view": "2.0.0-alpha.39",
     "@deck.gl/core": "catalog:",

--- a/packages/vis/src/ImageView/index.tsx
+++ b/packages/vis/src/ImageView/index.tsx
@@ -1,19 +1,20 @@
-import { useSpatialData } from '@spatialdata/react';
-import { useEffect, useMemo, useState, useId, type CSSProperties, useCallback } from 'react';
-import { useMeasure } from '@uidotdev/usehooks';
+import { VivViewer, getDefaultInitialViewState } from '@hms-dbmi/viv';
 import {
+  DEFAULT_CHANNEL_STATE,
+  VivProvider,
   createVivStores,
+  resolveRasterSource,
   useChannelsStore,
+  useChannelsStoreApi,
   useLoader,
   useViewerStore,
   useViewerStoreApi,
-  VivProvider,
-  useChannelsStoreApi,
-  DEFAULT_CHANNEL_STATE,
-  resolveRasterSource,
 } from '@spatialdata/avivatorish';
-import { DetailView, VivViewer, getDefaultInitialViewState } from '@hms-dbmi/viv';
 import { useImage } from '@spatialdata/avivatorish';
+import { useSpatialData } from '@spatialdata/react';
+import { useMeasure } from '@uidotdev/usehooks';
+import { DetailView, ScaleBarView } from '@vivjs/views';
+import { type CSSProperties, useCallback, useEffect, useId, useMemo, useState } from 'react';
 
 /**
  * when trying to getDefaultInitialViewState, it'll do something a bit like this internally...
@@ -35,16 +36,26 @@ function VivImage({ url, width, height }: { url?: string | URL; width: number; h
   const layerConfig = useMemo(() => ({ loader, ...channels }), [loader, channels]);
   const id = useId();
   const detailId = `${id}detail-react`;
+  const scaleBarId = `${detailId}-scalebar`;
   const viewState = useViewerStore((state) => state.viewState);
   const isViewerLoading = useViewerStore((store) => store.isViewerLoading);
   const detailView = useMemo(() => {
     return new DetailView({
       id: detailId,
-      snapScaleBar: true,
       width,
       height,
     });
   }, [detailId, width, height]);
+  const scaleBarView = useMemo(() => {
+    return new ScaleBarView({
+      id: scaleBarId,
+      width,
+      height,
+      loader,
+      snap: true,
+      imageViewId: detailId,
+    });
+  }, [scaleBarId, width, height, loader, detailId]);
   const deckProps = useMemo(
     () => ({
       style: {
@@ -92,11 +103,17 @@ function VivImage({ url, width, height }: { url?: string | URL; width: number; h
   return (
     <VivViewer
       deckProps={deckProps}
-      layerProps={[layerConfig]}
-      views={[detailView]}
-      viewStates={[{ ...viewState, id: detailId }]}
-      onViewStateChange={({ viewState: newViewState }) => {
-        viewerStore.setState({ viewState: newViewState });
+      layerProps={[layerConfig, layerConfig]}
+      views={[detailView, scaleBarView]}
+      viewStates={[
+        { ...viewState, id: detailId },
+        { ...viewState, id: scaleBarId },
+      ]}
+      onViewStateChange={({ viewId, viewState: newViewState }) => {
+        if (viewId === detailId) {
+          viewerStore.setState({ viewState: newViewState });
+        }
+        return newViewState;
       }}
     />
   );

--- a/packages/vis/src/SpatialCanvas/SpatialViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/SpatialViewer.tsx
@@ -10,13 +10,13 @@
  * - Otherwise: uses simplified functional component with DetailView
  */
 
-import { useCallback, useMemo, useId } from 'react';
-import { DeckGL } from 'deck.gl';
 import { DetailView } from '@hms-dbmi/viv';
+import { DeckGL } from 'deck.gl';
 import type { Layer, PickingInfo } from 'deck.gl';
+import { useCallback, useId, useMemo } from 'react';
+import VivSpatialViewer from './VivSpatialViewer';
 import type { ViewState } from './types';
 import type { ImageLayerConfig } from './useLayerData';
-import VivSpatialViewer from './VivSpatialViewer';
 
 export interface SpatialViewerProps {
   /** Viewport width */
@@ -104,7 +104,6 @@ function SpatialViewerSimple({
   const detailView = useMemo(() => {
     return new DetailView({
       id: `spatial-${viewId}`,
-      snapScaleBar: true,
       width,
       height,
     });

--- a/packages/vis/src/SpatialCanvas/VivSpatialViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/VivSpatialViewer.tsx
@@ -12,18 +12,19 @@
  * Structured to allow gradual refactoring to hooks in the future.
  */
 
-import * as React from 'react';
+import { ScaleBarLayer, getDefaultInitialViewState } from '@hms-dbmi/viv';
+import { DetailView, ScaleBarView } from '@vivjs/views';
 import { DeckGL } from 'deck.gl';
-import equal from 'fast-deep-equal';
-import { ScaleBarLayer, DetailView, getDefaultInitialViewState } from '@hms-dbmi/viv';
 import type {
-  OrthographicViewState,
-  OrbitViewState,
   DeckGLProps,
   Layer,
   LayersList,
+  OrbitViewState,
+  OrthographicViewState,
   PickingInfo,
 } from 'deck.gl';
+import equal from 'fast-deep-equal';
+import * as React from 'react';
 import type { ViewState } from './types';
 import type { ImageLayerConfig } from './useLayerData';
 
@@ -36,6 +37,7 @@ export type VivViewStates = VivViewState[];
 export type View = { id: string } & any; // Viv View type
 export type VivPickInfo = PickingInfo<any, any> & { tile?: any };
 type VivZoom = number | readonly number[] | null | undefined;
+type VivLoader = { meta?: { physicalSizes?: { x?: { size: number; unit: string } } } };
 
 export function normalizeVivZoom(zoom: VivZoom): number {
   if (Array.isArray(zoom)) {
@@ -184,18 +186,29 @@ function fromVivViewState(vivViewState: VivViewState): ViewState {
   };
 }
 
+function getScaleBarLoader(vivLayerProps: ImageLayerConfig[]): VivLoader[] | undefined {
+  for (const layerProps of vivLayerProps) {
+    const loader = layerProps.loader;
+    if (Array.isArray(loader) && loader[0]?.meta?.physicalSizes?.x) {
+      return loader as VivLoader[];
+    }
+  }
+  return undefined;
+}
+
 class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpatialViewerState> {
   private detailView: DetailView;
   private viewId: string;
+  private scaleBarViewId: string;
 
   constructor(props: VivSpatialViewerProps) {
     super(props);
     this.viewId = `spatial-detail-${Math.random().toString(36).substr(2, 9)}`;
+    this.scaleBarViewId = `${this.viewId}-scalebar`;
 
     // Create DetailView
     this.detailView = new DetailView({
       id: this.viewId,
-      snapScaleBar: true,
       width: props.width,
       height: props.height,
     });
@@ -208,6 +221,7 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
     this.state = {
       viewStates: {
         [this.viewId]: initialViewState,
+        [this.scaleBarViewId]: this.getScaleBarViewState(),
       },
       // deckRef: React.createRef(),
     };
@@ -255,13 +269,47 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
     } as VivViewState;
   }
 
+  private getScaleBarViewState(): VivViewState {
+    return {
+      id: this.scaleBarViewId,
+      target: [this.props.width / 2, this.props.height / 2, 0],
+      zoom: 0,
+      width: this.props.width,
+      height: this.props.height,
+    } as VivViewState;
+  }
+
+  private getScaleBarView(): ScaleBarView | undefined {
+    const loader = getScaleBarLoader(this.props.vivLayerProps);
+    if (!loader) {
+      return undefined;
+    }
+    return new ScaleBarView({
+      id: this.scaleBarViewId,
+      width: this.props.width,
+      height: this.props.height,
+      loader,
+      snap: true,
+      imageViewId: this.viewId,
+    });
+  }
+
   componentDidUpdate(prevProps: VivSpatialViewerProps) {
     const { width, height, viewState } = this.props;
+    const nextViewStates: Record<string, VivViewState> = { ...this.state.viewStates };
+    let viewStatesChanged = false;
 
     // Update view dimensions if changed
     if (width !== prevProps.width || height !== prevProps.height) {
       this.detailView.width = width;
       this.detailView.height = height;
+      nextViewStates[this.viewId] = {
+        ...nextViewStates[this.viewId],
+        width,
+        height,
+      } as unknown as VivViewState;
+      nextViewStates[this.scaleBarViewId] = this.getScaleBarViewState();
+      viewStatesChanged = true;
     }
 
     // Update view state if changed externally
@@ -272,12 +320,12 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
         this.state.viewStates[this.viewId]
       )
     ) {
-      this.setState((prevState) => ({
-        viewStates: {
-          ...prevState.viewStates,
-          [this.viewId]: toVivViewState(viewState, this.viewId, width, height),
-        },
-      }));
+      nextViewStates[this.viewId] = toVivViewState(viewState, this.viewId, width, height);
+      viewStatesChanged = true;
+    }
+
+    if (viewStatesChanged) {
+      this.setState({ viewStates: nextViewStates });
     }
   }
 
@@ -300,7 +348,7 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
     }));
 
     // Notify parent
-    if (onViewStateChange) {
+    if (viewId === this.viewId && onViewStateChange) {
       onViewStateChange(fromVivViewState(viewState));
     }
 
@@ -325,6 +373,7 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
 
     const vivLayers: Layer[] = [];
     let scaleBarAdded = false;
+    const scaleBarView = this.getScaleBarView();
 
     for (const imageLayerProps of vivLayerProps) {
       const layerProps: Record<string, unknown> = {
@@ -350,7 +399,6 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
       }
 
       const vivLayersResult = this.detailView.getLayers({
-        viewStates,
         props: layerProps,
       });
 
@@ -370,6 +418,15 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
       }
     }
 
+    if (!scaleBarAdded && scaleBarView) {
+      const scaleBarLayers = normalizeVivLayers(
+        scaleBarView.getLayers({
+          viewStates,
+        })
+      );
+      vivLayers.push(...scaleBarLayers);
+    }
+
     // Compose with extra layers - following MDV pattern exactly
     // MDV does: [otherLayers (images), ...deckProps.layers (shapes), scaleBar]
     return composeLayers(vivLayers, extraLayersWithVivId, deckPropsLayersWithVivId);
@@ -384,7 +441,10 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
     }
 
     const layers = this._renderLayers();
-    const deckGLView = this.detailView.getDeckGlView();
+    const scaleBarView = this.getScaleBarView();
+    const deckGLViews = scaleBarView
+      ? [this.detailView.getDeckGlView(), scaleBarView.getDeckGlView()]
+      : this.detailView.getDeckGlView();
 
     return (
       <DeckGL
@@ -394,7 +454,7 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
         layers={layers}
         //@ts-expect-error onViewStateChange
         onViewStateChange={this._onViewStateChange}
-        views={deckGLView}
+        views={deckGLViews}
         viewState={viewStates}
         useDevicePixels={deckProps?.useDevicePixels ?? true}
         getCursor={({ isDragging }) => (isDragging ? 'grabbing' : 'crosshair')}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,13 @@ settings:
 catalogs:
   default:
     '@deck.gl/core':
-      specifier: ~9.1.11
+      specifier: ~9.1.15
       version: 9.1.15
     '@hms-dbmi/viv':
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.20.1
+      version: 0.20.1
     '@luma.gl/core':
-      specifier: ~9.1.9
+      specifier: ~9.1.10
       version: 9.1.10
     '@math.gl/core':
       specifier: ^4.1.0
@@ -30,6 +30,9 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: ^6.0.1
       version: 6.0.1
+    '@vivjs/views':
+      specifier: 0.20.1
+      version: 0.20.1
     '@zarrita/storage':
       specifier: ^0.2.0
       version: 0.2.0
@@ -40,7 +43,7 @@ catalogs:
       specifier: ^17.0.0
       version: 17.0.0
     deck.gl:
-      specifier: ~9.1.11
+      specifier: ~9.1.15
       version: 9.1.15
     jsdom:
       specifier: ^27.4.0
@@ -152,7 +155,7 @@ importers:
     dependencies:
       '@hms-dbmi/viv':
         specifier: 'catalog:'
-        version: 0.19.0(fd776ac1e5acea3be9c5cb4e7aa1f916)
+        version: 0.20.1(fd776ac1e5acea3be9c5cb4e7aa1f916)
       '@math.gl/core':
         specifier: 'catalog:'
         version: 4.1.0
@@ -253,7 +256,7 @@ importers:
         version: 9.1.15
       '@hms-dbmi/viv':
         specifier: 'catalog:'
-        version: 0.19.0(fd776ac1e5acea3be9c5cb4e7aa1f916)
+        version: 0.20.1(fd776ac1e5acea3be9c5cb4e7aa1f916)
       '@math.gl/core':
         specifier: 'catalog:'
         version: 4.1.0
@@ -333,7 +336,7 @@ importers:
         version: 9.1.15
       '@hms-dbmi/viv':
         specifier: 'catalog:'
-        version: 0.19.0(9a614091add8d9561d5b393ea4eef7a1)
+        version: 0.20.1(9a614091add8d9561d5b393ea4eef7a1)
       '@luma.gl/core':
         specifier: 'catalog:'
         version: 9.1.10
@@ -358,6 +361,9 @@ importers:
       '@uiw/react-json-view':
         specifier: 2.0.0-alpha.39
         version: 2.0.0-alpha.39(@babel/runtime@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@vivjs/views':
+        specifier: 'catalog:'
+        version: 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
       anndata.js:
         specifier: 'catalog:'
         version: 0.0.2
@@ -1825,8 +1831,8 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
-  '@hms-dbmi/viv@0.19.0':
-    resolution: {integrity: sha512-wH/GBjti9686xwuGnZp9sMwwkE6pLGRaRW3Qc27S/3GRwq5j6C9Fd3du12F4InFfle47GV2nv0X9mWO+wiRwsQ==}
+  '@hms-dbmi/viv@0.20.1':
+    resolution: {integrity: sha512-Q7x6MeXrOQe9RwwqpxNe3Aw+CBRCC6fYNZ33I5m22N1F/soBB7fFi67YDlJmBIwXtA1i+ApPY5AWb34XgcuHPQ==}
 
   '@interactjs/types@1.10.27':
     resolution: {integrity: sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==}
@@ -3020,16 +3026,16 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
-  '@vivjs/constants@0.19.0':
-    resolution: {integrity: sha512-1X0cKfPGlFNscEgtXBhHsZu7BixMIq2cznZ1hNuvTnCtG7SDW9nsiAa3WrOMowDwYyzMFWkoaWmVcoJSdN0wkg==}
+  '@vivjs/constants@0.20.1':
+    resolution: {integrity: sha512-VYtQnT/3bO/kVx2RTspTCzX7lrTyeYMojDBzVy1zgJ/4co8iBan3Xtnbz7HlhvFFGBe3AssFTjNwwb6XdA8Cbw==}
 
-  '@vivjs/extensions@0.19.0':
-    resolution: {integrity: sha512-EHg7Y83+uv720micAaRjBh/Edw9lOq/uAfSQCbK0H4HBv7xUGzeXbCLmN/9ye8UgHWZd1cO6xvGDwBTQ7hp3gg==}
+  '@vivjs/extensions@0.20.1':
+    resolution: {integrity: sha512-ZWTqVHosSc0NIrteAL0yjQj1CWqpOtsm2K3SK/w3L6nLA/HMCIfbBcgRfkYerLFcUb8hRD86BNkGgV9kN2Iejg==}
     peerDependencies:
       '@deck.gl/core': ~9.1.11
 
-  '@vivjs/layers@0.19.0':
-    resolution: {integrity: sha512-M8zdlPsO8zEpESDevBiAnuEg9kv+H25B38XLfpPzTZS78hA6VD4PRw08xh5GjRHlaCV6CVnnKYAQDrvYNufDkg==}
+  '@vivjs/layers@0.20.1':
+    resolution: {integrity: sha512-DrB68BgLCTymmX/3sKd0h11K/ubA4x3Vy6TRUUOK3sX83j3a+SAsx0RHr2g/b7ethc0C/ZnQFBFJX6hTXHYzsA==}
     peerDependencies:
       '@deck.gl/core': ~9.1.11
       '@deck.gl/geo-layers': ~9.1.11
@@ -3040,20 +3046,20 @@ packages:
       '@luma.gl/shadertools': ~9.1.9
       '@luma.gl/webgl': ~9.1.9
 
-  '@vivjs/loaders@0.19.0':
-    resolution: {integrity: sha512-mCE2F8dih42hmIj96qYCPfvUqyNtuYlDKJa/i0LfT3Hrb5SclqgOpUrp4KW+C5Wy68O0P9c0ZIlmvWX0sMGJ8Q==}
+  '@vivjs/loaders@0.20.1':
+    resolution: {integrity: sha512-7F9uYXkoFPH945o+A+YO/2DIv2WO0LJYGFHiz0ZhO0THl1mBw8NaHO1YodwzM/sqoT4X+5oGCh+5E91YX87t7g==}
 
-  '@vivjs/types@0.19.0':
-    resolution: {integrity: sha512-936eBNXNmgSJUsfQ+iJcrC4oTVJS9vCb6J6I+TiSn7bymO0uKia+3yvLFN6cWGrjQiWo5hSTSh6ZV+ydiE4i5g==}
+  '@vivjs/types@0.20.1':
+    resolution: {integrity: sha512-VfWhqv893UDHii3Lr4UbWiSafDtqjXp2zsojYDAiabnLA7n4Q7bSk/BCoTt6CaehwwI7t8o3J6m9Axb2cLH4nQ==}
 
-  '@vivjs/viewers@0.19.0':
-    resolution: {integrity: sha512-Y58b/4F9J3RjZjPG80GciikiWZHFyIncRHFsmVqpIdE/7ubTUJTvzI0ZdrT5Y6NoP7dxjevIrhfSWQGbmjgZJQ==}
+  '@vivjs/viewers@0.20.1':
+    resolution: {integrity: sha512-4x9arLqI6beI6vp1hoSJ8JViG/k1WW0paC1sK92zKD/Ed0tfTZyAH69RwZf9I7TU/o+yGjNlMm3rH8HgowCHBQ==}
     peerDependencies:
       '@deck.gl/react': ~9.1.11
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@vivjs/views@0.19.0':
-    resolution: {integrity: sha512-2jSH6mfHaFk1ovE5oFvS3fAdUaVqZGr14gY+HlEF7V4lASgALcJoVvA8oVJflHvUZIn8jiwOqfIcoF9t7/m5eg==}
+  '@vivjs/views@0.20.1':
+    resolution: {integrity: sha512-cVtI4ILdfQ+vw/7VtHw5NPcrwz/sXlI5l3kU9pKjJ6Wp248OuJGvcOE8lAKdmb8nWSDbq1i0un+mQET1IVRERQ==}
     peerDependencies:
       '@deck.gl/core': ~9.1.11
       '@deck.gl/layers': ~9.1.11
@@ -5292,6 +5298,9 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@3.2.0:
     resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
@@ -10004,15 +10013,15 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hms-dbmi/viv@0.19.0(9a614091add8d9561d5b393ea4eef7a1)':
+  '@hms-dbmi/viv@0.20.1(9a614091add8d9561d5b393ea4eef7a1)':
     dependencies:
-      '@vivjs/constants': 0.19.0
-      '@vivjs/extensions': 0.19.0(@deck.gl/core@9.1.15)
-      '@vivjs/layers': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
-      '@vivjs/loaders': 0.19.0
-      '@vivjs/types': 0.19.0
-      '@vivjs/viewers': 0.19.0(9a614091add8d9561d5b393ea4eef7a1)
-      '@vivjs/views': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/constants': 0.20.1
+      '@vivjs/extensions': 0.20.1(@deck.gl/core@9.1.15)
+      '@vivjs/layers': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/loaders': 0.20.1
+      '@vivjs/types': 0.20.1
+      '@vivjs/viewers': 0.20.1(9a614091add8d9561d5b393ea4eef7a1)
+      '@vivjs/views': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
     transitivePeerDependencies:
       - '@deck.gl/core'
       - '@deck.gl/geo-layers'
@@ -10025,15 +10034,15 @@ snapshots:
       - '@luma.gl/webgl'
       - react
 
-  '@hms-dbmi/viv@0.19.0(fd776ac1e5acea3be9c5cb4e7aa1f916)':
+  '@hms-dbmi/viv@0.20.1(fd776ac1e5acea3be9c5cb4e7aa1f916)':
     dependencies:
-      '@vivjs/constants': 0.19.0
-      '@vivjs/extensions': 0.19.0(@deck.gl/core@9.1.15)
-      '@vivjs/layers': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
-      '@vivjs/loaders': 0.19.0
-      '@vivjs/types': 0.19.0
-      '@vivjs/viewers': 0.19.0(fd776ac1e5acea3be9c5cb4e7aa1f916)
-      '@vivjs/views': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/constants': 0.20.1
+      '@vivjs/extensions': 0.20.1(@deck.gl/core@9.1.15)
+      '@vivjs/layers': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/loaders': 0.20.1
+      '@vivjs/types': 0.20.1
+      '@vivjs/viewers': 0.20.1(fd776ac1e5acea3be9c5cb4e7aa1f916)
+      '@vivjs/views': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
     transitivePeerDependencies:
       - '@deck.gl/core'
       - '@deck.gl/geo-layers'
@@ -11488,16 +11497,16 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vivjs/constants@0.19.0':
+  '@vivjs/constants@0.20.1':
     dependencies:
       '@luma.gl/constants': 9.1.10
 
-  '@vivjs/extensions@0.19.0(@deck.gl/core@9.1.15)':
+  '@vivjs/extensions@0.20.1(@deck.gl/core@9.1.15)':
     dependencies:
       '@deck.gl/core': 9.1.15
-      '@vivjs/constants': 0.19.0
+      '@vivjs/constants': 0.20.1
 
-  '@vivjs/layers@0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)':
+  '@vivjs/layers@0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)':
     dependencies:
       '@deck.gl/core': 9.1.15
       '@deck.gl/geo-layers': 9.1.15(@deck.gl/core@9.1.15)(@deck.gl/extensions@9.1.15(@deck.gl/core@9.1.15)(@luma.gl/core@9.1.10)(@luma.gl/engine@9.1.10(@luma.gl/core@9.1.10)(@luma.gl/shadertools@9.1.10(@luma.gl/core@9.1.10))))(@deck.gl/layers@9.1.15(@deck.gl/core@9.1.15)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.1.10)(@luma.gl/engine@9.1.10(@luma.gl/core@9.1.10)(@luma.gl/shadertools@9.1.10(@luma.gl/core@9.1.10))))(@deck.gl/mesh-layers@9.1.15(@deck.gl/core@9.1.15)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.1.10)(@luma.gl/engine@9.1.10(@luma.gl/core@9.1.10)(@luma.gl/shadertools@9.1.10(@luma.gl/core@9.1.10))))(@loaders.gl/core@4.3.4)(@luma.gl/core@9.1.10)(@luma.gl/engine@9.1.10(@luma.gl/core@9.1.10)(@luma.gl/shadertools@9.1.10(@luma.gl/core@9.1.10)))
@@ -11509,32 +11518,33 @@ snapshots:
       '@luma.gl/webgl': 9.1.10(@luma.gl/core@9.1.10)
       '@math.gl/core': 4.1.0
       '@math.gl/culling': 4.1.0
-      '@vivjs/constants': 0.19.0
-      '@vivjs/extensions': 0.19.0(@deck.gl/core@9.1.15)
-      '@vivjs/loaders': 0.19.0
-      '@vivjs/types': 0.19.0
+      '@vivjs/constants': 0.20.1
+      '@vivjs/extensions': 0.20.1(@deck.gl/core@9.1.15)
+      '@vivjs/loaders': 0.20.1
+      '@vivjs/types': 0.20.1
 
-  '@vivjs/loaders@0.19.0':
+  '@vivjs/loaders@0.20.1':
     dependencies:
-      '@vivjs/types': 0.19.0
+      '@vivjs/types': 0.20.1
       geotiff: 2.1.3
       lzw-tiff-decoder: 0.1.1
       quickselect: 2.0.0
       zarrita: 0.5.4
       zod: 3.25.76
 
-  '@vivjs/types@0.19.0':
+  '@vivjs/types@0.20.1':
     dependencies:
-      '@vivjs/constants': 0.19.0
+      '@vivjs/constants': 0.20.1
       math.gl: 4.1.0
 
-  '@vivjs/viewers@0.19.0(9a614091add8d9561d5b393ea4eef7a1)':
+  '@vivjs/viewers@0.20.1(9a614091add8d9561d5b393ea4eef7a1)':
     dependencies:
       '@deck.gl/react': 9.1.15(@deck.gl/core@9.1.15)(@deck.gl/widgets@9.1.15(@deck.gl/core@9.1.15))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@vivjs/constants': 0.19.0
-      '@vivjs/extensions': 0.19.0(@deck.gl/core@9.1.15)
-      '@vivjs/views': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/constants': 0.20.1
+      '@vivjs/extensions': 0.20.1(@deck.gl/core@9.1.15)
+      '@vivjs/views': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
       fast-deep-equal: 3.1.3
+      lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
       - '@deck.gl/core'
@@ -11546,13 +11556,14 @@ snapshots:
       - '@luma.gl/shadertools'
       - '@luma.gl/webgl'
 
-  '@vivjs/viewers@0.19.0(fd776ac1e5acea3be9c5cb4e7aa1f916)':
+  '@vivjs/viewers@0.20.1(fd776ac1e5acea3be9c5cb4e7aa1f916)':
     dependencies:
       '@deck.gl/react': 9.1.15(@deck.gl/core@9.1.15)(@deck.gl/widgets@9.1.15(@deck.gl/core@9.1.15))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@vivjs/constants': 0.19.0
-      '@vivjs/extensions': 0.19.0(@deck.gl/core@9.1.15)
-      '@vivjs/views': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/constants': 0.20.1
+      '@vivjs/extensions': 0.20.1(@deck.gl/core@9.1.15)
+      '@vivjs/views': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
       fast-deep-equal: 3.1.3
+      lodash: 4.18.1
       react: 19.2.1
     transitivePeerDependencies:
       - '@deck.gl/core'
@@ -11564,13 +11575,13 @@ snapshots:
       - '@luma.gl/shadertools'
       - '@luma.gl/webgl'
 
-  '@vivjs/views@0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)':
+  '@vivjs/views@0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)':
     dependencies:
       '@deck.gl/core': 9.1.15
       '@deck.gl/layers': 9.1.15(@deck.gl/core@9.1.15)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.1.10)(@luma.gl/engine@9.1.10(@luma.gl/core@9.1.10)(@luma.gl/shadertools@9.1.10(@luma.gl/core@9.1.10)))
       '@math.gl/core': 4.1.0
-      '@vivjs/layers': 0.19.0(95853861a3a9bfb6cf4e0bb4f1c1545a)
-      '@vivjs/loaders': 0.19.0
+      '@vivjs/layers': 0.20.1(95853861a3a9bfb6cf4e0bb4f1c1545a)
+      '@vivjs/loaders': 0.20.1
       math.gl: 4.1.0
     transitivePeerDependencies:
       - '@deck.gl/geo-layers'
@@ -14015,6 +14026,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.18.1: {}
 
   long@3.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,17 +4,18 @@ packages:
 
 catalog:
   '@zarrita/storage': ^0.2.0
-  '@deck.gl/core': ~9.1.11
-  '@luma.gl/core': ~9.1.9
+  '@deck.gl/core': ~9.1.15
+  '@luma.gl/core': ~9.1.10
   '@math.gl/core': ^4.1.0
   '@types/node': ^22.10.5
   '@types/react': ^19.2.0
   '@types/react-dom': ^19.2.0
   '@vitejs/plugin-react': ^6.0.1
-  '@hms-dbmi/viv': ^0.19.0
+  '@hms-dbmi/viv': ^0.20.1
+  '@vivjs/views': 0.20.1
   anndata.js: ^0.0.2
   apache-arrow: ^17.0.0
-  deck.gl: ~9.1.11
+  deck.gl: ~9.1.15
   parquet-wasm: ^0.6.1
   react: ^19.2.1
   react-dom: ^19.2.1


### PR DESCRIPTION
## Summary
- Bump `@hms-dbmi/viv`, `deck.gl`, and `@deck.gl/core` to the newer catalog versions
- Add `@vivjs/views` and switch image and spatial viewers to the dedicated `ScaleBarView`
- Keep scale bar state separate from the main detail view and only forward view-state changes from the detail view

## Testing
- Not run (not requested)