### PR TITLE
Fix docs labels shader assembly and fullscreen refit

### DIFF
--- a/docs/docs/demo.mdx
+++ b/docs/docs/demo.mdx
@@ -2,9 +2,21 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import Sketch from '@site/src/components/Sketch/';
 
 export default function Page() {
+  const demoFrameStyle = {
+    height: 'calc(100vh - 9rem)',
+    minHeight: 640,
+    maxHeight: 900,
+    overflow: 'hidden',
+    width: '100%',
+  };
+
   return (
     <BrowserOnly>
-      {() => <Sketch />}
+      {() => (
+        <div style={demoFrameStyle}>
+          <Sketch />
+        </div>
+      )}
     </BrowserOnly>
   );
 }

--- a/packages/layers/src/LabelsBitmaskTileLayer.ts
+++ b/packages/layers/src/LabelsBitmaskTileLayer.ts
@@ -262,6 +262,7 @@ export class LabelsBitmaskTileLayer extends UntypedXRLayer {
     const { model, textures } = this.state as {
       model?: {
         shaderInputs?: { setProps: (props: Record<string, unknown>) => void };
+        setUniforms?: (uniforms: Record<string, unknown>, opts?: Record<string, unknown>) => void;
         setBindings: (bindings: Record<string, unknown>) => void;
         draw: (renderPass?: unknown) => void;
       };
@@ -338,6 +339,7 @@ export class LabelsBitmaskTileLayer extends UntypedXRLayer {
     ]);
 
     model.shaderInputs?.setProps({ labelsBitmask });
+    model.setUniforms?.(_opts.uniforms ?? {}, { disableWarnings: false });
     model.setBindings(textures);
     model.draw((this.context as { renderPass?: unknown }).renderPass);
   }

--- a/packages/layers/src/LabelsLayer.ts
+++ b/packages/layers/src/LabelsLayer.ts
@@ -4,6 +4,7 @@ import { CompositeLayer, TileLayer, type Layer, type LayersList } from 'deck.gl'
 import { LabelsBitmaskTileLayer } from './LabelsBitmaskTileLayer';
 
 export const MAX_LABEL_CHANNELS = 7 as const;
+const MIN_LABELS_DISPLAY_ZOOM = -20;
 
 export type LabelsSelection = Partial<{ z: number; c: number; t: number }>;
 
@@ -127,7 +128,7 @@ class SingleScaleLabelsLayer extends CompositeLayer<any> {
         id: `image-sub-layer-${bounds}-${id}`,
         interpolation: 'nearest',
         maxZoom: 0,
-        minZoom: 0,
+        minZoom: MIN_LABELS_DISPLAY_ZOOM,
         zoom: 0,
       }
     ) as unknown as Layer;
@@ -297,7 +298,7 @@ export class LabelsLayer extends CompositeLayer<LabelsLayerProps> {
           tileSize,
           extent: [0, 0, width, height],
           zoomOffset,
-          minZoom: Math.round(-(loader.length - 1)),
+          minZoom: MIN_LABELS_DISPLAY_ZOOM,
           maxZoom: 0,
           refinementStrategy: opacity === 1 ? 'best-available' : 'no-overlap',
           onTileError: baseLoader.onTileError,

--- a/packages/layers/src/labelsBitmaskLayerShaders.ts
+++ b/packages/layers/src/labelsBitmaskLayerShaders.ts
@@ -33,6 +33,7 @@ export const vs = `#version 300 es
 
 in vec2 texCoords;
 in vec3 positions;
+in vec3 positions64Low;
 in vec3 instancePickingColors;
 
 out vec2 vTexCoord;
@@ -41,11 +42,10 @@ void main(void) {
   geometry.worldPosition = positions;
   geometry.uv = texCoords;
   geometry.pickingColor = instancePickingColors;
-  gl_Position = project_position_to_clipspace(positions, vec3(0.0), vec3(0.0), geometry.position);
-  DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
+  gl_Position = project_position_to_clipspace(positions, positions64Low, vec3(0.0), geometry.position);
+  picking_setPickingAttribute(gl_Position.z / gl_Position.w);
   vTexCoord = texCoords;
-  vec4 color = vec4(0.0);
-  DECKGL_FILTER_COLOR(color, geometry);
+  picking_setPickingColor(geometry.pickingColor);
 }
 `;
 
@@ -152,6 +152,16 @@ vec4 dataToColor(
   return vec4(outRgb, outAlpha);
 }
 
+vec4 blendOver(vec4 baseColor, vec4 overlayColor) {
+  if (overlayColor.a <= 0.0) {
+    return baseColor;
+  }
+  return vec4(
+    mix(baseColor.rgb, overlayColor.rgb, overlayColor.a),
+    max(baseColor.a, overlayColor.a)
+  );
+}
+
 void main() {
   vec4 dat0 = sampleAndGetData(channel0, vTexCoord, labelsBitmask.channelFilled0, labelsBitmask.channelStrokeWidth0, labelsBitmask.channelVisible0);
   vec4 dat1 = sampleAndGetData(channel1, vTexCoord, labelsBitmask.channelFilled1, labelsBitmask.channelStrokeWidth1, labelsBitmask.channelVisible1);
@@ -177,15 +187,15 @@ void main() {
   vec4 val6 = dataToColor(dat6, labelsBitmask.color6, labelsBitmask.channelOpacity6, labelsBitmask.channelOutlineOpacity6, labelsBitmask.channelFilled6);
 
   fragColor = val0;
-  fragColor = (val1 == fragColor || val1 == vec4(0.0)) ? fragColor : vec4(mix(fragColor, val1, val1.a).rgb, max(fragColor.a, val1.a));
-  fragColor = (val2 == fragColor || val2 == vec4(0.0)) ? fragColor : vec4(mix(fragColor, val2, val2.a).rgb, max(fragColor.a, val2.a));
-  fragColor = (val3 == fragColor || val3 == vec4(0.0)) ? fragColor : vec4(mix(fragColor, val3, val3.a).rgb, max(fragColor.a, val3.a));
-  fragColor = (val4 == fragColor || val4 == vec4(0.0)) ? fragColor : vec4(mix(fragColor, val4, val4.a).rgb, max(fragColor.a, val4.a));
-  fragColor = (val5 == fragColor || val5 == vec4(0.0)) ? fragColor : vec4(mix(fragColor, val5, val5.a).rgb, max(fragColor.a, val5.a));
-  fragColor = (val6 == fragColor || val6 == vec4(0.0)) ? fragColor : vec4(mix(fragColor, val6, val6.a).rgb, max(fragColor.a, val6.a));
+  fragColor = blendOver(fragColor, val1);
+  fragColor = blendOver(fragColor, val2);
+  fragColor = blendOver(fragColor, val3);
+  fragColor = blendOver(fragColor, val4);
+  fragColor = blendOver(fragColor, val5);
+  fragColor = blendOver(fragColor, val6);
   fragColor.a = fragColor.a * labelsBitmask.labelOpacity;
 
-  geometry.uv = vTexCoord;
-  DECKGL_FILTER_COLOR(fragColor, geometry);
+  fragColor = picking_filterHighlightColor(fragColor);
+  fragColor = picking_filterPickingColor(fragColor);
 }
 `;

--- a/packages/vis/src/SpatialCanvas/SpatialViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/SpatialViewer.tsx
@@ -99,30 +99,48 @@ function SpatialViewerSimple({
   onClick,
 }: Omit<SpatialViewerProps, 'vivLayerProps'>) {
   const viewId = useId();
+  const detailViewId = useMemo(() => `spatial-${viewId}`, [viewId]);
+  type DeckDetailViewState = {
+    id: string;
+    target: [number, number, number];
+    zoom: number;
+    width: number;
+    height: number;
+  };
 
   // Use DetailView for consistency with Viv pattern
   const detailView = useMemo(() => {
     return new DetailView({
-      id: `spatial-${viewId}`,
+      id: detailViewId,
       width,
       height,
     });
-  }, [viewId, width, height]);
+  }, [detailViewId, width, height]);
 
   // Convert our ViewState to deck.gl's expected format
-  const deckViewState = useMemo((): { target: [number, number, number]; zoom: number } => {
+  const deckViewState = useMemo((): Record<string, DeckDetailViewState> => {
     if (!viewState) {
       return {
-        target: [0, 0, 0],
-        zoom: 0,
+        [detailViewId]: {
+          id: detailViewId,
+          target: [0, 0, 0],
+          zoom: 0,
+          width,
+          height,
+        },
       };
     }
     const [x, y, z = 0] = viewState.target;
     return {
-      target: [x, y, z],
-      zoom: viewState.zoom,
+      [detailViewId]: {
+        id: detailViewId,
+        target: [x, y, z],
+        zoom: viewState.zoom,
+        width,
+        height,
+      },
     };
-  }, [viewState]);
+  }, [detailViewId, height, viewState, width]);
 
   // Handle view state changes from deck.gl
   const handleViewStateChange = useCallback(

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -228,6 +228,10 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
   const shellRef = useRef<HTMLDivElement | null>(null);
   const viewerContainerRef = useRef<HTMLDivElement | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
+  const [pendingFullscreenRefitSize, setPendingFullscreenRefitSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
   const [hoverTooltip, setHoverTooltip] = useState<{
     x: number;
     y: number;
@@ -302,6 +306,34 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
       : { target: [0, 0] as [number, number], zoom: 0 };
     actions.setViewState(next);
   }, [hasEnabledLayers, vw, vh, isBlocking, viewState, getWorldBoundsForVisibleLayers, actions]);
+
+  useEffect(() => {
+    if (
+      !pendingFullscreenRefitSize ||
+      !hasEnabledLayers ||
+      vw <= 0 ||
+      vh <= 0 ||
+      isBlocking ||
+      (vw === pendingFullscreenRefitSize.width && vh === pendingFullscreenRefitSize.height)
+    ) {
+      return;
+    }
+
+    const bounds = getWorldBoundsForVisibleLayers();
+    const next = bounds
+      ? viewStateFromBounds(bounds, vw, vh)
+      : { target: [0, 0] as [number, number], zoom: 0 };
+    actions.setViewState(next);
+    setPendingFullscreenRefitSize(null);
+  }, [
+    actions,
+    getWorldBoundsForVisibleLayers,
+    hasEnabledLayers,
+    isBlocking,
+    pendingFullscreenRefitSize,
+    vh,
+    vw,
+  ]);
 
   useEffect(() => {
     if (coordinateSystems.length > 0 && !coordinateSystem) {
@@ -507,7 +539,10 @@ function SpatialCanvasInner({ tooltipContainer, renderTooltip }: SpatialCanvasIn
             <button
               type="button"
               style={{ ...selectStyle, marginLeft: 'auto', cursor: 'pointer' }}
-              onClick={() => setFullscreen((f) => !f)}
+              onClick={() => {
+                setPendingFullscreenRefitSize({ width: vw, height: vh });
+                setFullscreen((f) => !f);
+              }}
             >
               {fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
             </button>

--- a/packages/vis/vite.config.ts
+++ b/packages/vis/vite.config.ts
@@ -9,7 +9,19 @@ const workspaceRoot = path.resolve(pkgRoot, '../..');
 const baseConfig = defineViteConfig({
   pkgRoot,
   libName: 'SpatialDataVis',
-  external: [/^@spatialdata\/[^/]+$/, /^zustand(?:\/.*)?$/],
+  external: [
+    /^@spatialdata\/[^/]+$/,
+    /^zustand(?:\/.*)?$/,
+    /^@deck\.gl\/.+$/,
+    /^@luma\.gl\/.+$/,
+    /^@vivjs\/.+$/,
+    '@hms-dbmi/viv',
+    '@math.gl/core',
+    'deck.gl',
+    'geotiff',
+    'anndata.js',
+    'zarrita',
+  ],
 });
 
 export default mergeConfig(baseConfig, {


### PR DESCRIPTION
## Summary
- Externalize the rendering/runtime stack from `@spatialdata/vis` so docs and the Vite demo share the same deck/luma/viv shader assembly path.
- Restore the labels shader plumbing that was dropping fp64 inputs and deck uniforms, and keep label tiles visible at low zooms.
- Refit the SpatialCanvas view when toggling fullscreen so the docs demo does not keep a stale narrow-canvas zoom.
- Keep the docs demo frame bounded so the embedded example lays out consistently.

## Testing
- `pnpm --filter @spatialdata/layers test`
- `pnpm --filter @spatialdata/layers build`
- `pnpm --filter @spatialdata/vis build`
- `pnpm --filter docs build`
- Verified in Playwright that labels render in the docs demo after refitting fullscreen, with nonzero framebuffer pixels.