### PR TITLE
Audit labels prop flow and simplify labels UI to one plane

### DIFF
--- a/packages/layers/src/LabelsLayer.ts
+++ b/packages/layers/src/LabelsLayer.ts
@@ -1,6 +1,12 @@
-import type { Matrix4 } from '@math.gl/core';
 import { getImageSize } from '@hms-dbmi/viv';
-import { CompositeLayer, TileLayer, type Layer, type LayersList } from 'deck.gl';
+import type { Matrix4 } from '@math.gl/core';
+import {
+  CompositeLayer,
+  type CompositeLayerProps,
+  type Layer,
+  type LayersList,
+  TileLayer,
+} from 'deck.gl';
 import { LabelsBitmaskTileLayer } from './LabelsBitmaskTileLayer';
 
 /** One instance-ID raster per labels element (see `LabelsBitmaskTileLayer`). */
@@ -11,6 +17,14 @@ export type LabelsSelection = Partial<{ z: number; c: number; t: number }>;
 
 function firstSelection(selections: LabelsSelection[] | undefined): LabelsSelection {
   return selections?.[0] ?? {};
+}
+
+function selectionKey(selection: LabelsSelection): string {
+  return `z:${selection.z ?? ''}|c:${selection.c ?? ''}|t:${selection.t ?? ''}`;
+}
+
+function labelsSelectionKey(selections: LabelsSelection[] | undefined): string {
+  return selectionKey(firstSelection(selections));
 }
 
 function stylePlane<T>(arr: T[] | undefined, fallback: T): [T] {
@@ -33,6 +47,7 @@ export interface LabelsLayerProps {
   channelStrokeWidths?: number[];
   onClick?: (info: unknown) => void;
   onHover?: (info: unknown) => void;
+  _subLayerProps?: CompositeLayerProps['_subLayerProps'];
 }
 
 const VIV_SIGNAL_ABORTED = '__vivSignalAborted';
@@ -56,7 +71,7 @@ class SingleScaleLabelsLayer extends CompositeLayer<any> {
 
   updateState({ props, oldProps }: { props: any; oldProps: any }): void {
     const loaderChanged = props.loader !== oldProps.loader;
-    const selectionsChanged = props.selections !== oldProps.selections;
+    const selectionsChanged = props.labelsSelectionKey !== oldProps.labelsSelectionKey;
 
     if (!loaderChanged && !selectionsChanged) {
       return;
@@ -158,8 +173,49 @@ class SingleScaleLabelsLayer extends CompositeLayer<any> {
 class MultiscaleLabelsTileLayer extends UntypedTileLayer {
   static layerName = 'MultiscaleLabelsTileLayer';
 
+  // biome-ignore lint/complexity/noUselessConstructor: TileLayer's public types reject the Viv-style constructor overload used here.
   constructor(...args: any[]) {
     super(...args);
+  }
+
+  async getTileData({
+    index: { x, y, z },
+    signal,
+  }: {
+    index: { x: number; y: number; z: number };
+    signal: AbortSignal;
+  }) {
+    const loader = this.props.loader;
+    const loaders = Array.isArray(loader) ? loader : [loader];
+    const resolution = Math.max(0, Math.min(loaders.length - 1, Math.round(-z)));
+    const selection = firstSelection(this.props.selections);
+    const tileLoader = loaders[resolution] as any;
+    const getTile = tileLoader?.getTile?.bind(tileLoader);
+
+    if (!getTile) {
+      return null;
+    }
+
+    try {
+      const tile = await getTile({ x, y, selection, signal });
+      if (!tile) {
+        return null;
+      }
+      return {
+        data: [tile.data],
+        width: tile.width,
+        height: tile.height,
+      };
+    } catch (error) {
+      if (
+        error === VIV_SIGNAL_ABORTED ||
+        signal.aborted ||
+        (error as { name?: string } | null)?.name === 'AbortError'
+      ) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   _updateTileset(): void {
@@ -246,10 +302,12 @@ export class LabelsLayer extends CompositeLayer<LabelsLayerProps> {
     }
 
     const selections = [firstSelection(selectionsProp)];
+    const structuralSelectionKey = labelsSelectionKey(selections);
     const nextLoader = Array.isArray(loader) && loader.length === 1 ? loader[0] : loader;
     const commonProps = {
       loader: nextLoader,
       selections,
+      labelsSelectionKey: structuralSelectionKey,
       modelMatrix,
       opacity,
       channelsVisible: stylePlane(channelsVisible, true),
@@ -269,55 +327,25 @@ export class LabelsLayer extends CompositeLayer<LabelsLayerProps> {
       const { height, width } = getImageSize(baseLoader);
       const tileSize = baseLoader.tileSize;
       const zoomOffset = Math.round(Math.log2(modelMatrix ? modelMatrix.getScale()[0] : 1));
-      const getTileData = async ({
-        index: { x, y, z },
-        signal,
-      }: {
-        index: { x: number; y: number; z: number };
-        signal: AbortSignal;
-      }) => {
-        const resolution = Math.max(0, Math.min(loader.length - 1, Math.round(-z)));
-        const selection = firstSelection(selections);
-        const getTile = (loader[resolution] as any).getTile.bind(loader[resolution]);
-
-        try {
-          const tile = await getTile({ x, y, selection, signal });
-          if (!tile) {
-            return null;
-          }
-          return {
-            data: [tile.data],
-            width: tile.width,
-            height: tile.height,
-          };
-        } catch (error) {
-          if (
-            error === VIV_SIGNAL_ABORTED ||
-            signal.aborted ||
-            (error as { name?: string } | null)?.name === 'AbortError'
-          ) {
-            return null;
-          }
-          throw error;
-        }
-      };
 
       return new MultiscaleLabelsTileLayer(
         this.getSubLayerProps({
           id: 'labels',
           pickable: true,
           visible,
+          updateTriggers: {
+            getTileData: [nextLoader, structuralSelectionKey],
+          },
         }),
         {
           ...commonProps,
           ...interactionProps,
-          getTileData,
           tileSize,
           extent: [0, 0, width, height],
           zoomOffset,
           minZoom: MIN_LABELS_DISPLAY_ZOOM,
           maxZoom: 0,
-          refinementStrategy: opacity === 1 ? 'best-available' : 'no-overlap',
+          refinementStrategy: 'best-available',
           onTileError: baseLoader.onTileError,
           renderSubLayers: renderSubBitmaskLayers,
         } as any

--- a/packages/layers/tests/labelsLayer.spec.ts
+++ b/packages/layers/tests/labelsLayer.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LabelsLayer } from '../src/LabelsLayer';
+import type { LabelsLayerProps } from '../src/LabelsLayer';
+
+type TileLayerLike = {
+  props: {
+    updateTriggers?: { getTileData?: unknown[] };
+    refinementStrategy?: string;
+    renderSubLayers: (props: Record<string, unknown>) => unknown;
+    [key: string]: unknown;
+  };
+  getTileData: (props: {
+    index: { x: number; y: number; z: number };
+    signal: AbortSignal;
+  }) => Promise<unknown>;
+};
+
+function getTileTrigger(layer: TileLayerLike): unknown[] {
+  return layer.props.updateTriggers?.getTileData ?? [];
+}
+
+function triggerChanged(a: TileLayerLike, b: TileLayerLike): boolean {
+  const left = getTileTrigger(a);
+  const right = getTileTrigger(b);
+  return (
+    left.length !== right.length || left.some((value, index) => !Object.is(value, right[index]))
+  );
+}
+
+function makeLabelsLoader() {
+  const onGetTile = vi.fn();
+  const makeScale = (resolution: number) => ({
+    shape: [512, 512],
+    tileSize: 256,
+    getTile: vi.fn(
+      async ({
+        x,
+        y,
+        selection,
+      }: {
+        x: number;
+        y: number;
+        selection: unknown;
+      }) => {
+        onGetTile({ resolution, x, y, selection });
+        return {
+          data: new Float32Array([0, 1, 2, 0]),
+          width: 2,
+          height: 2,
+        };
+      }
+    ),
+  });
+  return {
+    loader: [makeScale(0), makeScale(1)],
+    onGetTile,
+  };
+}
+
+function renderLabelsLayer(props: Record<string, unknown>): TileLayerLike {
+  const layer = new LabelsLayer({
+    id: 'labels-layer',
+    visible: true,
+    opacity: 1,
+    selections: [{ z: 0, c: 0, t: 0 }],
+    ...props,
+  } as LabelsLayerProps);
+  const rendered = layer.renderLayers();
+  expect(rendered).toBeTruthy();
+  return rendered as unknown as TileLayerLike;
+}
+
+async function loadOneTile(layer: TileLayerLike) {
+  return layer.getTileData({
+    index: { x: 0, y: 0, z: 0 },
+    signal: new AbortController().signal,
+  });
+}
+
+describe('LabelsLayer prop flow', () => {
+  it('keeps cosmetic props out of the tile-data trigger', async () => {
+    const { loader, onGetTile } = makeLabelsLoader();
+    const initial = renderLabelsLayer({
+      loader,
+      opacity: 1,
+      channelColors: [[255, 255, 255]],
+      channelOpacities: [0.18],
+      channelsFilled: [true],
+      channelStrokeWidths: [1.5],
+    });
+
+    await loadOneTile(initial);
+    expect(onGetTile).toHaveBeenCalledTimes(1);
+
+    const cosmetic = renderLabelsLayer({
+      loader,
+      opacity: 0.35,
+      channelColors: [[255, 0, 0]],
+      channelOpacities: [0.5],
+      channelsFilled: [false],
+      channelStrokeWidths: [3],
+    });
+
+    if (triggerChanged(initial, cosmetic)) {
+      await loadOneTile(cosmetic);
+    }
+
+    expect(getTileTrigger(cosmetic)).toEqual(getTileTrigger(initial));
+    expect(cosmetic.props.refinementStrategy).toBe(initial.props.refinementStrategy);
+    expect(onGetTile).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats label selection changes as structural tile-data changes', async () => {
+    const { loader, onGetTile } = makeLabelsLoader();
+    const initial = renderLabelsLayer({
+      loader,
+      selections: [{ z: 0, c: 0, t: 0 }],
+    });
+
+    await loadOneTile(initial);
+    expect(onGetTile).toHaveBeenCalledTimes(1);
+
+    const structural = renderLabelsLayer({
+      loader,
+      selections: [{ z: 1, c: 0, t: 0 }],
+    });
+
+    if (triggerChanged(initial, structural)) {
+      await loadOneTile(structural);
+    }
+
+    expect(getTileTrigger(structural)).not.toEqual(getTileTrigger(initial));
+    expect(onGetTile).toHaveBeenCalledTimes(2);
+    expect(onGetTile).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selection: { z: 1, c: 0, t: 0 },
+      })
+    );
+  });
+
+  it('passes extension sublayer props through to labels bitmask tiles', () => {
+    const { loader } = makeLabelsLoader();
+    const tileLayer = renderLabelsLayer({
+      loader,
+      _subLayerProps: {
+        labels: {
+          customExtensionProp: 'forwarded',
+        },
+      },
+    });
+
+    const bitmaskLayer = tileLayer.props.renderSubLayers({
+      ...tileLayer.props,
+      id: 'tile-0-0-0',
+      data: {
+        data: [new Float32Array([0, 1, 2, 0])],
+        width: 2,
+        height: 2,
+      },
+      tile: {
+        bbox: { left: 0, top: 0, right: 2, bottom: 2 },
+        index: { x: 0, y: 0, z: 0 },
+        zoom: 0,
+      },
+    }) as { props: Record<string, unknown> };
+
+    expect(tileLayer.props.customExtensionProp).toBe('forwarded');
+    expect(bitmaskLayer.props.customExtensionProp).toBe('forwarded');
+  });
+});

--- a/packages/vis/src/SpatialCanvas/LabelsChannelPanel.tsx
+++ b/packages/vis/src/SpatialCanvas/LabelsChannelPanel.tsx
@@ -1,9 +1,9 @@
-import type { CSSProperties } from 'react';
 import { clampVivSelectionsToAxes } from '@spatialdata/avivatorish';
+import type { CSSProperties } from 'react';
 import type { LabelsLayerConfig } from './types';
 import type { LabelsLoaderData } from './useLayerData';
 
-const MAX_CHANNELS = 7;
+const LABEL_PLANE_COUNT = 1;
 
 const inputStyle: CSSProperties = {
   width: '100%',
@@ -134,19 +134,7 @@ function mergeForDisplay(
         )
       : baseSelections.map((selection) => mergeSelectionRow(undefined, selection, axisSizes));
 
-  const channelCount = Math.min(
-    MAX_CHANNELS,
-    Math.max(
-      colors.length,
-      channelsVisible.length,
-      channelOpacities.length,
-      channelOutlineOpacities.length,
-      channelsFilled.length,
-      channelStrokeWidths.length,
-      selections.length,
-      1
-    )
-  );
+  const channelCount = LABEL_PLANE_COUNT;
 
   const fillSelection = emptySelectionRow(axisSizes);
   const channelIds = Array.from(
@@ -199,9 +187,7 @@ export function LabelsChannelPanel({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <div style={{ color: '#ccc', fontSize: '12px', fontWeight: 600 }}>
-        Labels channels (max {MAX_CHANNELS})
-      </div>
+      <div style={{ color: '#ccc', fontSize: '12px', fontWeight: 600 }}>Labels</div>
       {Array.from({ length: m.channelCount }, (_, i) => (
         <div
           key={m.channelIds[i] ?? `${layerId}:labels:${i}`}
@@ -214,7 +200,7 @@ export function LabelsChannelPanel({
             gap: 8,
           }}
         >
-          <span style={{ color: '#666', fontSize: '11px' }}>Channel {i + 1}</span>
+          <span style={{ color: '#666', fontSize: '11px' }}>Style</span>
           <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
               <input
@@ -242,7 +228,7 @@ export function LabelsChannelPanel({
             </label>
           </div>
           <div>
-            <span style={labelStyle}>RGB</span>
+            <span style={labelStyle}>Color</span>
             <div style={{ display: 'flex', gap: 4 }}>
               {(
                 [

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -646,29 +646,26 @@ export function useLayerData(
                         shape: loaderObj.shape,
                       }),
                       axisSizes
-                    ).slice(0, 7);
-                    const channelCount = Math.max(selections.length, 1);
+                    ).slice(0, 1);
                     const metadataChannels = (element.element as LabelsElement).attrs.omero
                       ?.channels;
 
-                    const colors = Array.from(
-                      { length: channelCount },
-                      (_, index): [number, number, number] => {
-                        const rgb = tryParseOmeroHexColor(metadataChannels?.[index]?.color);
-                        const palette = COLOR_PALLETE[index % COLOR_PALLETE.length];
-                        return rgb ?? [palette[0], palette[1], palette[2]];
-                      }
-                    );
+                    const rgb = tryParseOmeroHexColor(metadataChannels?.[0]?.color);
+                    const palette = COLOR_PALLETE[0];
+                    const color: [number, number, number] = rgb ?? [
+                      palette[0],
+                      palette[1],
+                      palette[2],
+                    ];
+
                     labelsData.selectionAxisSizes = axisSizes;
                     labelsData.selections = selections.length > 0 ? selections : [{}];
-                    labelsData.colors = colors;
-                    labelsData.channelsVisible = colors.map(
-                      (_, index) => metadataChannels?.[index]?.active ?? true
-                    );
-                    labelsData.channelOpacities = colors.map(() => 0.18);
-                    labelsData.channelOutlineOpacities = colors.map(() => 0.95);
-                    labelsData.channelsFilled = colors.map(() => true);
-                    labelsData.channelStrokeWidths = colors.map(() => 1.5);
+                    labelsData.colors = [color];
+                    labelsData.channelsVisible = [metadataChannels?.[0]?.active ?? true];
+                    labelsData.channelOpacities = [0.18];
+                    labelsData.channelOutlineOpacities = [0.95];
+                    labelsData.channelsFilled = [true];
+                    labelsData.channelStrokeWidths = [1.5];
                   }
 
                   loadedDataRef.current.labels.set(element.key, {

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -21,19 +21,19 @@ import {
   type AxisAlignedBounds,
   type ImageElement,
   type LabelsElement,
+  type LabelsTooltipMetadata,
   type PointsElement,
   type ShapesElement,
   type ShapesRenderData,
-  type LabelsTooltipMetadata,
   type ShapesTooltipMetadata,
-  type SpatialFeatureTooltipData,
   type SpatialData,
+  type SpatialFeatureTooltipData,
+  boundsFromCircles,
   boundsFromImagePixelExtents,
   boundsFromPoints,
-  boundsFromCircles,
   boundsFromPolygons,
-  getTooltipSignature,
   getPhysicalSizeScalingMatrixFromMeta,
+  getTooltipSignature,
   loadLabelsTooltipMetadata,
   loadShapesTooltipMetadata,
   resolveTooltipItems,
@@ -54,8 +54,8 @@ import {
   applyPerChannelFallbackWithoutOmero,
 } from './imageLoaderChannelDefaults';
 import { createImageLoader } from './renderers/imageRenderer';
-import { type PointData, renderPointsLayer } from './renderers/pointsRenderer';
 import { renderLabelsLayer } from './renderers/labelsRenderer';
+import { type PointData, renderPointsLayer } from './renderers/pointsRenderer';
 import { loadShapesData, renderShapesLayer } from './renderers/shapesRenderer';
 import type { AvailableElement, ElementsByType, LayerConfig } from './types';
 
@@ -94,6 +94,7 @@ interface LoadedData {
 }
 
 type ResourceLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+type RasterSelection = Partial<{ z: number; c: number; t: number }>;
 
 export interface LayerLoadState {
   geometry?: ResourceLoadStatus;
@@ -179,6 +180,12 @@ function serializeHiddenIds(ids?: string[]): string {
   return ids.slice().sort().join('\x00');
 }
 
+function serializeRasterSelections(selections: RasterSelection[]): string {
+  return selections
+    .map((selection) => `z:${selection.z ?? ''}|c:${selection.c ?? ''}|t:${selection.t ?? ''}`)
+    .join('\x00');
+}
+
 async function loadShapesLayerData(
   element: ShapesElement
 ): Promise<Pick<LoadedShapesData, 'renderData'>> {
@@ -212,6 +219,9 @@ export function useLayerData(
     labels: new Map(),
     shapePrebuiltData: new Map(),
   });
+  const stableSelectionArraysRef = useRef<
+    Map<string, { signature: string; value: RasterSelection[] }>
+  >(new Map());
 
   const layersRef = useRef(layers);
   layersRef.current = layers;
@@ -431,10 +441,7 @@ export function useLayerData(
                           ? layersRef.current[layerId].featureState?.hiddenFeatureIds
                           : undefined;
                       loadedDataRef.current.shapePrebuiltData.set(layerId, {
-                        prebuilt: buildShapesPrebuiltData(
-                          mergedShapeData.renderData,
-                          hiddenIds
-                        ),
+                        prebuilt: buildShapesPrebuiltData(mergedShapeData.renderData, hiddenIds),
                         signature: serializeHiddenIds(hiddenIds),
                       });
                     }
@@ -756,6 +763,17 @@ export function useLayerData(
     // The useEffect will pick up the missing data and reload
   }, []);
 
+  const getStableSelections = useCallback((key: string, selections: RasterSelection[]) => {
+    const signature = serializeRasterSelections(selections);
+    const cached = stableSelectionArraysRef.current.get(key);
+    if (cached?.signature === signature) {
+      return cached.value;
+    }
+    const value = selections.map((selection) => ({ ...selection }));
+    stableSelectionArraysRef.current.set(key, { signature, value });
+    return value;
+  }, []);
+
   const hasRenderableLayerData = useCallback((layerId: string): boolean => {
     const elem = elementMap.current.get(layerId);
     if (!elem) return false;
@@ -893,6 +911,7 @@ export function useLayerData(
             labelsData.selectionAxisSizes !== undefined
               ? clampVivSelectionsToAxes(rawSelections, labelsData.selectionAxisSizes)
               : rawSelections;
+          const stableSelections = getStableSelections(`labels:${layerId}`, selections);
 
           const layer = renderLabelsLayer({
             id: layerId,
@@ -921,7 +940,7 @@ export function useLayerData(
               ch?.channelStrokeWidths && ch.channelStrokeWidths.length > 0
                 ? ch.channelStrokeWidths
                 : labelsData.channelStrokeWidths,
-            selections,
+            selections: stableSelections,
           });
           if (layer) deckLayers.push(layer);
         }
@@ -930,7 +949,7 @@ export function useLayerData(
     }
 
     return deckLayers;
-  }, [layers, layerOrder]);
+  }, [layers, layerOrder, getStableSelections]);
 
   const getImageLayerLoadedData = useCallback((layerId: string): ImageLoaderData | undefined => {
     const elem = elementMap.current.get(layerId);
@@ -1033,10 +1052,7 @@ export function useLayerData(
   );
 
   const getShapePickEvent = useCallback(
-    (
-      layerId: string,
-      pickInfo: Pick<{ index?: number; object?: unknown }, 'index' | 'object'>
-    ) => {
+    (layerId: string, pickInfo: Pick<{ index?: number; object?: unknown }, 'index' | 'object'>) => {
       const elem = elementMap.current.get(layerId);
       if (!elem || elem.type !== 'shapes') {
         return undefined;
@@ -1049,9 +1065,9 @@ export function useLayerData(
         return undefined;
       }
       const rowIndex =
-        loadedDataRef.current.shapes.get(elem.key)?.tooltipRowIndexByFeatureId?.get(
-          feature.featureId
-        ) ?? feature.rowIndex;
+        loadedDataRef.current.shapes
+          .get(elem.key)
+          ?.tooltipRowIndexByFeatureId?.get(feature.featureId) ?? feature.rowIndex;
       return {
         layerId,
         elementKey: elem.key,
@@ -1096,6 +1112,7 @@ export function useLayerData(
         axisSizes !== undefined
           ? clampVivSelectionsToAxes(rawSelections, axisSizes)
           : rawSelections;
+      const stableSelections = getStableSelections(`image:${layerId}`, selections);
 
       vivProps.push({
         id: config.id,
@@ -1103,7 +1120,7 @@ export function useLayerData(
         colors,
         contrastLimits,
         channelsVisible,
-        selections,
+        selections: stableSelections,
         modelMatrix: elem.transform, // Apply coordinate transformation
         opacity: config.opacity,
         visible: config.visible,
@@ -1111,7 +1128,7 @@ export function useLayerData(
     }
 
     return vivProps;
-  }, [layers, layerOrder]);
+  }, [layers, layerOrder, getStableSelections]);
 
   const isLoading = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- Moved labels tile loading onto `MultiscaleLabelsTileLayer.getTileData()` and made tile reloads depend only on loader + selection state via `updateTriggers.getTileData`.
- Stabilized selection arrays in `useLayerData` so cosmetic label prop changes repaint without retriggering fetches.
- Simplified the labels panel to reflect the real model: one labels plane, not image-style multi-channel controls.
- Added regression tests for cosmetic prop changes, structural selection changes, and `_subLayerProps` forwarding.

## Testing
- `pnpm --filter @spatialdata/layers test`
- `pnpm --filter @spatialdata/vis test`
- `pnpm --filter @spatialdata/layers build`
- `pnpm --filter @spatialdata/vis build`