### PR TITLE
Prepare MDV prerelease release workflow and rename zarrextra

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "Taylor-CCB-Group/SpatialData.js"
+    }
+  ],
+  "commit": false,
+  "fixed": [
+    [
+      "@spatialdata/core",
+      "@spatialdata/react",
+      "@spatialdata/layers",
+      "@spatialdata/avivatorish",
+      "@spatialdata/vis"
+    ]
+  ],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [],
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
+}

--- a/.changeset/mdv-prerelease.md
+++ b/.changeset/mdv-prerelease.md
@@ -1,0 +1,10 @@
+---
+"zarrextra": minor
+"@spatialdata/core": minor
+"@spatialdata/react": minor
+"@spatialdata/layers": minor
+"@spatialdata/avivatorish": minor
+"@spatialdata/vis": minor
+---
+
+Prepare the first MDV-targeted alpha prerelease.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "zarrextra": "0.0.1",
+    "@spatialdata/core": "0.0.1",
+    "@spatialdata/react": "0.0.1",
+    "@spatialdata/layers": "0.0.1",
+    "@spatialdata/avivatorish": "0.0.1",
+    "@spatialdata/vis": "0.0.1"
+  },
+  "changesets": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Version Packages
 
 on:
   push:
@@ -34,12 +34,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create release PR or publish prerelease
+      - name: Create version PR
         uses: changesets/action@v1
         with:
-          publish: pnpm release
+          version: pnpm version-packages
           title: Version packages
           commit: Version packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.14.1'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create release PR or publish prerelease
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          title: Version packages
+          commit: Version packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ A library for interfacing with SpatialData stores in TypeScript/JavaScript.
 
 This monorepo contains:
 
-- **[@spatialdata/zarrextra](./packages/zarrextra)** - Utility layer on top of `zarrita` for higher-level representations of metadata
+- **[zarrextra](./packages/zarrextra)** - Lower-level utility layer on top of `zarrita` for higher-level metadata representations
 - **[@spatialdata/core](./packages/core)** - Core library for reading and validating SpatialData stores
 - **[@spatialdata/react](./packages/react)** - React hooks for providing SpatialData context, with few extra dependencies
+- **[@spatialdata/layers](./packages/layers)** - deck.gl layers and versioned rendering props
+- **[@spatialdata/avivatorish](./packages/avivatorish)** - Viv loaders, channel stats, and image viewer state helpers
 - **[@spatialdata/vis](./packages/vis)** - High-level react components for visualising data
 - **[docs](./docs)** - Documentation site built with Docusaurus
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,100 @@
+# Release Process
+
+SpatialData.js uses Changesets for versioning and release notes, but npm
+publishing is intentionally manual for now.
+
+## Security posture
+
+- Do not add `NPM_TOKEN` or other npm publish credentials to GitHub repository
+  secrets.
+- GitHub Actions may create the Changesets version PR, but it must not publish
+  packages to npm.
+- Publish only from a clean local checkout after reviewing the final diff and
+  generated package contents.
+- Use the npm `next` dist-tag for the MDV-targeted alpha line. Do not publish
+  this prerelease as `latest`.
+
+## Package versioning
+
+- The `@spatialdata/*` packages are fixed together by Changesets:
+  - `@spatialdata/core`
+  - `@spatialdata/react`
+  - `@spatialdata/layers`
+  - `@spatialdata/avivatorish`
+  - `@spatialdata/vis`
+- `zarrextra` is published outside the `@spatialdata/*` namespace.
+- `zarrextra` participates in the first prerelease because `@spatialdata/core`
+  depends on it, but it is not fixed to the `@spatialdata/*` version train for
+  future releases.
+
+## Normal flow
+
+1. Add one or more Changesets for user-facing package changes:
+
+   ```bash
+   pnpm changeset
+   ```
+
+2. Merge the feature PR.
+
+3. Let the `Version Packages` GitHub Action open the version PR, or run it
+   locally:
+
+   ```bash
+   pnpm version-packages
+   ```
+
+4. Review the version PR carefully:
+
+   - package versions
+   - changelog entries
+   - generated dependency versions
+   - any unexpected files
+
+5. Merge the version PR.
+
+6. From a clean local checkout of the merged commit on `main`, verify:
+
+   ```bash
+   pnpm install --frozen-lockfile
+   pnpm build
+   pnpm -r --filter @spatialdata/vis test
+   pnpm docs:build
+   ```
+
+7. Dry-run the important publish targets:
+
+   ```bash
+   pnpm --filter zarrextra publish --dry-run --no-git-checks --tag next
+   pnpm --filter @spatialdata/core publish --dry-run --no-git-checks --tag next
+   pnpm --filter @spatialdata/vis publish --dry-run --no-git-checks --tag next
+   ```
+
+8. Confirm the generated `@spatialdata/core` package manifest depends on
+   `zarrextra`, not `@spatialdata/zarrextra`:
+
+   ```bash
+   pnpm --filter @spatialdata/core pack --pack-destination /tmp --json
+   tar -xOf /tmp/spatialdata-core-*.tgz package/package.json
+   ```
+
+9. Publish manually with the `next` dist-tag:
+
+   ```bash
+   pnpm publish:next
+   ```
+
+10. Smoke-test in MDV:
+
+    ```bash
+    pnpm add @spatialdata/vis@next
+    ```
+
+## If something looks wrong
+
+- Do not publish.
+- Delete local tarballs or build outputs if needed, rebuild, and repeat the
+  dry-runs.
+- If a bad version is published, prefer deprecating it on npm and publishing a
+  fixed version. Unpublishing should be a last resort because it can disrupt
+  downstream installs.

--- a/docs/docs/core/error-handling.mdx
+++ b/docs/docs/core/error-handling.mdx
@@ -16,7 +16,7 @@ This aspect of the design may be subject to review, and community feedback is en
 
 :::note Result implementation
 
-The `Result` type is implemented in `@spatialdata/zarrextra` and re-exported from `@spatialdata/core` for convenience. This is currently a custom implementation for simplicity and to avoid dependencies. We may review using an existing Result library (such as `neverthrow`) in the future, but for now this provides a lightweight, dependency-free solution.
+The `Result` type is implemented in `zarrextra` and re-exported from `@spatialdata/core` for convenience. This is currently a custom implementation for simplicity and to avoid dependencies. We may review using an existing Result library (such as `neverthrow`) in the future, but for now this provides a lightweight, dependency-free solution.
 
 :::
 

--- a/docs/docs/core/internals.mdx
+++ b/docs/docs/core/internals.mdx
@@ -243,10 +243,10 @@ The `zarrUtils.ts` module handles parsing zarr store contents:
 
 ## Result Type Implementation
 
-The `Result` type and utilities are implemented in `@spatialdata/zarrextra` and re-exported from `@spatialdata/core` for convenience:
+The `Result` type and utilities are implemented in `zarrextra` and re-exported from `@spatialdata/core` for convenience:
 
 ```ts
-// In @spatialdata/zarrextra
+// In zarrextra
 type Result<T, E = Error> = 
   | { ok: true; value: T }
   | { ok: false; error: E };
@@ -259,7 +259,7 @@ const unwrap = <T, E>(result: Result<T, E>): T => { ... };
 const unwrapOr = <T, E>(result: Result<T, E>, defaultValue: T): T => { ... };
 ```
 
-You can import `Result` and its utilities from either `@spatialdata/core` or `@spatialdata/zarrextra`.
+You can import `Result` and its utilities from either `@spatialdata/core` or `zarrextra`.
 
 :::note Future considerations
 

--- a/docs/docs/core/overview.mdx
+++ b/docs/docs/core/overview.mdx
@@ -10,20 +10,22 @@ The bundle should be tree-shakeable and avoid loading heavy dependencies before 
 
 ## Installation
 
-:::info you can't actually install this from npm right now
+:::info alpha prerelease
 
-As of writing, this isn't actually published to npm yet and when it is it may not be under this exact name. This documentation is evolving with the implementation, anticipating the expected usage.
+The first npm line is an MDV-targeted alpha prerelease. Install from the
+`next` tag until the public API is declared stable.
 
 You're more than welcome to clone the git repo and do what you will with it.
 
-Note that as of now it only works with outputs from `spatialdata ~=0.5.0` / `zarr v2` (this should change reasonably soon).
+Known risks and release-readiness notes are tracked in the
+[MDV release checklist](../vis/mdv-release-checklist).
 
 :::
 
 ```bash
-npm install @spatialdata/core
+npm install @spatialdata/core@next
 # or
-pnpm add @spatialdata/core
+pnpm add @spatialdata/core@next
 ```
 
 ## Quick Start

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -16,13 +16,22 @@ There are several packages that aim to facilitate the use and development of thi
 
 | Package | Role | React? | npm status |
 |---------|------|--------|------------|
-| `@spatialdata/core` | Load SpatialData Zarr stores; elements, transforms, table association | No | Not published yet |
-| `@spatialdata/react` | Thin hooks around core (`useSpatialData`, provider) | Yes | Not published yet |
-| `@spatialdata/layers` | deck.gl layers, shape/point renderers, versioned layer props | No | Not published yet |
-| `@spatialdata/avivatorish` | Viv loaders, channel stats, image Zustand stores | No | Not published yet |
-| `@spatialdata/vis` | `SpatialCanvas` UI + headless `SpatialCanvasViewer` | Yes | Not published yet; MDV-targeted prerelease in progress |
+| `zarrextra` | Lower-level zarr metadata helpers used by core | No | Prerelease via `next` |
+| `@spatialdata/core` | Load SpatialData Zarr stores; elements, transforms, table association | No | Prerelease via `next` |
+| `@spatialdata/react` | Thin hooks around core (`useSpatialData`, provider) | Yes | Prerelease via `next` |
+| `@spatialdata/layers` | deck.gl layers, shape/point renderers, versioned layer props | No | Prerelease via `next` |
+| `@spatialdata/avivatorish` | Viv loaders, channel stats, image Zustand stores | No | Prerelease via `next` |
+| `@spatialdata/vis` | `SpatialCanvas` UI + headless `SpatialCanvasViewer` | Yes | MDV-targeted prerelease via `next` |
 
-Nothing is on npm yet. Clone the monorepo or `pnpm pack` workspace packages for local integration (see [Headless viewer guide](./vis/headless-viewer)).
+The first npm release line is an MDV-targeted prerelease. Install with the
+`next` tag while the API is still alpha:
+
+```bash
+pnpm add @spatialdata/vis@next
+```
+
+Clone the monorepo or `pnpm pack` workspace packages for local integration
+while preparing release candidates (see [Headless viewer guide](./vis/headless-viewer)).
 
 ## `@spatialdata/core`
 

--- a/docs/docs/vis/headless-viewer.mdx
+++ b/docs/docs/vis/headless-viewer.mdx
@@ -224,7 +224,13 @@ Suggested experiments (matching the [MDV integration roadmap](./mdv-integration)
 4. **Controlled view** — save/restore `viewState` in `sessionStorage`.
 5. **External tooltips** — `renderTooltip={false}` + log `onShapeHover` payloads.
 
-Pack for MDV smoke tests:
+Install the prerelease for MDV smoke tests:
+
+```bash
+pnpm add @spatialdata/vis@next
+```
+
+Pack local builds when testing an unpublished branch:
 
 ```bash
 pnpm build
@@ -244,7 +250,7 @@ Before treating the API as stable for MDV:
 - [x] `demo/headless` route with local `blobs.zarr` fixture
 - [ ] Additional `demo/headless-*` variants (Leva controls, custom deck layers)
 - [ ] Tooltip/pick row resolution fully on shared `FeatureTableAlignment` (in progress)
-- [ ] npm prerelease published and smoke-tested in MDV
+- [ ] npm `next` prerelease published and smoke-tested in MDV
 
 See also [MDV release checklist](./mdv-release-checklist) and
 [Feature table associations](./feature-table-associations).

--- a/docs/docs/vis/mdv-integration.mdx
+++ b/docs/docs/vis/mdv-integration.mdx
@@ -25,7 +25,7 @@ The near-term target is not a full replacement for every MDV spatial feature. Th
 
 **Remaining MDV blockers** are packaging and polish, not the absence of a headless component:
 
-- packages are not yet published to npm (pack / link / prerelease for MDV smoke tests)
+- publish and smoke-test the npm `next` prerelease in MDV
 - tooltip/pick row resolution should finish converging on the shared core resolver
 - points layer is minimal scatter only (v1.1 for MDV parity)
 
@@ -62,6 +62,7 @@ Acceptance signal: demos should import the same public API MDV uses (`SpatialCan
   - `@spatialdata/layers`
   - `@spatialdata/vis`
   - optional: `@spatialdata/avivatorish`
+  - lower-level dependency: `zarrextra`
 - [ ] Decide whether MDV first consumes via local `npm link` / packed tarballs / workspace path / published prerelease.
 - [ ] Treat this repo as the place where Viv/deck/luma versions are selected. MDV should follow those versions, not constrain them.
 - [x] Upgrade to `@hms-dbmi/viv@0.21.0` / deck.gl `9.2.9` in this repo (Viv PR [hms-dbmi/viv#924](https://github.com/hms-dbmi/viv/pull/924): uniform-buffer-backed shader props, `model.shaderInputs`, variable channel counts).

--- a/docs/docs/vis/mdv-release-checklist.mdx
+++ b/docs/docs/vis/mdv-release-checklist.mdx
@@ -105,6 +105,20 @@ Practical checks for this branch:
 
 ## Release checklist (this branch)
 
+### 0) npm prerelease setup
+
+- [x] `zarrextra` is published outside the `@spatialdata/*` namespace.
+- [x] Changesets is configured with a fixed `@spatialdata/*` prerelease suite:
+  - `@spatialdata/core`
+  - `@spatialdata/react`
+  - `@spatialdata/layers`
+  - `@spatialdata/avivatorish`
+  - `@spatialdata/vis`
+- [x] `zarrextra` participates in the initial prerelease but can version independently in future releases.
+- [x] Release automation publishes via npm dist-tag `next`.
+- [ ] `NPM_TOKEN` is configured in GitHub repository secrets before publishing.
+- [ ] `@spatialdata/vis@next` installs cleanly in MDV.
+
 ### 1) API and export sanity
 
 - [x] `@spatialdata/vis` exports `SpatialCanvasViewer` as public API.
@@ -138,7 +152,7 @@ Practical checks for this branch:
 
 - [ ] `pnpm -r --filter @spatialdata/vis test` passes.
 - [ ] package build succeeds for `@spatialdata/vis` and dependent workspace packages.
-- [ ] produce installable package(s) for MDV testing (pack or prerelease).
+- [ ] produce installable package(s) for MDV testing (npm `next` prerelease or packed tarballs).
 - [ ] smoke-test install in MDV workspace and verify viewer renders.
 
 ### 5) Non-goals (explicit)
@@ -147,6 +161,23 @@ Practical checks for this branch:
 - [ ] No 3D rendering (orbit views, volume rendering, pitch/bearing navigation) in this release — 2D Cartesian only.
 - [ ] No in-repo implementation of broad GIS support in this release.
 - [ ] No hard coupling of `core` API to deck-specific loaders for this release.
+
+## Known alpha risks
+
+Track these as explicit prerelease risks rather than blockers to the first MDV
+smoke package:
+
+- [#41](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/41) — very large shape/image inputs can exhaust browser memory; add resource estimates and guard rails before broad use.
+- [#33](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/33) — stale elements can appear after switching stores when element names overlap.
+- [#12](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/12) — parquet-wasm loading can fail in the vis dev server.
+- [#13](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/13) — image source changes can temporarily hit an invalid source and surface runtime errors.
+- [#24](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/24) — points parquet loading should fail gracefully when server responses are directory listings or otherwise misconfigured.
+
+Post-prerelease unless MDV needs them immediately:
+
+- [#11](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/11) — multipart parquet sources.
+- [#16](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/16) — 3D volumetric state/UI.
+- [#6](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/6) — local file selection.
 
 ## Viv extensions and Viv `0.21.0` stack
 

--- a/docs/docs/vis/mdv-release-checklist.mdx
+++ b/docs/docs/vis/mdv-release-checklist.mdx
@@ -115,8 +115,9 @@ Practical checks for this branch:
   - `@spatialdata/avivatorish`
   - `@spatialdata/vis`
 - [x] `zarrextra` participates in the initial prerelease but can version independently in future releases.
-- [x] Release automation publishes via npm dist-tag `next`.
-- [ ] `NPM_TOKEN` is configured in GitHub repository secrets before publishing.
+- [x] Release automation creates the Changesets version PR only; npm publishing is manual for now.
+- [x] No npm publish token is required in GitHub repository secrets.
+- [ ] Publish manually from a clean local checkout using `pnpm publish:next`.
 - [ ] `@spatialdata/vis@next` installs cleanly in MDV.
 
 ### 1) API and export sanity

--- a/package.json
+++ b/package.json
@@ -27,17 +27,22 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "dev": "pnpm -r --parallel dev",
+    "changeset": "changeset",
+    "version-packages": "changeset version",
+    "release": "pnpm build && changeset publish --tag next",
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm --filter docs build"
   },
   "devDependencies": {
-    "@zarrita/storage": "catalog:",
     "@biomejs/biome": "^1.9.4",
+    "@changesets/changelog-github": "^0.7.0",
+    "@changesets/cli": "^2.31.0",
+    "@vitejs/plugin-react": "catalog:",
+    "@zarrita/storage": "catalog:",
+    "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-dts": "catalog:",
-    "@vitejs/plugin-react": "catalog:",
-    "vitest": "catalog:",
-    "typescript": "catalog:"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20.19",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "pnpm -r --parallel dev",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm build && changeset publish --tag next",
+    "publish:next": "pnpm build && changeset publish --tag next",
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm --filter docs build"
   },

--- a/packages/avivatorish/package.json
+++ b/packages/avivatorish/package.json
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build && tsc --noEmit",
     "test": "vitest run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build && tsc --emitDeclarationOnly --outDir dist",
     "dev": "vite build --watch",
@@ -20,7 +23,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@spatialdata/zarrextra": "workspace:*",
+    "zarrextra": "workspace:*",
     "@math.gl/core": "catalog:",
     "@zarrita/storage": "catalog:",
     "anndata.js": "catalog:",

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -8,7 +8,7 @@ import {
   type ConsolidatedStore,
   openExtraConsolidated,
   serializeZarrTree,
-} from '@spatialdata/zarrextra';
+} from 'zarrextra';
 import {
   getTableKeys,
   loadElements,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,7 +14,7 @@
 
 import type * as ad from 'anndata.js';
 import type * as zarr from 'zarrita';
-import type { ConsolidatedStore } from '@spatialdata/zarrextra';
+import type { ConsolidatedStore } from 'zarrextra';
 
 /**
  * Element name constants and types
@@ -76,13 +76,13 @@ export type ZGroup = zarr.Group<Store>;
 
 // Re-export zarr-related types from zarrextra for convenience
 // These are used in SDataProps and models, so we keep them accessible from core/types
-export type { ZarrTree, LazyZarrArray, ZAttrsAny } from '@spatialdata/zarrextra';
-export { ATTRS_KEY, ZARRAY_KEY } from '@spatialdata/zarrextra';
+export type { ZarrTree, LazyZarrArray, ZAttrsAny } from 'zarrextra';
+export { ATTRS_KEY, ZARRAY_KEY } from 'zarrextra';
 
 // Re-export Result type and utilities from zarrextra for convenience
 // Result is used throughout core for explicit error handling
-export type { Result } from '@spatialdata/zarrextra';
-export { Ok, Err, isOk, isErr, unwrap, unwrapOr } from '@spatialdata/zarrextra';
+export type { Result } from 'zarrextra';
+export { Ok, Err, isOk, isErr, unwrap, unwrapOr } from 'zarrextra';
 
 /**
  * Used internally when passing around properties of a spatialdata object to be used by the models/loaders.

--- a/packages/core/tests/badFiles.spec.ts
+++ b/packages/core/tests/badFiles.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ATTRS_KEY } from '@spatialdata/zarrextra';
-import type { ConsolidatedStore } from '@spatialdata/zarrextra';
+import { ATTRS_KEY } from 'zarrextra';
+import type { ConsolidatedStore } from 'zarrextra';
 import type * as zarr from 'zarrita';
 import { SpatialData } from '../src/store/index.js';
 

--- a/packages/core/tests/shapesRenderData.spec.ts
+++ b/packages/core/tests/shapesRenderData.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ATTRS_KEY } from '@spatialdata/zarrextra';
+import { ATTRS_KEY } from 'zarrextra';
 import { SpatialData } from '../src/store/index.js';
 import { loadFeatureRowIndexByFeatureIndex } from '../src/tableAssociations.js';
 

--- a/packages/core/tests/tableAssociations.spec.ts
+++ b/packages/core/tests/tableAssociations.spec.ts
@@ -1,5 +1,5 @@
-import { ATTRS_KEY } from '@spatialdata/zarrextra';
-import type { ConsolidatedStore } from '@spatialdata/zarrextra';
+import { ATTRS_KEY } from 'zarrextra';
+import type { ConsolidatedStore } from 'zarrextra';
 import { describe, expect, it } from 'vitest';
 import { getTableKeys } from '../src/models/index.js';
 import { SpatialData } from '../src/store/index.js';

--- a/packages/core/tests/tableElement.spec.ts
+++ b/packages/core/tests/tableElement.spec.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it, vi } from 'vitest';
-import { ATTRS_KEY } from '@spatialdata/zarrextra';
+import { ATTRS_KEY } from 'zarrextra';
 import { SpatialData } from '../src/store/index.js';
 
 function createMockSpatialData() {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,10 @@
     "module": "ESNext",
     "lib": ["ES2020"],
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "zarrextra": ["../zarrextra/dist/index.d.ts"]
+    },
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "declaration": true,

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
     },
     rollupOptions: {
-      external: ['zarrita', 'zod', 'anndata.js', 'parquet-wasm', '@spatialdata/zarrextra'],
+      external: ['zarrita', 'zod', 'anndata.js', 'parquet-wasm', 'zarrextra'],
     },
     sourcemap: true,
     target: 'es2020',

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build && tsc --noEmit",
     "test": "vitest run",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build && tsc --noEmit",
     "dev": "vite build --watch",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -16,8 +16,8 @@
     "paths": {
       "@spatialdata/core": ["../core/src/index.ts"],
       "@spatialdata/core/*": ["../core/src/*"],
-      "@spatialdata/zarrextra": ["../zarrextra/src/index.ts"],
-      "@spatialdata/zarrextra/*": ["../zarrextra/src/*"]
+      "zarrextra": ["../zarrextra/src/index.ts"],
+      "zarrextra/*": ["../zarrextra/src/*"]
     },
     "types": ["react", "react-dom"]
   },

--- a/packages/vis/demo/tsconfig.json
+++ b/packages/vis/demo/tsconfig.json
@@ -27,7 +27,7 @@
       "@spatialdata/layers": ["../../layers/src/index.ts"],
       "@spatialdata/react": ["../../react/src/index.ts"],
       "@spatialdata/vis": ["../src/index.ts"],
-      "@spatialdata/zarrextra": ["../../zarrextra/src/index.ts"]
+      "zarrextra": ["../../zarrextra/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/packages/vis/package.json
+++ b/packages/vis/package.json
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build && tsc --noEmit",
     "dev": "node scripts/dev.mjs",

--- a/packages/vis/tsconfig.json
+++ b/packages/vis/tsconfig.json
@@ -22,8 +22,8 @@
       "@spatialdata/layers/*": ["../layers/src/*"],
       "@spatialdata/react": ["../react/src/index.ts"],
       "@spatialdata/react/*": ["../react/src/*"],
-      "@spatialdata/zarrextra": ["../zarrextra/src/index.ts"],
-      "@spatialdata/zarrextra/*": ["../zarrextra/src/*"]
+      "zarrextra": ["../zarrextra/src/index.ts"],
+      "zarrextra/*": ["../zarrextra/src/*"]
     },
     "types": ["react", "react-dom"]
   },

--- a/packages/zarrextra/README.md
+++ b/packages/zarrextra/README.md
@@ -1,4 +1,4 @@
-# @spatialdata/zarrextra
+# zarrextra
 
 Extra utilities for working with zarr stores using zarrita.
 
@@ -15,13 +15,13 @@ This package includes a `Result<T, E>` type inspired by Rust for explicit error 
 ## Installation
 
 ```bash
-npm install @spatialdata/zarrextra
+npm install zarrextra
 ```
 
 ## Usage
 
 ```typescript
-import { openExtraConsolidated } from '@spatialdata/zarrextra';
+import { openExtraConsolidated } from 'zarrextra';
 import * as zarr from 'zarrita';
 
 const result = await openExtraConsolidated('https://example.com/store.zarr');

--- a/packages/zarrextra/package.json
+++ b/packages/zarrextra/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spatialdata/zarrextra",
+  "name": "zarrextra",
   "version": "0.0.1",
   "description": "Extra utilities for working with zarr stores using zarrita",
   "type": "module",
@@ -12,6 +12,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@changesets/changelog-github':
+        specifier: ^0.7.0
+        version: 0.7.0
+      '@changesets/cli':
+        specifier: ^2.31.0
+        version: 2.31.0(@types/node@22.18.8)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.1(vite@8.0.8(@types/node@22.18.8)(jiti@1.21.7)(terser@5.44.0))
@@ -205,9 +211,6 @@ importers:
       '@math.gl/core':
         specifier: 'catalog:'
         version: 4.1.0
-      '@spatialdata/zarrextra':
-        specifier: workspace:*
-        version: link:../zarrextra
       '@zarrita/storage':
         specifier: 'catalog:'
         version: 0.2.0
@@ -223,6 +226,9 @@ importers:
       parquet-wasm:
         specifier: 'catalog:'
         version: 0.6.1
+      zarrextra:
+        specifier: workspace:*
+        version: link:../zarrextra
       zarrita:
         specifier: 'catalog:'
         version: 0.7.1
@@ -1203,6 +1209,67 @@ packages:
   '@carto/api-client@0.5.28':
     resolution: {integrity: sha512-H/bG49eh9tMKppnFcxEeaFPDUcfZAIAEig9MUVi6Tl6QVAKXEyQOj3yFfrSk2c08xsdm8ZIAARXNLxIrZvAr3A==}
 
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
+
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
+
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+
+  '@changesets/changelog-github@0.7.0':
+    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
+
+  '@changesets/cli@2.31.0':
+    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+    hasBin: true
+
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
+
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1840,6 +1907,15 @@ packages:
   '@hms-dbmi/viv@0.21.0':
     resolution: {integrity: sha512-mHQYuGupbgz+s2PBI9lNBF/oT+AsrdB9V3Qgxd+oYwNm77m654ERtZo/pOIt/9ulC39T5CXLwpg/2ucmmOoV+Q==}
 
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@interactjs/types@1.10.27':
     resolution: {integrity: sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==}
 
@@ -2045,6 +2121,12 @@ packages:
     resolution: {integrity: sha512-NGBTdxJMk7j8Ygr1zuTyAvr1Tw+EpupMIQo7RelFjEsZXg6pujFqiDMM+rgxex8voCeuhWBJc7Rs+MoSqd46UQ==}
     peerDependencies:
       '@luma.gl/core': ~9.2.0
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
   '@mapbox/martini@0.2.0':
     resolution: {integrity: sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ==}
@@ -2793,6 +2875,9 @@ packages:
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
@@ -2901,6 +2986,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vaadin/a11y-base@24.9.6':
     resolution: {integrity: sha512-CWvREuPNGjnstmXMxJFXVo0ujZ4O9MtbyuYRNDQHkan83VtbbqExijhnTMp03IHC7JE+ovtHykGKjOQr3+ODxw==}
@@ -3232,6 +3318,10 @@ packages:
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -3343,6 +3433,10 @@ packages:
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
+
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -3487,6 +3581,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
@@ -4014,6 +4111,9 @@ packages:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
@@ -4124,6 +4224,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -4183,6 +4287,10 @@ packages:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
     engines: {node: '>=10'}
 
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
+
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
@@ -4235,6 +4343,10 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -4401,6 +4513,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4473,6 +4588,10 @@ packages:
     resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
     engines: {node: '>=4.0.0'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4521,6 +4640,14 @@ packages:
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4768,6 +4895,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-id@4.2.0:
+    resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
+    hasBin: true
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -4782,6 +4913,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   icss-utils@5.1.0:
@@ -4994,8 +5129,16 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -5059,6 +5202,10 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsdom@27.4.0:
     resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -5104,6 +5251,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -5247,6 +5397,10 @@ packages:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@7.2.0:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5259,6 +5413,9 @@ packages:
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -5640,6 +5797,10 @@ packages:
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -5679,6 +5840,15 @@ packages:
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -5775,21 +5945,40 @@ packages:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
 
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
   p-cancelable@3.0.0:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
     engines: {node: '>=12.20'}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
 
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
@@ -5807,9 +5996,16 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   package-json@8.1.1:
     resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
     engines: {node: '>=14.16'}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -5861,6 +6057,10 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
@@ -5918,6 +6118,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
 
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
@@ -6333,6 +6537,11 @@ packages:
   preact@10.27.2:
     resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
@@ -6486,6 +6695,10 @@ packages:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
 
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -6602,6 +6815,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -6795,6 +7012,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -6852,6 +7073,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spawndamnit@3.0.1:
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
   spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
@@ -6920,6 +7144,10 @@ packages:
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -6992,6 +7220,10 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
 
   terser-webpack-plugin@5.3.14:
     resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
@@ -7088,6 +7320,9 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -7206,6 +7441,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -7266,6 +7505,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uzip-module@1.0.3:
@@ -7400,6 +7640,9 @@ packages:
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -7481,6 +7724,9 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -8634,6 +8880,164 @@ snapshots:
       quadbin: 0.4.2
     transitivePeerDependencies:
       - '@loaders.gl/core'
+
+  '@changesets/apply-release-plan@7.1.1':
+    dependencies:
+      '@changesets/config': 3.1.4
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.7.2
+
+  '@changesets/assemble-release-plan@6.0.10':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.7.2
+
+  '@changesets/changelog-git@0.2.1':
+    dependencies:
+      '@changesets/types': 6.1.0
+
+  '@changesets/changelog-github@0.7.0':
+    dependencies:
+      '@changesets/get-github-info': 0.8.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@changesets/cli@2.31.0(@types/node@22.18.8)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.4
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@22.18.8)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.7.2
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@changesets/config@3.1.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
+
+  '@changesets/errors@0.2.0':
+    dependencies:
+      extendable-error: 0.1.7
+
+  '@changesets/get-dependents-graph@2.1.4':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      picocolors: 1.1.1
+      semver: 7.7.2
+
+  '@changesets/get-github-info@0.8.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@changesets/get-release-plan@4.0.16':
+    dependencies:
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.8
+      spawndamnit: 3.0.1
+
+  '@changesets/logger@0.1.1':
+    dependencies:
+      picocolors: 1.1.1
+
+  '@changesets/parse@0.4.3':
+    dependencies:
+      '@changesets/types': 6.1.0
+      js-yaml: 4.2.0
+
+  '@changesets/pre@2.0.2':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+
+  '@changesets/read@0.6.7':
+    dependencies:
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.3
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/should-skip-package@0.1.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.1.0': {}
+
+  '@changesets/write@0.4.0':
+    dependencies:
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      human-id: 4.2.0
+      prettier: 2.8.8
 
   '@colors/colors@1.5.0':
     optional: true
@@ -10009,6 +10413,13 @@ snapshots:
       - '@luma.gl/webgl'
       - react
 
+  '@inquirer/external-editor@1.0.3(@types/node@22.18.8)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.18.8
+
   '@interactjs/types@1.10.27': {}
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -10311,6 +10722,22 @@ snapshots:
       '@luma.gl/core': 9.2.6
       '@math.gl/types': 4.1.0
       '@probe.gl/env': 4.1.1
+
+  '@manypkg/find-root@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+
+  '@manypkg/get-packages@1.1.3':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
 
   '@mapbox/martini@0.2.0': {}
 
@@ -11068,6 +11495,8 @@ snapshots:
     dependencies:
       '@types/node': 22.18.8
 
+  '@types/node@12.20.55': {}
+
   '@types/node@17.0.45': {}
 
   '@types/node@20.19.20':
@@ -11692,6 +12121,8 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  ansi-colors@4.1.3: {}
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -11799,6 +12230,10 @@ snapshots:
   baseline-browser-mapping@2.8.12: {}
 
   batch@0.6.1: {}
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
 
   bidi-js@1.0.3:
     dependencies:
@@ -11968,6 +12403,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  chardet@2.1.1: {}
 
   charenc@0.0.2: {}
 
@@ -12546,6 +12983,8 @@ snapshots:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
 
+  dataloader@1.4.0: {}
+
   de-indent@1.0.2: {}
 
   debounce@1.2.1: {}
@@ -12680,6 +13119,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-indent@6.1.0: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
@@ -12752,6 +13193,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dotenv@8.6.0: {}
+
   draco3d@1.5.7: {}
 
   dunder-proto@1.0.1:
@@ -12790,6 +13233,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   entities@2.2.0: {}
 
@@ -12972,6 +13420,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extendable-error@0.1.7: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -13049,6 +13499,11 @@ snapshots:
     dependencies:
       array-back: 3.1.0
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@6.3.0:
     dependencies:
       locate-path: 7.2.0
@@ -13081,6 +13536,18 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
 
   fsevents@2.3.3:
     optional: true
@@ -13459,6 +13926,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-id@4.2.0: {}
+
   human-signals@2.1.0: {}
 
   hyperdyperid@1.2.0: {}
@@ -13468,6 +13937,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -13619,7 +14092,13 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
   is-typedarray@1.0.0: {}
+
+  is-windows@1.0.2: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -13686,6 +14165,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsdom@27.4.0:
     dependencies:
       '@acemir/cssom': 0.9.31
@@ -13733,6 +14216,10 @@ snapshots:
   json-schema@0.4.0: {}
 
   json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonfile@6.2.0:
     dependencies:
@@ -13859,6 +14346,10 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
@@ -13868,6 +14359,8 @@ snapshots:
   lodash.debounce@4.0.8: {}
 
   lodash.memoize@4.1.2: {}
+
+  lodash.startcase@4.4.0: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -14520,6 +15013,8 @@ snapshots:
 
   moment@2.30.1: {}
 
+  mri@1.2.0: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -14552,6 +15047,10 @@ snapshots:
       char-regex: 1.0.2
       emojilib: 2.4.0
       skin-tone: 2.0.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-forge@1.3.1: {}
 
@@ -14642,17 +15141,33 @@ snapshots:
 
   opener@1.5.2: {}
 
+  outdent@0.5.0: {}
+
   p-cancelable@3.0.0: {}
 
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
+
   p-finally@1.0.0: {}
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
 
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.2.1
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+
+  p-map@2.1.0: {}
 
   p-map@4.0.0:
     dependencies:
@@ -14673,12 +15188,18 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
+  p-try@2.2.0: {}
+
   package-json@8.1.1:
     dependencies:
       got: 12.6.1
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
       semver: 7.7.2
+
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
 
   pako@0.2.9: {}
 
@@ -14740,6 +15261,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-exists@4.0.0: {}
+
   path-exists@5.0.0: {}
 
   path-is-inside@1.0.2: {}
@@ -14783,6 +15306,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  pify@4.0.1: {}
 
   pkg-dir@7.0.0:
     dependencies:
@@ -15251,6 +15776,8 @@ snapshots:
 
   preact@10.27.2: {}
 
+  prettier@2.8.8: {}
+
   pretty-error@4.0.0:
     dependencies:
       lodash: 4.17.21
@@ -15401,6 +15928,13 @@ snapshots:
   react@19.2.0: {}
 
   react@19.2.1: {}
+
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.14.1
+      pify: 4.0.1
+      strip-bom: 3.0.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -15593,6 +16127,8 @@ snapshots:
   resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pathname@3.0.0: {}
 
@@ -15859,6 +16395,8 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  signal-exit@4.1.0: {}
+
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -15911,6 +16449,11 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spawndamnit@3.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   spdy-transport@3.0.0:
     dependencies:
@@ -15990,6 +16533,8 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strip-bom@3.0.0: {}
+
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@2.0.1: {}
@@ -16054,6 +16599,8 @@ snapshots:
       wordwrapjs: 5.1.1
 
   tapable@2.3.0: {}
+
+  term-size@2.2.1: {}
 
   terser-webpack-plugin@5.3.14(webpack@5.102.0):
     dependencies:
@@ -16124,6 +16671,8 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.19
+
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -16231,6 +16780,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 
@@ -16398,6 +16949,8 @@ snapshots:
 
   web-worker@1.5.0: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-bundle-analyzer@4.10.2:
@@ -16543,6 +17096,11 @@ snapshots:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.1
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -10,7 +10,7 @@ export function createWorkspaceSourceAliases(rootDir: string) {
     '@spatialdata/layers': path.resolve(rootDir, 'packages/layers/src/index.ts'),
     '@spatialdata/react': path.resolve(rootDir, 'packages/react/src/index.ts'),
     '@spatialdata/vis': path.resolve(rootDir, 'packages/vis/src/index.ts'),
-    '@spatialdata/zarrextra': path.resolve(rootDir, 'packages/zarrextra/src/index.ts'),
+    zarrextra: path.resolve(rootDir, 'packages/zarrextra/src/index.ts'),
   };
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@spatialdata/core': resolve(__dirname, 'packages/core/src'),
-      '@spatialdata/zarrextra': resolve(__dirname, 'packages/zarrextra/src'),
+      zarrextra: resolve(__dirname, 'packages/zarrextra/src'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add Changesets prerelease setup for the first MDV-targeted `next` release line.
- Rename `@spatialdata/zarrextra` to unscoped `zarrextra` and update workspace references, docs, and build aliases accordingly.
- Add a root release guide and make GitHub Actions prepare version PRs only, with manual npm publishing kept out of repo secrets.

## Testing
- `pnpm build`
- `pnpm -r --filter @spatialdata/vis test`
- `pnpm docs:build`
- npm dry-runs for `zarrextra`, `@spatialdata/core`, and `@spatialdata/vis` with the `next` tag
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SpatialData.js packages are now available as prerelease versions on npm via the `next` tag (e.g., `npm install `@spatialdata/core`@next`).
  * `zarrextra` is now published as a separately available package on npm.

* **Documentation**
  * Updated installation guides to reflect package availability on npm.
  * Clarified prerelease status and installation procedures across the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->