### PR TITLE
Fix glitchy labels layer when zoom changes, make labels sublayer ids unique per tile

### DIFF
--- a/.changeset/steady-labels-transform.md
+++ b/.changeset/steady-labels-transform.md
@@ -1,0 +1,5 @@
+---
+"@spatialdata/layers": patch
+---
+
+Fix intermittent labels layer transform glitches when multiple multiscale labels layers are rendered together by making generated bitmask tile layer ids unique per tile resolution.

--- a/packages/layers/src/LabelsLayer.ts
+++ b/packages/layers/src/LabelsLayer.ts
@@ -256,7 +256,7 @@ function renderSubBitmaskLayers(props: any) {
   return new LabelsBitmaskTileLayer(props, {
     channelData: data,
     bounds,
-    id: `sub-layer-${bounds}-${id}`,
+    id: `sub-layer-${z}-${x}-${y}-${bounds}-${id}`,
     tileId: { x, y, z },
     zoom,
     minZoom,

--- a/packages/layers/tests/labelsLayer.spec.ts
+++ b/packages/layers/tests/labelsLayer.spec.ts
@@ -167,4 +167,39 @@ describe('LabelsLayer prop flow', () => {
     expect(tileLayer.props.customExtensionProp).toBe('forwarded');
     expect(bitmaskLayer.props.customExtensionProp).toBe('forwarded');
   });
+
+  it('keeps labels bitmask sublayer ids distinct across tile resolutions', () => {
+    const { loader } = makeLabelsLoader();
+    const tileLayer = renderLabelsLayer({ loader });
+    const baseTileProps = {
+      ...tileLayer.props,
+      id: 'labels:mask-viewport-labels',
+      data: {
+        data: [new Float32Array([0, 1, 2, 0])],
+        width: 2,
+        height: 2,
+      },
+      tile: {
+        bbox: { left: 0, top: 0, right: 512, bottom: 512 },
+        zoom: 0,
+      },
+    };
+
+    const highResolutionLayer = tileLayer.props.renderSubLayers({
+      ...baseTileProps,
+      tile: {
+        ...baseTileProps.tile,
+        index: { x: 0, y: 0, z: 0 },
+      },
+    }) as { id: string };
+    const lowResolutionLayer = tileLayer.props.renderSubLayers({
+      ...baseTileProps,
+      tile: {
+        ...baseTileProps.tile,
+        index: { x: 0, y: 0, z: -1 },
+      },
+    }) as { id: string };
+
+    expect(highResolutionLayer.id).not.toBe(lowResolutionLayer.id);
+  });
 });

--- a/packages/vis/tests/featureTooltipHover.spec.ts
+++ b/packages/vis/tests/featureTooltipHover.spec.ts
@@ -6,6 +6,9 @@ import {
   resolveHoverFeatureTooltip,
 } from '../src/SpatialCanvas/featureTooltipHover.js';
 
+const LABELS_BITMASK_LAYER_ID =
+  'sub-layer-0-0-0-0,512,512,0-labels:mask-#spatial-view#-labels';
+
 describe('featureTooltipHover', () => {
   it('normalizes viv-suffixed deck layer ids', () => {
     expect(normalizeDeckLayerId('shapes:cells-#image-a#')).toBe('shapes:cells');
@@ -132,7 +135,7 @@ describe('featureTooltipHover', () => {
           layerManager: {
             getLayers: () => [
               { id: 'shapes:cells-#spatial-view#' },
-              { id: 'sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels' },
+              { id: LABELS_BITMASK_LAYER_ID },
             ],
           },
           pickMultipleObjects: () => [],
@@ -142,7 +145,7 @@ describe('featureTooltipHover', () => {
     ).toEqual([
       'labels:mask-#spatial-view#',
       'shapes:cells-#spatial-view#',
-      'sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels',
+      LABELS_BITMASK_LAYER_ID,
     ]);
   });
 
@@ -225,7 +228,7 @@ describe('featureTooltipHover', () => {
         picked: true,
         x: 10,
         y: 20,
-        layer: { id: 'sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels' },
+        layer: { id: LABELS_BITMASK_LAYER_ID },
         index: 0,
         object: { labelId: 7 },
       },
@@ -246,7 +249,7 @@ describe('featureTooltipHover', () => {
           layerManager: {
             getLayers: () => [
               { id: 'shapes:cells-#spatial-view#' },
-              { id: 'sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels' },
+              { id: LABELS_BITMASK_LAYER_ID },
             ],
           },
           pickMultipleObjects,
@@ -271,16 +274,13 @@ describe('featureTooltipHover', () => {
       items: [{ label: 'element', value: layerId }],
     }));
     const pickMultipleObjects = vi.fn(({ layerIds }: { layerIds?: string[] }) => {
-      if (
-        layerIds?.length === 1 &&
-        layerIds.includes('sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels')
-      ) {
+      if (layerIds?.length === 1 && layerIds.includes(LABELS_BITMASK_LAYER_ID)) {
         return [
           {
             picked: true,
             x: 10,
             y: 20,
-            layer: { id: 'sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels' },
+            layer: { id: LABELS_BITMASK_LAYER_ID },
             index: 0,
             object: { labelId: 7 },
           },
@@ -322,7 +322,7 @@ describe('featureTooltipHover', () => {
           layerManager: {
             getLayers: () => [
               { id: 'shapes:cells-#spatial-view#' },
-              { id: 'sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels' },
+              { id: LABELS_BITMASK_LAYER_ID },
             ],
           },
           pickMultipleObjects,
@@ -337,7 +337,7 @@ describe('featureTooltipHover', () => {
       y: 20,
       radius: 4,
       depth: 1,
-      layerIds: ['sub-layer-0,512,512,0-labels:mask-#spatial-view#-labels'],
+      layerIds: [LABELS_BITMASK_LAYER_ID],
     });
     expect(result?.sections).toHaveLength(2);
     expect(getFeatureTooltip).toHaveBeenCalledWith('shapes:cells', expect.any(Object));


### PR DESCRIPTION
`multiscale` labels bitmask sublayers could reuse the same deck layer id across different tile resolutions when their world bounds matched. During `viewState` changes, deck could transfer stale tile/texture state between those layers, leading to intermittent bad transformations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label rendering precision by enhancing tile coordinate handling in layer identification, ensuring correct label display across different zoom levels and map positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->