### PR TITLE
Clarify prop-to-layer flow and move render stack ownership into layers

### DIFF
--- a/.changeset/render-stack-events.md
+++ b/.changeset/render-stack-events.md
@@ -1,0 +1,8 @@
+---
+"@spatialdata/layers": minor
+"@spatialdata/vis": minor
+---
+
+Add the render stack contract for ordered SpatialData and host-layer rendering, with React viewer adapters for resolving stack entries into Viv/deck output.
+
+Expose richer SpatialCanvas feature-pick events for labels and shapes, including `elementKind`, `spatialElement`, tooltip metadata, and runtime SpatialData context.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: viewer-local cache, periodic snapshotter
 The code that turns resolved resources plus entry props into Viv/deck layer instances.
 _Avoid_: state store
 
+**Runtime Attachment**:
+An unsaved function or object supplied by the host application alongside a **Render Stack**, such as `hostLayerResolver`, `onFeatureHover`, `onFeatureClick`, raw deck handlers, DOM portal targets, or deck layer factories.
+_Avoid_: serializable prop, stack entry prop
+
 **MobX Control Island**:
 A small MDV/control-layer UI area that edits observable state directly while passing plain values through renderer and third-party boundaries.
 _Avoid_: MobX renderer contract
@@ -42,6 +46,7 @@ _Avoid_: MobX renderer contract
 - A **Spatial Entry** is resolved by a **Resource Resolver** before a **Renderer Adapter** creates Viv/deck output.
 - A **Host Overlay** is saved as a descriptor and materialized by the host application at runtime.
 - A **Group Entry** may order child entries, but does not yet imply framebuffer or blending behavior.
+- A **Runtime Attachment** may observe or materialize stack entries, but is not part of saved **Render Stack** config.
 - A **MobX Control Island** may edit MDV state directly, but default SpatialData.js renderer APIs remain plain-object APIs.
 
 ## Example Dialogue
@@ -53,3 +58,4 @@ _Avoid_: MobX renderer contract
 
 - "Layer" was used for SpatialData elements, deck.gl layer instances, UI rows, and saved config entries. Resolved: use **Stack Entry** for saved/render order, **Spatial Entry** for SpatialData-backed entries, and deck.gl layer only for runtime renderer output.
 - "Snapshot" was used for both persisted config and temporary UI/render state. Resolved: persisted config is a **Render Stack**; live MDV direct-edit areas are **MobX Control Islands** and should not periodically snapshot the whole stack during interaction.
+- "Props" was used for both serialized renderer inputs and runtime callback objects. Resolved: `entry.props` must remain serializable renderer input; listeners, factories, portals, and raw deck integration points are **Runtime Attachments**.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,55 @@
+# SpatialData.js Rendering Context
+
+Canonical language for SpatialData.js rendering, renderer integration, and MDV-facing state work.
+
+## Language
+
+**Render Stack**:
+An ordered, serializable description of what should be drawn in a spatial viewport.
+_Avoid_: `layerOrder`, `stackOrder`, parallel layer maps
+
+**Stack Entry**:
+One ordered item in a **Render Stack**, identified by a stable `id` and split into structural `source` identity plus renderer `props`.
+_Avoid_: ad-hoc layer descriptor
+
+**Spatial Entry**:
+A **Stack Entry** whose source is a SpatialData element such as an image, shapes, points, or labels element.
+_Avoid_: treating every entry as a deck layer
+
+**Host Overlay**:
+A **Stack Entry** whose source is owned by the host application and resolved at runtime into one or more deck.gl layers.
+_Avoid_: external layer tail, raw saved deck layer
+
+**Group Entry**:
+A reserved **Stack Entry** that names ordered children for future blending or aggregation behavior.
+_Avoid_: framebuffer layer until the rendering behavior exists
+
+**Resource Resolver**:
+The store-agnostic boundary that turns structural **Render Stack** inputs into stable loaded resources for renderers.
+_Avoid_: viewer-local cache, periodic snapshotter
+
+**Renderer Adapter**:
+The code that turns resolved resources plus entry props into Viv/deck layer instances.
+_Avoid_: state store
+
+**MobX Control Island**:
+A small MDV/control-layer UI area that edits observable state directly while passing plain values through renderer and third-party boundaries.
+_Avoid_: MobX renderer contract
+
+## Relationships
+
+- A **Render Stack** contains zero or more ordered **Stack Entries**.
+- A **Spatial Entry** is resolved by a **Resource Resolver** before a **Renderer Adapter** creates Viv/deck output.
+- A **Host Overlay** is saved as a descriptor and materialized by the host application at runtime.
+- A **Group Entry** may order child entries, but does not yet imply framebuffer or blending behavior.
+- A **MobX Control Island** may edit MDV state directly, but default SpatialData.js renderer APIs remain plain-object APIs.
+
+## Example Dialogue
+
+> **Dev:** "Can I put MDV scatter between an image and labels?"
+> **Domain expert:** "Yes — make the scatter a **Host Overlay** entry in the **Render Stack** and let MDV resolve it into a deck layer."
+
+## Flagged Ambiguities
+
+- "Layer" was used for SpatialData elements, deck.gl layer instances, UI rows, and saved config entries. Resolved: use **Stack Entry** for saved/render order, **Spatial Entry** for SpatialData-backed entries, and deck.gl layer only for runtime renderer output.
+- "Snapshot" was used for both persisted config and temporary UI/render state. Resolved: persisted config is a **Render Stack**; live MDV direct-edit areas are **MobX Control Islands** and should not periodically snapshot the whole stack during interaction.

--- a/docs/adr/0001-render-stack-owned-by-layers.md
+++ b/docs/adr/0001-render-stack-owned-by-layers.md
@@ -1,0 +1,5 @@
+# Render Stack Owned By Layers
+
+The canonical ordered render description lives in `@spatialdata/layers` as `RenderStack`, while `@spatialdata/vis` adapts that stack into React, Viv, and deck.gl rendering. Host overlays are saved as descriptors and resolved by the host application at runtime, so MDV can interleave scatter, gates, selections, and SpatialData entries without storing raw deck layer instances or reintroducing parallel `layerOrder` / `stackOrder` state.
+
+MobX may be used by MDV-facing control UI, but it is not part of the `@spatialdata/layers` contract or the default renderer API. MobX-controlled panels should be explicit control islands, especially while adopting React Compiler, because observable direct editing and automatic memoization have different assumptions.

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -138,7 +138,7 @@ React components and the SpatialCanvas stack (Viv images + deck vectors).
 **Two entry modes:**
 
 1. **Batteries included** — `SpatialCanvas` with coordinate-system picker, layer list, properties panels, tooltips.
-2. **Headless / controlled** — `SpatialCanvasViewer` or `useSpatialCanvasRenderer`: same render path, **your** state for `layers`, `layerOrder`, `viewState`, plus optional `deckLayers` for app overlays.
+2. **Headless / controlled** — `SpatialCanvasViewer` or `useSpatialCanvasRenderer`: same render path, **your** state for `renderStack.entries` and `viewState`, plus host overlay descriptors resolved by your app at runtime.
 
 The vis package is more experimental than `core`/`layers` because of the
 Viv/deck/luma dependency stack. The near-term goal is an MDV-consumable
@@ -154,18 +154,28 @@ that smoke test.
 ### Headless vis example
 
 ```tsx
-import { SpatialCanvasViewer, type LayerConfig } from '@spatialdata/vis';
+import { SpatialCanvasViewer, type RenderStack } from '@spatialdata/vis';
+
+const renderStack: RenderStack = {
+  schemaVersion: 1,
+  entries: [
+    { kind: 'spatial', id: 'image', source: { elementType: 'image', elementKey: 'morphology' } },
+    { kind: 'host', id: 'deck:selection', source: { hostLayerId: 'deck:selection' } },
+    { kind: 'spatial', id: 'shapes', source: { elementType: 'shapes', elementKey: 'cells' } },
+  ],
+};
 
 <SpatialCanvasViewer
   spatialData={spatialData}
   coordinateSystem="global"
-  layers={layers}
-  layerOrder={['image', 'shapes']}
+  renderStack={renderStack}
   viewState={viewState}
   onViewStateChange={setViewState}
-  deckLayers={myMdvOverlays}
+  hostLayerResolver={(entry) =>
+    entry.source.hostLayerId === 'deck:selection' ? mySelectionLayer : undefined
+  }
   renderTooltip={false}
-  onShapeHover={handleShapeHover}
+  onFeatureHover={handleFeatureHover}
 />
 ```
 

--- a/docs/docs/layers/overview.mdx
+++ b/docs/docs/layers/overview.mdx
@@ -4,11 +4,16 @@ sidebar_position: 1
 
 # `@spatialdata/layers`
 
-The **deck.gl–native** package for composable spatial rendering: a top-level **`SpatialLayer`** `CompositeLayer` and a versioned, JSON-serializable **`SpatialLayerProps`** contract.
+The **deck.gl–native** package for composable spatial rendering: a canonical
+ordered **`RenderStack`** contract, a top-level **`SpatialLayer`**
+`CompositeLayer`, and versioned, JSON-serializable **`SpatialLayerProps`**.
 
 ## Role
 
 - **`SpatialLayer`** — validates props and will orchestrate Viv / scatter / shapes sublayers as they are ported from `@spatialdata/vis` and MDV-style stacks.
+- **`RenderStack`** — ordered saved/render state for SpatialData entries, host
+  overlay descriptors, and reserved group entries. This replaces public
+  dependence on parallel `layers` maps plus `layerOrder` arrays.
 - **`spatialLayerPropsSchema`** / **`migrateSpatialLayerProps`** — runtime validation and migrations for saved views, URL state, and integrators (e.g. MDV chart config).
 
 ## Relationships
@@ -17,8 +22,8 @@ The **deck.gl–native** package for composable spatial rendering: a top-level *
 |--------|-----------------|
 | `@spatialdata/core` | SpatialData on Zarr: elements, transforms, read APIs |
 | `@spatialdata/avivatorish` | OME loaders, tile cache, channel stats, Zustand image state |
-| `@spatialdata/layers` | How data enters **deck** via `SpatialLayer` + props |
-| `@spatialdata/vis` | **SpatialCanvas** React shell: UI ↔ props |
+| `@spatialdata/layers` | Canonical render-stack schema and how data enters **deck** via `SpatialLayer` + props |
+| `@spatialdata/vis` | **SpatialCanvas** React/Viv adapter: render stack ↔ resources ↔ viewport |
 
 ## API tiers
 
@@ -54,6 +59,43 @@ load-bearing:
 The migration test is the same as shapes: MDV or Vitessce should be able to
 drive hide/fade/color/radius state without knowing whether the renderer used JS
 arrays, deck binary attributes, or GeoArrow batches underneath.
+
+## Render stack contract
+
+The public saved/render order is `renderStack.entries`, not a separate
+`layerOrder` array:
+
+```ts
+import type { RenderStack } from '@spatialdata/layers';
+
+const renderStack: RenderStack = {
+  schemaVersion: 1,
+  entries: [
+    {
+      kind: 'spatial',
+      id: 'image-morphology',
+      source: { elementType: 'image', elementKey: 'morphology_focus' },
+      props: { opacity: 0.8 },
+    },
+    {
+      kind: 'host',
+      id: 'deck:scatter',
+      source: { hostLayerId: 'deck:scatter' },
+    },
+    {
+      kind: 'group',
+      id: 'group:future-blend',
+      children: ['image-morphology', 'deck:scatter'],
+      props: { blendMode: 'reserved' },
+    },
+  ],
+};
+```
+
+`source` holds structural identity. `props` holds renderer inputs. Resource
+resolvers and deck/Viv `updateTriggers` decide what actually invalidates IO,
+geometry, attributes, or tile data; do not add a second visual-vs-structural
+prop registry.
 
 ## React-agnostic usage
 

--- a/docs/docs/vis/headless-viewer.mdx
+++ b/docs/docs/vis/headless-viewer.mdx
@@ -172,8 +172,14 @@ layer-stack interleaving.
 <SpatialCanvasViewer
   renderTooltip={false}
   onFeatureHover={(event) => {
-    // event.elementType is "shapes" or "labels".
-    // event.featureId, event.rowIndex, event.tooltip, event.pickInfo, ...
+    // event.elementKind is "shapes" or "labels".
+    // event.element.key, event.featureId, event.rowIndex, event.tooltip, event.pickInfo, ...
+  }}
+  onFeatureClick={(event) => {
+    if (event.elementKind !== 'labels') return;
+    if (event.element.key !== 'blobs_labels') return;
+
+    // event.labelId and event.element are narrowed here.
   }}
   onHover={(info) => {
     // raw deck PickingInfo for custom layers
@@ -197,8 +203,10 @@ Runtime attachments live beside the stack:
   layers for this running application.
 - `onFeatureHover` / `onFeatureClick` receive a typed SpatialData feature event
   for shapes and labels. The payload includes the stable stack `layerId`,
-  `elementKey`, `featureId`, optional table `rowIndex`, the raw `pickInfo`, and
-  the same tooltip payload used by `SpatialFeatureTooltip` when available.
+  `elementKind` for TypeScript narrowing, resolved `element` (use
+  `event.element.kind` and `event.element.key`), current `spatialData`,
+  `featureId`, optional table `rowIndex`, the raw `pickInfo`, and the same
+  tooltip payload used by `SpatialFeatureTooltip` when available.
 - `onShapeHover` / `onShapeClick` remain as shape-only compatibility callbacks.
 - raw `onHover` / `onClick` remain available for host layers or lower-level deck
   integrations.

--- a/docs/docs/vis/headless-viewer.mdx
+++ b/docs/docs/vis/headless-viewer.mdx
@@ -173,13 +173,13 @@ layer-stack interleaving.
   renderTooltip={false}
   onFeatureHover={(event) => {
     // event.elementKind is "shapes" or "labels".
-    // event.element.key, event.featureId, event.rowIndex, event.tooltip, event.pickInfo, ...
+    // event.spatialElement.key, event.featureId, event.rowIndex, event.tooltip, event.pickInfo, ...
   }}
   onFeatureClick={(event) => {
     if (event.elementKind !== 'labels') return;
-    if (event.element.key !== 'blobs_labels') return;
+    if (event.spatialElement.key !== 'blobs_labels') return;
 
-    // event.labelId and event.element are narrowed here.
+    // event.labelId and event.spatialElement are narrowed here.
   }}
   onHover={(info) => {
     // raw deck PickingInfo for custom layers
@@ -203,10 +203,10 @@ Runtime attachments live beside the stack:
   layers for this running application.
 - `onFeatureHover` / `onFeatureClick` receive a typed SpatialData feature event
   for shapes and labels. The payload includes the stable stack `layerId`,
-  `elementKind` for TypeScript narrowing, resolved `element` (use
-  `event.element.kind` and `event.element.key`), current `spatialData`,
-  `featureId`, optional table `rowIndex`, the raw `pickInfo`, and the same
-  tooltip payload used by `SpatialFeatureTooltip` when available.
+  `elementKind` for TypeScript narrowing, resolved `spatialElement` (use
+  `event.spatialElement.kind` and `event.spatialElement.key`), current
+  `spatialData`, `featureId`, optional table `rowIndex`, the raw `pickInfo`, and
+  the same tooltip payload used by `SpatialFeatureTooltip` when available.
 - `onShapeHover` / `onShapeClick` remain as shape-only compatibility callbacks.
 - raw `onHover` / `onClick` remain available for host layers or lower-level deck
   integrations.

--- a/docs/docs/vis/headless-viewer.mdx
+++ b/docs/docs/vis/headless-viewer.mdx
@@ -211,6 +211,26 @@ Runtime attachments live beside the stack:
 - raw `onHover` / `onClick` remain available for host layers or lower-level deck
   integrations.
 
+### Planned event API
+
+In a follow-up breaking experimental pass, `onFeatureHover` and
+`onFeatureClick` should be superseded by SpatialData-scoped element callbacks:
+`onSpatialElementMove`, `onSpatialElementOver`, `onSpatialElementOut`, and
+`onSpatialElementClick`.
+
+Those events should cover SpatialData-backed images, labels, shapes, and points.
+Each event should carry `layerId`, `elementKind`, `spatialElement`,
+`coordinateSystem`, `spatialData`, and `pickInfo`. Shapes and labels should also
+carry feature-specific fields such as `featureId`, `labelId`, `featureIndex`,
+`rowIndex`, `object`, and `tooltip` when available. `onSpatialElementOver` and
+`onSpatialElementOut` should be synthesized from hover transitions; for shapes
+and labels, those transitions should be per feature rather than only per layer.
+
+Raw deck `onHover` and `onClick` remain the escape hatch for host layers and
+custom deck.gl layers. This planned API does not add custom SpatialData-aware
+host layer events or invent feature semantics for images and points beyond what
+deck's `pickInfo` already provides.
+
 ## Shapes: table-driven colour and filter state
 
 MDV should drive styling by updating the target stack entry props — not by

--- a/docs/docs/vis/headless-viewer.mdx
+++ b/docs/docs/vis/headless-viewer.mdx
@@ -31,7 +31,7 @@ import { useState } from 'react';
 import { readZarr } from '@spatialdata/core';
 import {
   SpatialCanvasViewer,
-  type LayerConfig,
+  type RenderStack,
   type ViewState,
 } from '@spatialdata/vis';
 
@@ -39,41 +39,43 @@ const [spatialData, setSpatialData] = useState<Awaited<ReturnType<typeof readZar
 const [coordinateSystem, setCoordinateSystem] = useState<string | null>(null);
 const [viewState, setViewState] = useState<ViewState | null>(null);
 
-const layers: Record<string, LayerConfig> = {
-  image: {
-    id: 'image',
-    type: 'image',
-    elementKey: 'my_image',
-    visible: true,
-    opacity: 1,
-  },
-  shapes: {
-    id: 'shapes',
-    type: 'shapes',
-    elementKey: 'cell_shapes',
-    visible: true,
-    opacity: 1,
-    fillColor: [100, 149, 237, 180],
-    fillColorByColumn: { columnName: 'cell_type', mode: 'categorical' },
-    tooltipFields: ['cell_type'],
-  },
+const renderStack: RenderStack = {
+  schemaVersion: 1,
+  entries: [
+    {
+      kind: 'spatial',
+      id: 'image',
+      source: { elementType: 'image', elementKey: 'my_image' },
+      props: { opacity: 1 },
+    },
+    {
+      kind: 'spatial',
+      id: 'shapes',
+      source: { elementType: 'shapes', elementKey: 'cell_shapes' },
+      props: {
+        opacity: 1,
+        fillColor: [100, 149, 237, 180],
+        fillColorByColumn: { columnName: 'cell_type', mode: 'categorical' },
+        tooltipFields: ['cell_type'],
+      },
+    },
+  ],
 };
-const layerOrder = ['image', 'shapes'];
 
 // After loading:
 <SpatialCanvasViewer
   spatialData={spatialData}
   coordinateSystem={coordinateSystem}
-  layers={layers}
-  layerOrder={layerOrder}
+  renderStack={renderStack}
   viewState={viewState}
   onViewStateChange={setViewState}
   style={{ width: '100%', height: '100%' }}
 />
 ```
 
-**You own all state.** Change `layers`, `layerOrder`, or `viewState` from your
-app store (MobX, zustand, React state, Leva, etc.) and the viewer re-renders.
+**You own all state.** Change `renderStack` or `viewState` from your app store
+(MobX, zustand, React state, Leva, etc.) and the viewer re-renders. Keep
+structural identity in `entry.source`; use `entry.props` for renderer inputs.
 
 ## Hook-only composition (custom layout)
 
@@ -84,13 +86,12 @@ import { useMeasure } from '@uidotdev/usehooks';
 import { useSpatialCanvasRenderer } from '@spatialdata/vis';
 import { SpatialViewer } from '@spatialdata/vis';
 
-function MyViewport({ spatialData, coordinateSystem, layers, layerOrder, viewState, onViewStateChange }) {
+function MyViewport({ spatialData, coordinateSystem, renderStack, viewState, onViewStateChange }) {
   const [ref, { width, height }] = useMeasure();
   const renderer = useSpatialCanvasRenderer({
     spatialData,
     coordinateSystem,
-    layers,
-    layerOrder,
+    renderStack,
     viewState,
     onViewStateChange,
     width: width ?? 0,
@@ -105,7 +106,8 @@ function MyViewport({ spatialData, coordinateSystem, layers, layerOrder, viewSta
         height={height ?? 0}
         viewState={viewState}
         onViewStateChange={onViewStateChange}
-        deckLayers={renderer.deckLayers}
+        layers={renderer.deckLayers}
+        layerOrder={renderer.layerOrder}
         vivLayerProps={renderer.vivLayerProps}
       />
     </div>
@@ -117,9 +119,10 @@ function MyViewport({ spatialData, coordinateSystem, layers, layerOrder, viewSta
 flags, bounds helpers, and shape pick/tooltip resolvers — same as inside
 `SpatialCanvasViewer`.
 
-## MDV-style overlays
+## MDV-style host overlays
 
-Pass app-built deck layers **above** SpatialData-generated layers:
+Use host overlay descriptors when app-built deck layers need to interleave with
+SpatialData entries:
 
 ```tsx
 import { ScatterplotLayer } from 'deck.gl';
@@ -133,7 +136,17 @@ const mdvScatter = new ScatterplotLayer({
 
 <SpatialCanvasViewer
   /* ...controlled props... */
-  deckLayers={[mdvScatter]}
+  renderStack={{
+    schemaVersion: 1,
+    entries: [
+      { kind: 'spatial', id: 'image', source: { elementType: 'image', elementKey: 'my_image' } },
+      { kind: 'host', id: 'deck:scatter', source: { hostLayerId: 'deck:scatter' } },
+      { kind: 'spatial', id: 'shapes', source: { elementType: 'shapes', elementKey: 'cell_shapes' } },
+    ],
+  }}
+  hostLayerResolver={(entry) => {
+    if (entry.source.hostLayerId === 'deck:scatter') return mdvScatter;
+  }}
   deckProps={{
     controller: true,
     getCursor: ({ isDragging }) => (isDragging ? 'grabbing' : 'default'),
@@ -141,8 +154,9 @@ const mdvScatter = new ScatterplotLayer({
 />
 ```
 
-Composition order is always: **SpatialData layers first**, then `deckLayers`,
-then scale bar (inside `SpatialViewer`).
+The older `deckLayers` prop remains as a compatibility tail for simple overlays
+that always sit above SpatialData output. It should not be used for saved MDV
+layer-stack interleaving.
 
 ## Tooltips: internal, external, or off
 
@@ -169,12 +183,12 @@ picks through your existing portal hook.
 
 ## Shapes: table-driven colour and filter state
 
-MDV should drive styling by updating `layers[layerId]` — not by reaching into
-vis internals:
+MDV should drive styling by updating the target stack entry props — not by
+reaching into vis internals:
 
 ```ts
-layers[shapesId] = {
-  ...layers[shapesId],
+entry.props = {
+  ...entry.props,
   fillColorByColumn: { columnName: 'leiden', mode: 'categorical' },
   featureState: {
     hiddenFeatureIds: filteredOutIds,
@@ -221,9 +235,9 @@ The dev script starts the fixture server on port **38473** (override with
 
 Suggested experiments (matching the [MDV integration roadmap](./mdv-integration)):
 
-1. **Fixed stack** — hard-code `layers` / `layerOrder` for one fixture URL.
+1. **Fixed stack** — hard-code `renderStack.entries` for one fixture URL.
 2. **External controls** — Leva panel for coordinate system, visibility, opacity, channel colours.
-3. **Custom deck layer** — one `ScatterplotLayer` above the image.
+3. **Host overlay** — one `ScatterplotLayer` interleaved by descriptor and resolver.
 4. **Controlled view** — save/restore `viewState` in `sessionStorage`.
 5. **External tooltips** — `renderTooltip={false}` + log `onShapeHover` payloads.
 
@@ -247,8 +261,8 @@ Before treating the API as stable for MDV:
 
 - [x] `SpatialCanvasViewer` exported from `@spatialdata/vis`
 - [x] `useSpatialCanvasRenderer`, `composeSpatialDeckLayers`, `shouldAutoFitSpatialView`, `shouldRenderInternalTooltip` exported
-- [x] Controlled `coordinateSystem`, `layers`, `layerOrder`, `viewState`
-- [x] `deckLayers` / `deckProps` passthrough
+- [x] Controlled `coordinateSystem`, `renderStack`, `viewState`
+- [x] Host overlay descriptors with `hostLayerResolver`; `deckLayers` / `deckProps` passthrough remains for compatibility
 - [x] `renderTooltip={false}` for external tooltip ownership
 - [x] `demo/headless` route with local `blobs.zarr` fixture
 - [ ] Additional `demo/headless-*` variants (Leva controls, custom deck layers)

--- a/docs/docs/vis/headless-viewer.mdx
+++ b/docs/docs/vis/headless-viewer.mdx
@@ -96,7 +96,9 @@ function MyViewport({ spatialData, coordinateSystem, renderStack, viewState, onV
     onViewStateChange,
     width: width ?? 0,
     height: height ?? 0,
-    deckLayers: myCustomScatterLayer ? [myCustomScatterLayer] : undefined,
+    hostLayerResolver: (entry) => {
+      if (entry.source.hostLayerId === 'deck:scatter') return myCustomScatterLayer;
+    },
   });
 
   return (
@@ -116,7 +118,7 @@ function MyViewport({ spatialData, coordinateSystem, renderStack, viewState, onV
 ```
 
 `useSpatialCanvasRenderer` returns `deckLayers`, `vivLayerProps`, loading
-flags, bounds helpers, and shape pick/tooltip resolvers — same as inside
+flags, bounds helpers, and feature pick/tooltip resolvers — same as inside
 `SpatialCanvasViewer`.
 
 ## MDV-style host overlays
@@ -163,14 +165,15 @@ layer-stack interleaving.
 | `renderTooltip` | Behaviour |
 |-----------------|-----------|
 | `undefined` (default) | Built-in `SpatialFeatureTooltip` on hover |
-| `false` | No internal tooltip; use `onHover` / `onShapeHover` |
+| `false` | No internal tooltip; use `onFeatureHover` / raw `onHover` |
 | `(props) => <MyTooltip {...props} />` | Custom renderer; optional `tooltipContainer` for portals |
 
 ```tsx
 <SpatialCanvasViewer
   renderTooltip={false}
-  onShapeHover={(event) => {
-    // event.featureId, event.rowIndex, event.pickInfo, ...
+  onFeatureHover={(event) => {
+    // event.elementType is "shapes" or "labels".
+    // event.featureId, event.rowIndex, event.tooltip, event.pickInfo, ...
   }}
   onHover={(info) => {
     // raw deck PickingInfo for custom layers
@@ -180,6 +183,25 @@ layer-stack interleaving.
 
 For MDV-style outer-container tooltips, set `renderTooltip={false}` and route
 picks through your existing portal hook.
+
+## Serializable props vs runtime listeners
+
+`renderStack.entries` is the saved, serializable contract. Put element identity,
+visibility, opacity, channel selections, tooltip field names, feature-state
+records, and other renderer props there. Do not put functions, MobX observables,
+deck.gl layer instances, DOM refs, or event handlers in `entry.props`.
+
+Runtime attachments live beside the stack:
+
+- `hostLayerResolver(entry)` turns a host descriptor into one or more deck.gl
+  layers for this running application.
+- `onFeatureHover` / `onFeatureClick` receive a typed SpatialData feature event
+  for shapes and labels. The payload includes the stable stack `layerId`,
+  `elementKey`, `featureId`, optional table `rowIndex`, the raw `pickInfo`, and
+  the same tooltip payload used by `SpatialFeatureTooltip` when available.
+- `onShapeHover` / `onShapeClick` remain as shape-only compatibility callbacks.
+- raw `onHover` / `onClick` remain available for host layers or lower-level deck
+  integrations.
 
 ## Shapes: table-driven colour and filter state
 
@@ -239,7 +261,7 @@ Suggested experiments (matching the [MDV integration roadmap](./mdv-integration)
 2. **External controls** — Leva panel for coordinate system, visibility, opacity, channel colours.
 3. **Host overlay** — one `ScatterplotLayer` interleaved by descriptor and resolver.
 4. **Controlled view** — save/restore `viewState` in `sessionStorage`.
-5. **External tooltips** — `renderTooltip={false}` + log `onShapeHover` payloads.
+5. **External tooltips** — `renderTooltip={false}` + log `onFeatureHover` payloads.
 
 Install the prerelease for MDV smoke tests:
 

--- a/docs/docs/vis/layer-prop-flow.mdx
+++ b/docs/docs/vis/layer-prop-flow.mdx
@@ -232,6 +232,21 @@ frame.
   `@spatialdata/layers` colour encoder. Do not add local feature-to-row
   precedence rules in `SpatialCanvas` or layer modules.
 
+### Runtime attachments are not layer props
+
+`renderStack.entries[*].props` is for serializable renderer input. Runtime
+functions and objects must stay outside that bag:
+
+- host overlay factories belong in `hostLayerResolver`
+- feature listeners belong in `onFeatureHover` / `onFeatureClick`
+- raw deck listeners belong in `onHover` / `onClick` or `deckProps`
+- tooltip portals belong in `tooltipContainer`
+
+These runtime attachments may read the resolved feature payload, including the
+same `SpatialFeatureTooltipData` used by built-in tooltips, but they must not be
+part of resource cache keys. Changing a listener should not reload images,
+geometry, bounds, shape prebuilds, or feature-state runtimes.
+
 ### Layer contract (`@spatialdata/layers`)
 
 - **`buildShapeFeatureStateRuntime`**: converts serializable `featureState`

--- a/docs/docs/vis/layer-prop-flow.mdx
+++ b/docs/docs/vis/layer-prop-flow.mdx
@@ -51,6 +51,10 @@ refetches. The fix is upstream stability, not downstream caching.
 
 ### For `useLayerData` (the producer)
 
+- The public ordered input is moving toward `RenderStack` (`renderStack.entries`)
+  from `@spatialdata/layers`. The resolver may normalize that into lookup maps
+  internally, but entry order and identity come from the stack, not a parallel
+  public `layerOrder` array.
 - `loader`: same object reference until the underlying element changes.
 - `selections`: same array reference until the selected values change. Memoize
   with `useMemo` keyed on a stable signature of the selection values.

--- a/docs/docs/vis/mdv-integration.mdx
+++ b/docs/docs/vis/mdv-integration.mdx
@@ -87,7 +87,7 @@ Current surface:
   hostLayerResolver={resolveMdvHostLayer}
   deckProps={deckProps}
   renderTooltip={false}
-  onShapeHover={onShapeHover}
+  onFeatureHover={onFeatureHover}
 />
 ```
 
@@ -99,7 +99,7 @@ Implementation status:
 - [x] Host overlay descriptors plus `hostLayerResolver` for MDV scatter, gates, contours, ROI overlays.
 - [x] Deprecated compatibility path for `layers`, `layerOrder`, and `deckLayers`.
 - [x] `showLoadingOverlay` and `renderTooltip={false}` for external tooltip ownership.
-- [x] `onShapeHover` / `onShapeClick` for feature-aware picking.
+- [x] `onFeatureHover` / `onFeatureClick` for shape and label picking, with `onShapeHover` / `onShapeClick` kept as compatibility callbacks.
 - [ ] Stable externally supplied Viv/deck view id or layer id suffix (`getVivId` compatibility).
 - [ ] Viv extension prop audit once MDV merge lands (low risk; versions already aligned).
 
@@ -115,9 +115,9 @@ Adapter responsibilities:
 
 - derive `source` / SpatialData store URL from MDV project state
 - select the active coordinate system from MDV region metadata
-- map MDV chart config to `LayerConfig[]`
+- map MDV chart config to `renderStack.entries`
 - map MDV view state to `SpatialCanvas` view state
-- pass existing MDV deck layers:
+- resolve existing MDV deck layers from host overlay descriptors:
   - scatterplot layer
   - grey/background scatter layer
   - selection layer
@@ -151,6 +151,14 @@ Host overlays are descriptors in saved config. MDV owns the runtime resolver
 that turns `deck:scatter`, gates, selections, contours, or ROI descriptors into
 deck.gl layers. This avoids storing raw deck layer instances in project state
 and avoids parallel `stackOrder` / `layerOrder` arrays.
+
+Listeners follow the same split. Saved `renderStack.entries[*].props` should
+contain serializable renderer input only. MDV-owned callbacks such as
+`onFeatureHover` / `onFeatureClick`, tooltip portal wiring, and host overlay
+factories are runtime attachments supplied beside the stack. The feature events
+cover shapes and labels and include the same tooltip payload that built-in
+SpatialData.js tooltips use, so MDV does not need to decode deck.gl pick objects
+for normal table-backed hover/click interactions.
 
 ### Constrained MobX
 
@@ -202,9 +210,9 @@ integrators can read `obs`, `var`, selected `X` columns, `obsm`, and future
 into `anndata.js` where possible; SpatialData.js should thin-wrap table
 elements and preserve Python association semantics.
 
-MDV should pass resolved **`featureState`** and **`fillColorByColumn`** on
-`ShapesLayerConfig` when selection or colour mappings change — not re-load
-geometry. See [Feature table associations](./feature-table-associations).
+MDV should pass resolved **`featureState`** and **`fillColorByColumn`** on the
+target shapes stack entry props when selection or colour mappings change — not
+re-load geometry. See [Feature table associations](./feature-table-associations).
 
 ## Phase 3: layer styling, filtering, and highlighting
 

--- a/docs/docs/vis/mdv-integration.mdx
+++ b/docs/docs/vis/mdv-integration.mdx
@@ -81,11 +81,10 @@ Current surface:
 <SpatialCanvasViewer
   spatialData={spatialData}
   coordinateSystem={coordinateSystem}
-  layers={layers}
-  layerOrder={layerOrder}
+  renderStack={renderStack}
   viewState={viewState}
   onViewStateChange={setViewState}
-  deckLayers={mdvDeckLayers}
+  hostLayerResolver={resolveMdvHostLayer}
   deckProps={deckProps}
   renderTooltip={false}
   onShapeHover={onShapeHover}
@@ -96,8 +95,9 @@ Implementation status:
 
 - [x] Split viewer core (`SpatialCanvasViewer` / `useSpatialCanvasRenderer`) from `SpatialCanvas` UI shell.
 - [x] Export `SpatialCanvasViewer` from public `@spatialdata/vis` entry.
-- [x] Controlled `coordinateSystem`, `layers`, `layerOrder`, and `viewState`.
-- [x] `deckLayers` / `deckProps` for MDV scatter, gates, contours, ROI overlays.
+- [x] Controlled `coordinateSystem`, `renderStack`, and `viewState`.
+- [x] Host overlay descriptors plus `hostLayerResolver` for MDV scatter, gates, contours, ROI overlays.
+- [x] Deprecated compatibility path for `layers`, `layerOrder`, and `deckLayers`.
 - [x] `showLoadingOverlay` and `renderTooltip={false}` for external tooltip ownership.
 - [x] `onShapeHover` / `onShapeClick` for feature-aware picking.
 - [ ] Stable externally supplied Viv/deck view id or layer id suffix (`getVivId` compatibility).
@@ -130,6 +130,53 @@ Adapter responsibilities:
 - keep MDV keyboard/selection behavior around the viewer container
 
 The first-pass chart can deliberately avoid replacing the channel dialog and most image editing UI. It only needs enough layer config to render an image/labels/shapes baseline and enough view-state synchronization to sanity-check against the current Viv chart.
+
+## Render stack and MDV state model
+
+The next MDV pass should treat `@spatialdata/layers` **`RenderStack`** as the
+canonical saved/render order:
+
+```ts
+const renderStack = {
+  schemaVersion: 1,
+  entries: [
+    { kind: 'spatial', id: 'image', source: { elementType: 'image', elementKey: 'morphology' } },
+    { kind: 'host', id: 'deck:scatter', source: { hostLayerId: 'deck:scatter' } },
+    { kind: 'spatial', id: 'labels', source: { elementType: 'labels', elementKey: 'cells' } },
+  ],
+};
+```
+
+Host overlays are descriptors in saved config. MDV owns the runtime resolver
+that turns `deck:scatter`, gates, selections, contours, or ROI descriptors into
+deck.gl layers. This avoids storing raw deck layer instances in project state
+and avoids parallel `stackOrder` / `layerOrder` arrays.
+
+### Constrained MobX
+
+MobX is acceptable for MDV-facing direct-edit control state, but it should be
+kept out of `@spatialdata/layers` and out of the default `@spatialdata/vis`
+renderer contract:
+
+- Use small **MobX control islands** for layer rows and controls.
+- Let each observer component read only the observable fields it renders.
+- Do not pass broad observable stack/config objects into MUI, dnd-kit, deck.gl,
+  Viv, or non-observer components; pass plain values at those boundaries.
+- Sliders should patch renderer-visible props immediately and persist config
+  intentionally, not through periodic whole-stack snapshots.
+- Avoid `toJS` on large stack/config objects during drag interactions.
+
+React Compiler adoption makes this boundary more important. MobX `observer`
+components rely on observable reads rather than React's immutable-prop
+memoization assumptions, so MobX-heavy components should be explicit islands
+that can be excluded from compiler optimization or marked with `"use no memo"`
+where needed. The default SpatialData.js viewer path should remain
+plain-object and compiler-friendly.
+
+Acceptance for the MDV UI path is separate from tile-fetch correctness: opacity
+dragging should not re-render the whole layer dialog/list, should not show a
+periodic stop-start GUI cadence, and should not create large stack snapshots on
+every granular mutation.
 
 ## Tables, AnnData.js, and zarrita `DataLoader`
 

--- a/docs/docs/vis/mdv-release-checklist.mdx
+++ b/docs/docs/vis/mdv-release-checklist.mdx
@@ -32,19 +32,20 @@ MDV is the **source of truth** for viewer state. `SpatialCanvasViewer` is a **co
 MDV passes and updates (from chart / datastore / MobX):
 
 - `spatialData`, `coordinateSystem`
-- `layers` (`Record<string, LayerConfig>`) — visibility, opacity, per-layer style, and (for shapes v1) filter/colour driven by table rows
-- `layerOrder`
+- `renderStack.entries` — canonical order plus visibility, opacity, per-layer style, and (for shapes v1) filter/colour driven by table rows
 - `viewState` + `onViewStateChange`
-- optional `deckLayers` / `deckProps` for overlays MDV builds directly
+- `hostLayerResolver` for overlays MDV builds directly, plus optional `deckProps`
 
-When MDV selection or colour mappings change, MDV updates `layers` (and/or `deckLayers`) and React re-renders the viewer. This repo loads SpatialData geometry/images and maps **MDV’s layer config** to deck.gl layers.
+When MDV selection or colour mappings change, MDV updates the relevant stack
+entry props and React re-renders the viewer. This repo loads SpatialData
+geometry/images and maps **MDV’s render stack** to Viv/deck output.
 
 ### What `@spatialdata/vis` owns
 
 - SpatialData-backed discovery and async loading (images, shapes, labels)
 - Viv image path and labels bitmask path
-- Turning **caller-supplied** `LayerConfig` into deck layers (`useLayerData` / renderers)
-- Composing generated layers with caller `deckLayers` / `deckProps.layers`
+- Turning **caller-supplied** render stack entries into deck layers (`useLayerData` / renderers)
+- Composing generated layers with host overlays resolved from stack descriptors
 - Stable picking/tooltip hooks keyed by layer id (for MDV tooltip portals)
 
 ### What MDV owns (v1)
@@ -66,7 +67,9 @@ When MDV selection or colour mappings change, MDV updates `layers` (and/or `deck
 
 ### Custom deck layers (additive, not a replacement for state)
 
-MDV can still pass layers it constructs entirely in app code (for example from `spatial_context.ts`) via `deckLayers` or `deckProps.layers`. Those sit **above** SpatialData-generated layers in the composed stack.
+MDV can still resolve layers it constructs entirely in app code (for example
+from `spatial_context.ts`) from host overlay descriptors in `renderStack.entries`.
+Those can interleave with SpatialData-generated layers in the composed stack.
 
 Over time, patterns that repeat in MDV (shared shape styling, common overlays) may move into `@spatialdata/vis` or `@spatialdata/layers`; v1 does not require that migration.
 
@@ -94,14 +97,14 @@ Optional later: MDV-only `PolygonLayer` built from exported geometry helpers; no
 
 ### Bespoke layer extension path
 
-- Primary extension for **state-owned** SpatialData layers: MDV-controlled `layers` + `layerOrder`
-- Primary extension for **fully custom** deck layers: `deckLayers` / `deckProps.layers` on `SpatialCanvasViewer`
-- Composition order: SpatialData-generated layers, then MDV `deckLayers`, with scale bar last (see `composeSpatialDeckLayers`)
+- Primary extension for **state-owned** SpatialData layers: MDV-controlled `renderStack.entries`
+- Primary extension for **fully custom** deck layers: host overlay entries plus `hostLayerResolver`
+- Composition order: canonical render-stack order, with unmanaged deck layers treated as compatibility output
 
 Practical checks for this branch:
 
-- [ ] MDV can drive a shapes layer only by updating `layers` props (no `SpatialCanvas` zustand store)
-- [ ] An MDV-style custom layer from `spatial_context.ts` can be supplied via `deckLayers` without importing `packages/vis/src/*` internals
+- [ ] MDV can drive a shapes layer only by updating render stack entry props (no `SpatialCanvas` zustand store)
+- [ ] An MDV-style custom layer from `spatial_context.ts` can be supplied through a host overlay resolver without importing `packages/vis/src/*` internals
 
 ## Release checklist (this branch)
 
@@ -135,11 +138,10 @@ Practical checks for this branch:
 
 - [x] `SpatialCanvasViewer` renders with externally controlled:
   - `coordinateSystem`
-  - `layers`
-  - `layerOrder`
+  - `renderStack`
   - `viewState`
-- [x] It composes caller deck layers above SpatialData-rendered layers.
-- [x] It allows MDV-owned tooltip flow (`renderTooltip={false}`, `onShapeHover`).
+- [x] It composes host overlays with SpatialData-rendered layers.
+- [x] It allows MDV-owned tooltip flow (`renderTooltip={false}`, `onFeatureHover`).
 - [x] It supports MDV-owned controller settings through `deckProps`.
 
 ### 3) MDV touchpoint checks

--- a/docs/docs/vis/overview.mdx
+++ b/docs/docs/vis/overview.mdx
@@ -23,6 +23,7 @@ semantics, see [Feature table associations and annotation columns](./feature-tab
 ## `@spatialdata/layers`
 
 - **`SpatialLayer`** `CompositeLayer` and versioned **`SpatialLayerProps`** (Zod + `schemaVersion` + **`migrateSpatialLayerProps`**).
+- The canonical home for **`RenderStack`** saved/render order, including SpatialData entries, host overlay descriptors, and reserved group entries.
 - The deck-native place for **sub**layers: image, scatter, shapes, points, contours — including future **GeoArrow / Parquet** paths for vectors. (Sublayer factories are still being wired; the schema and class are scaffolded.)
 - **No MobX**; plain TypeScript and deck APIs.
 
@@ -43,7 +44,7 @@ Details: [Layers package overview](../layers/overview).
 
 | Tier | Typical use |
 |------|-------------|
-| **Deck / SpatialLayer** | Non-React or custom `DeckGL` apps; versioned props |
+| **RenderStack / Deck / SpatialLayer** | Non-React or custom `DeckGL` apps; ordered stack, host overlay descriptors, versioned props |
 | **Headless avivatorish** | Loaders, cache, `getSingleSelectionStats` |
 | **Zustand + VivProvider** | MDV-style embeds |
 | **SpatialCanvas** | Batteries-included SpatialData React UI |

--- a/packages/layers/src/index.ts
+++ b/packages/layers/src/index.ts
@@ -49,3 +49,22 @@ export {
   migrateSpatialLayerProps,
   SPATIAL_LAYER_PROPS_SCHEMA_VERSION,
 } from './spatialLayerProps';
+export {
+  getRenderStackEntryIds,
+  getRenderStackHostLayerIds,
+  renderStackEntrySchema,
+  renderStackGroupEntrySchema,
+  renderStackHostEntrySchema,
+  renderStackSchema,
+  renderStackSpatialElementTypeSchema,
+  renderStackSpatialEntrySchema,
+  RENDER_STACK_SCHEMA_VERSION,
+} from './renderStack';
+export type {
+  RenderStack,
+  RenderStackEntry,
+  RenderStackGroupEntry,
+  RenderStackHostEntry,
+  RenderStackSpatialElementType,
+  RenderStackSpatialEntry,
+} from './renderStack';

--- a/packages/layers/src/renderStack.ts
+++ b/packages/layers/src/renderStack.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+/** Current serialized render-stack version; bump for breaking saved-stack changes. */
+export const RENDER_STACK_SCHEMA_VERSION = 1 as const;
+
+export const renderStackSpatialElementTypeSchema = z.enum([
+  'image',
+  'shapes',
+  'points',
+  'labels',
+]);
+
+const jsonishRecordSchema = z.record(z.string(), z.unknown()).default({});
+
+const renderStackEntryBaseSchema = z.object({
+  /** Stable logical id for saved config, UI rows, host overlays, and deck layer ordering. */
+  id: z.string().min(1),
+  /** Visibility is common stack state, independent of renderer-specific props. */
+  visible: z.boolean().optional().default(true),
+  /** Renderer props for this entry. Keep structural source identity out of this bag. */
+  props: jsonishRecordSchema.optional().default({}),
+});
+
+export const renderStackSpatialEntrySchema = renderStackEntryBaseSchema.extend({
+  kind: z.literal('spatial'),
+  source: z.object({
+    elementType: renderStackSpatialElementTypeSchema,
+    elementKey: z.string().min(1),
+    coordinateSystem: z.string().optional(),
+  }),
+});
+
+export const renderStackHostEntrySchema = renderStackEntryBaseSchema.extend({
+  kind: z.literal('host'),
+  source: z.object({
+    /** Host-owned stable descriptor, e.g. `deck:scatter` or `deck:selection`. */
+    hostLayerId: z.string().min(1),
+  }),
+});
+
+export const renderStackGroupEntrySchema = renderStackEntryBaseSchema.extend({
+  kind: z.literal('group'),
+  /**
+   * Reserved for future framebuffer/blending work. For now these are child entry
+   * ids rather than nested objects so flat saved stacks can migrate cheaply.
+   */
+  children: z.array(z.string().min(1)).optional().default([]),
+});
+
+export const renderStackEntrySchema = z.discriminatedUnion('kind', [
+  renderStackSpatialEntrySchema,
+  renderStackHostEntrySchema,
+  renderStackGroupEntrySchema,
+]);
+
+export const renderStackSchema = z.object({
+  schemaVersion: z.literal(RENDER_STACK_SCHEMA_VERSION).default(RENDER_STACK_SCHEMA_VERSION),
+  entries: z.array(renderStackEntrySchema).default([]),
+});
+
+export type RenderStackSpatialElementType = z.infer<typeof renderStackSpatialElementTypeSchema>;
+export type RenderStackSpatialEntry = z.infer<typeof renderStackSpatialEntrySchema>;
+export type RenderStackHostEntry = z.infer<typeof renderStackHostEntrySchema>;
+export type RenderStackGroupEntry = z.infer<typeof renderStackGroupEntrySchema>;
+export type RenderStackEntry = z.infer<typeof renderStackEntrySchema>;
+export type RenderStack = z.infer<typeof renderStackSchema>;
+
+export function getRenderStackEntryIds(renderStack: RenderStack): string[] {
+  return renderStack.entries.map((entry) => entry.id);
+}
+
+export function getRenderStackHostLayerIds(renderStack: RenderStack): string[] {
+  return renderStack.entries
+    .filter((entry): entry is RenderStackHostEntry => entry.kind === 'host')
+    .map((entry) => entry.source.hostLayerId);
+}

--- a/packages/layers/src/renderStack.ts
+++ b/packages/layers/src/renderStack.ts
@@ -12,30 +12,36 @@ export const renderStackSpatialElementTypeSchema = z.enum([
 
 const jsonishRecordSchema = z.record(z.string(), z.unknown()).default({});
 
-const renderStackEntryBaseSchema = z.object({
-  /** Stable logical id for saved config, UI rows, host overlays, and deck layer ordering. */
-  id: z.string().min(1),
-  /** Visibility is common stack state, independent of renderer-specific props. */
-  visible: z.boolean().optional().default(true),
-  /** Renderer props for this entry. Keep structural source identity out of this bag. */
-  props: jsonishRecordSchema.optional().default({}),
-});
+const renderStackEntryBaseSchema = z
+  .object({
+    /** Stable logical id for saved config, UI rows, host overlays, and deck layer ordering. */
+    id: z.string().min(1),
+    /** Visibility is common stack state, independent of renderer-specific props. */
+    visible: z.boolean().optional().default(true),
+    /** Renderer props for this entry. Keep structural source identity out of this bag. */
+    props: jsonishRecordSchema.optional().default({}),
+  })
+  .strict();
 
 export const renderStackSpatialEntrySchema = renderStackEntryBaseSchema.extend({
   kind: z.literal('spatial'),
-  source: z.object({
-    elementType: renderStackSpatialElementTypeSchema,
-    elementKey: z.string().min(1),
-    coordinateSystem: z.string().optional(),
-  }),
+  source: z
+    .object({
+      elementType: renderStackSpatialElementTypeSchema,
+      elementKey: z.string().min(1),
+      coordinateSystem: z.string().optional(),
+    })
+    .strict(),
 });
 
 export const renderStackHostEntrySchema = renderStackEntryBaseSchema.extend({
   kind: z.literal('host'),
-  source: z.object({
-    /** Host-owned stable descriptor, e.g. `deck:scatter` or `deck:selection`. */
-    hostLayerId: z.string().min(1),
-  }),
+  source: z
+    .object({
+      /** Host-owned stable descriptor, e.g. `deck:scatter` or `deck:selection`. */
+      hostLayerId: z.string().min(1),
+    })
+    .strict(),
 });
 
 export const renderStackGroupEntrySchema = renderStackEntryBaseSchema.extend({
@@ -53,10 +59,33 @@ export const renderStackEntrySchema = z.discriminatedUnion('kind', [
   renderStackGroupEntrySchema,
 ]);
 
-export const renderStackSchema = z.object({
-  schemaVersion: z.literal(RENDER_STACK_SCHEMA_VERSION).default(RENDER_STACK_SCHEMA_VERSION),
-  entries: z.array(renderStackEntrySchema).default([]),
-});
+export const renderStackSchema = z
+  .object({
+    schemaVersion: z.literal(RENDER_STACK_SCHEMA_VERSION).default(RENDER_STACK_SCHEMA_VERSION),
+    entries: z.array(renderStackEntrySchema).default([]),
+  })
+  .strict()
+  .superRefine((renderStack, ctx) => {
+    const seen = new Set<string>();
+    const duplicateIds = new Set<string>();
+
+    for (const entry of renderStack.entries) {
+      if (seen.has(entry.id)) {
+        duplicateIds.add(entry.id);
+      }
+      seen.add(entry.id);
+    }
+
+    if (duplicateIds.size > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['entries'],
+        message: `Render stack entry ids must be unique; duplicate ids: ${Array.from(
+          duplicateIds
+        ).join(', ')}`,
+      });
+    }
+  });
 
 export type RenderStackSpatialElementType = z.infer<typeof renderStackSpatialElementTypeSchema>;
 export type RenderStackSpatialEntry = z.infer<typeof renderStackSpatialEntrySchema>;

--- a/packages/layers/tests/renderStack.spec.ts
+++ b/packages/layers/tests/renderStack.spec.ts
@@ -46,6 +46,57 @@ describe('renderStackSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('rejects duplicate stack entry ids', () => {
+    const result = renderStackSchema.safeParse({
+      entries: [
+        {
+          kind: 'spatial',
+          id: 'labels-cells',
+          source: { elementType: 'labels', elementKey: 'cells' },
+        },
+        {
+          kind: 'host',
+          id: 'labels-cells',
+          source: { hostLayerId: 'deck:selection' },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]).toMatchObject({
+        path: ['entries'],
+        message: 'Render stack entry ids must be unique; duplicate ids: labels-cells',
+      });
+    }
+  });
+
+  it('rejects unknown keys outside renderer props', () => {
+    const result = renderStackSchema.safeParse({
+      unexpected: true,
+      entries: [
+        {
+          kind: 'spatial',
+          id: 'labels-cells',
+          source: {
+            elementType: 'labels',
+            elementKey: 'cells',
+            unexpected: true,
+          },
+          unexpected: true,
+          props: { extensionProp: true },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path.join('.'))).toEqual(
+        expect.arrayContaining(['', 'entries.0', 'entries.0.source'])
+      );
+    }
+  });
 });
 
 describe('render-stack entry schemas', () => {

--- a/packages/layers/tests/renderStack.spec.ts
+++ b/packages/layers/tests/renderStack.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRenderStackEntryIds,
+  getRenderStackHostLayerIds,
+  RENDER_STACK_SCHEMA_VERSION,
+  renderStackGroupEntrySchema,
+  renderStackHostEntrySchema,
+  renderStackSchema,
+  renderStackSpatialEntrySchema,
+} from '../src/renderStack';
+
+describe('renderStackSchema', () => {
+  it('parses current render stacks', () => {
+    const stack = renderStackSchema.parse({
+      schemaVersion: RENDER_STACK_SCHEMA_VERSION,
+      entries: [
+        {
+          kind: 'spatial',
+          id: 'image-morphology',
+          source: { elementType: 'image', elementKey: 'morphology_focus' },
+          props: { opacity: 0.5 },
+        },
+        {
+          kind: 'host',
+          id: 'deck:scatter',
+          source: { hostLayerId: 'deck:scatter' },
+        },
+      ],
+    });
+
+    expect(stack.entries.map((entry) => entry.id)).toEqual(['image-morphology', 'deck:scatter']);
+    expect(stack.entries[0]).toMatchObject({
+      kind: 'spatial',
+      source: { elementType: 'image', elementKey: 'morphology_focus' },
+      props: { opacity: 0.5 },
+    });
+  });
+
+  it('rejects invalid current entries instead of migrating them', () => {
+    const result = renderStackSchema.safeParse({
+      entries: [
+        { kind: 'host', id: 'deck:gates', source: { hostLayerId: 'deck:gates' } },
+        { kind: 'spatial', id: 'bad', source: { elementType: 'not-real', elementKey: 'x' } },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('render-stack entry schemas', () => {
+  it('validates spatial entries with structural source separate from props', () => {
+    const parsed = renderStackSpatialEntrySchema.parse({
+      kind: 'spatial',
+      id: 'shapes-cells',
+      source: { elementType: 'shapes', elementKey: 'cell_boundaries' },
+      props: {
+        opacity: 1,
+        featureState: { hiddenFeatureIds: ['cell-1'] },
+      },
+    });
+
+    expect(parsed.source.elementKey).toBe('cell_boundaries');
+    expect(parsed.props.featureState).toEqual({ hiddenFeatureIds: ['cell-1'] });
+  });
+
+  it('validates host overlays as descriptors instead of deck layer instances', () => {
+    const parsed = renderStackHostEntrySchema.parse({
+      kind: 'host',
+      id: 'deck:scatter',
+      source: { hostLayerId: 'deck:scatter' },
+      props: { opacity: 0.8 },
+    });
+
+    expect(parsed.source.hostLayerId).toBe('deck:scatter');
+  });
+
+  it('reserves group entries with ordered child ids', () => {
+    const parsed = renderStackGroupEntrySchema.parse({
+      kind: 'group',
+      id: 'group:blend',
+      children: ['image-morphology', 'labels-cells'],
+      props: { blendMode: 'reserved' },
+    });
+
+    expect(parsed.children).toEqual(['image-morphology', 'labels-cells']);
+  });
+
+  it('returns stack entry and host ids in canonical order', () => {
+    const stack = renderStackSchema.parse({
+      entries: [
+        { kind: 'host', id: 'deck:scatter', source: { hostLayerId: 'deck:scatter' } },
+        {
+          kind: 'spatial',
+          id: 'labels-cells',
+          source: { elementType: 'labels', elementKey: 'cells' },
+        },
+        { kind: 'host', id: 'deck:selection', source: { hostLayerId: 'deck:selection' } },
+      ],
+    });
+
+    expect(getRenderStackEntryIds(stack)).toEqual(['deck:scatter', 'labels-cells', 'deck:selection']);
+    expect(getRenderStackHostLayerIds(stack)).toEqual(['deck:scatter', 'deck:selection']);
+  });
+});

--- a/packages/vis/demo/src/CodecFixtureDemo.tsx
+++ b/packages/vis/demo/src/CodecFixtureDemo.tsx
@@ -1,7 +1,12 @@
 import { SpatialDataProvider, useSpatialData } from '@spatialdata/react';
 import { useEffect, useMemo, useState } from 'react';
-import { type LayerConfig, SpatialCanvas, SpatialCanvasViewer, type ViewState } from '../../src/index';
-import { buildHeadlessLayersForCoordinateSystem } from './buildHeadlessLayers';
+import {
+  type RenderStack,
+  SpatialCanvas,
+  SpatialCanvasViewer,
+  type ViewState,
+} from '../../src/index';
+import { buildHeadlessRenderStackForCoordinateSystem } from './buildHeadlessLayers';
 import {
   getLocalHtj2kEncodeDemoFixtureUrl,
   getLocalHtj2kEncodeDemoManifestUrl,
@@ -110,8 +115,7 @@ function HeadlessCodecFixtureViewer({
   const { spatialData, loading, error } = useSpatialData();
   const coordinateSystems = useMemo(() => spatialData?.coordinateSystems ?? [], [spatialData]);
   const [coordinateSystem, setCoordinateSystem] = useState<string | null>(null);
-  const [layers, setLayers] = useState<Record<string, LayerConfig>>({});
-  const [layerOrder, setLayerOrder] = useState<string[]>([]);
+  const [renderStack, setRenderStack] = useState<RenderStack>({ schemaVersion: 1, entries: [] });
   const [viewState, setViewState] = useState<ViewState | null>(null);
 
   useEffect(() => {
@@ -125,9 +129,7 @@ function HeadlessCodecFixtureViewer({
     if (!spatialData || !coordinateSystem) {
       return;
     }
-    const built = buildHeadlessLayersForCoordinateSystem(spatialData, coordinateSystem);
-    setLayers(built.layers);
-    setLayerOrder(built.layerOrder);
+    setRenderStack(buildHeadlessRenderStackForCoordinateSystem(spatialData, coordinateSystem));
     setViewState(null);
   }, [spatialData, coordinateSystem]);
 
@@ -136,15 +138,23 @@ function HeadlessCodecFixtureViewer({
     if (error) return `Failed to load ${fixtureConfig.label} fixture: ${error.message}`;
     if (!spatialData) return 'No SpatialData loaded.';
     if (!coordinateSystem) return 'No coordinate system available.';
-    if (layerOrder.length === 0) return 'No layers in this coordinate system.';
+    if (renderStack.entries.length === 0) return 'No layers in this coordinate system.';
     return null;
-  }, [loading, error, spatialData, coordinateSystem, layerOrder.length, fixtureConfig.label]);
+  }, [
+    loading,
+    error,
+    spatialData,
+    coordinateSystem,
+    renderStack.entries.length,
+    fixtureConfig.label,
+  ]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
       <div style={panelStyle}>
         <div style={{ color: '#888', marginBottom: 6 }}>
-          Codec fixture <code>SpatialCanvasViewer</code> - local <code>{fixtureConfig.storeName}</code>
+          Codec fixture <code>SpatialCanvasViewer</code> - local{' '}
+          <code>{fixtureConfig.storeName}</code>
         </div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginBottom: 8 }}>
           <a href={fixtureUrl} style={{ color: '#8af' }}>
@@ -160,7 +170,7 @@ function HeadlessCodecFixtureViewer({
             Coordinate system: <code>{coordinateSystem ?? '-'}</code>
           </span>
           <span style={{ color: '#aaa' }}>
-            Layers: <code>{layerOrder.length}</code>
+            Layers: <code>{renderStack.entries.length}</code>
           </span>
         </div>
         {error ? (
@@ -189,8 +199,7 @@ function HeadlessCodecFixtureViewer({
           <SpatialCanvasViewer
             spatialData={spatialData}
             coordinateSystem={coordinateSystem}
-            layers={layers}
-            layerOrder={layerOrder}
+            renderStack={renderStack}
             viewState={viewState}
             onViewStateChange={setViewState}
             renderTooltip={false}
@@ -269,7 +278,8 @@ function Htj2kEncodeDemoPanel({
   return (
     <div style={panelStyle}>
       <div style={{ color: '#888', marginBottom: 6 }}>
-        HTJ2K encode demo <code>SpatialCanvas</code> - local <code>{htj2kDemo?.store ?? 'htj2k-demo.zarr'}</code>
+        HTJ2K encode demo <code>SpatialCanvas</code> - local{' '}
+        <code>{htj2kDemo?.store ?? 'htj2k-demo.zarr'}</code>
       </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginBottom: 8 }}>
         <a href={fixtureUrl} style={{ color: '#8af' }}>
@@ -319,7 +329,9 @@ function Htj2kEncodeDemoPanel({
                 <td style={{ padding: '4px 8px' }}>{variant.label}</td>
                 <td style={{ padding: '4px 8px' }}>{formatBytes(variant.encoded_bytes)}</td>
                 <td style={{ padding: '4px 8px' }}>
-                  {variant.compression_ratio != null ? `${variant.compression_ratio.toFixed(1)}×` : '-'}
+                  {variant.compression_ratio != null
+                    ? `${variant.compression_ratio.toFixed(1)}×`
+                    : '-'}
                 </td>
               </tr>
             ))}
@@ -427,7 +439,11 @@ export default function CodecFixtureDemo() {
       </div>
       {fixtureKind === 'htj2k' ? (
         <SpatialDataProvider source={fixtureUrl}>
-          <Htj2kEncodeDemoPanel fixtureUrl={fixtureUrl} manifestUrl={manifestUrl} htj2kDemo={htj2kDemo} />
+          <Htj2kEncodeDemoPanel
+            fixtureUrl={fixtureUrl}
+            manifestUrl={manifestUrl}
+            htj2kDemo={htj2kDemo}
+          />
           <div style={viewerShellStyle}>
             <SpatialCanvas />
           </div>

--- a/packages/vis/demo/src/HeadlessBlobsDemo.tsx
+++ b/packages/vis/demo/src/HeadlessBlobsDemo.tsx
@@ -132,8 +132,8 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
           >
             {JSON.stringify(
               {
-                elementType: lastFeatureHover.elementType,
-                elementKey: lastFeatureHover.elementKey,
+                elementKind: lastFeatureHover.elementKind,
+                elementKey: lastFeatureHover.element.key,
                 featureId: lastFeatureHover.featureId,
                 rowIndex: lastFeatureHover.rowIndex,
               },
@@ -175,6 +175,11 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
             onViewStateChange={setViewState}
             renderTooltip={false}
             onFeatureHover={setLastFeatureHover}
+            onFeatureClick={(event) => {
+              if (event.elementKind !== 'labels') return;
+              if (event.element.key !== 'blobs_labels') return;
+              console.log(event.labelId, event.element);
+            }}
             style={{ width: '100%', height: '100%' }}
           />
         )}

--- a/packages/vis/demo/src/HeadlessBlobsDemo.tsx
+++ b/packages/vis/demo/src/HeadlessBlobsDemo.tsx
@@ -133,7 +133,7 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
             {JSON.stringify(
               {
                 elementKind: lastFeatureHover.elementKind,
-                elementKey: lastFeatureHover.element.key,
+                elementKey: lastFeatureHover.spatialElement.key,
                 featureId: lastFeatureHover.featureId,
                 rowIndex: lastFeatureHover.rowIndex,
               },
@@ -177,8 +177,8 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
             onFeatureHover={setLastFeatureHover}
             onFeatureClick={(event) => {
               if (event.elementKind !== 'labels') return;
-              if (event.element.key !== 'blobs_labels') return;
-              console.log(event.labelId, event.element);
+              if (event.spatialElement.key !== 'blobs_labels') return;
+              console.log(event.labelId, event.spatialElement);
             }}
             style={{ width: '100%', height: '100%' }}
           />

--- a/packages/vis/demo/src/HeadlessBlobsDemo.tsx
+++ b/packages/vis/demo/src/HeadlessBlobsDemo.tsx
@@ -1,8 +1,12 @@
 import { SpatialDataProvider, useSpatialData } from '@spatialdata/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { SpatialCanvasViewer, type LayerConfig, type ViewState } from '../../src/index';
-import type { ShapesLayerPickEvent } from '../../src/SpatialCanvas/types';
-import { buildHeadlessLayersForCoordinateSystem } from './buildHeadlessLayers';
+import {
+  SpatialCanvasViewer,
+  type RenderStack,
+  type SpatialFeaturePickEvent,
+  type ViewState,
+} from '../../src/index';
+import { buildHeadlessRenderStackForCoordinateSystem } from './buildHeadlessLayers';
 import { getLocalBlobsFixtureUrl } from './fixtureUrls';
 
 const panelStyle = {
@@ -22,14 +26,13 @@ const viewerShellStyle = {
 function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
   const { spatialData, loading, error } = useSpatialData();
   const coordinateSystems = useMemo(() => spatialData?.coordinateSystems ?? [], [spatialData]);
-  const tables = spatialData?.getAssociatedTables("shapes", "blobs_multipolygons");
-  console.log(tables);
+  // const tables = spatialData?.getAssociatedTables("shapes", "blobs_multipolygons");
+  // console.log(tables);
 
   const [coordinateSystem, setCoordinateSystem] = useState<string | null>(null);
-  const [layers, setLayers] = useState<Record<string, LayerConfig>>({});
-  const [layerOrder, setLayerOrder] = useState<string[]>([]);
+  const [renderStack, setRenderStack] = useState<RenderStack>({ schemaVersion: 1, entries: [] });
   const [viewState, setViewState] = useState<ViewState | null>(null);
-  const [lastShapeHover, setLastShapeHover] = useState<ShapesLayerPickEvent | null>(null);
+  const [lastFeatureHover, setLastFeatureHover] = useState<SpatialFeaturePickEvent | null>(null);
 
   useEffect(() => {
     if (!spatialData || coordinateSystems.length === 0) {
@@ -42,18 +45,17 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
     if (!spatialData || !coordinateSystem) {
       return;
     }
-    const built = buildHeadlessLayersForCoordinateSystem(spatialData, coordinateSystem);
-    setLayers(built.layers);
-    setLayerOrder(built.layerOrder);
+    setRenderStack(buildHeadlessRenderStackForCoordinateSystem(spatialData, coordinateSystem));
     setViewState(null);
   }, [spatialData, coordinateSystem]);
 
   const toggleLayerVisibility = useCallback((layerId: string) => {
-    setLayers((prev) => {
-      const existing = prev[layerId];
-      if (!existing) return prev;
-      return { ...prev, [layerId]: { ...existing, visible: !existing.visible } };
-    });
+    setRenderStack((prev) => ({
+      ...prev,
+      entries: prev.entries.map((entry) =>
+        entry.id === layerId ? { ...entry, visible: !entry.visible } : entry
+      ),
+    }));
   }, []);
 
   const statusMessage = useMemo(() => {
@@ -61,16 +63,15 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
     if (error) return `Failed to load fixture: ${error.message}`;
     if (!spatialData) return 'No SpatialData loaded.';
     if (!coordinateSystem) return 'No coordinate system available.';
-    if (layerOrder.length === 0) return 'No layers in this coordinate system.';
+    if (renderStack.entries.length === 0) return 'No layers in this coordinate system.';
     return null;
-  }, [loading, error, spatialData, coordinateSystem, layerOrder.length]);
+  }, [loading, error, spatialData, coordinateSystem, renderStack.entries.length]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
       <div style={panelStyle}>
         <div style={{ color: '#888', marginBottom: 6 }}>
-          Headless <code>SpatialCanvasViewer</code> — local{' '}
-          <code>blobs.zarr</code> (v0.7.2)
+          Headless <code>SpatialCanvasViewer</code> — local <code>blobs.zarr</code> (v0.7.2)
         </div>
         <div style={{ marginBottom: 8, wordBreak: 'break-all' }}>
           <span style={{ color: '#666' }}>Fixture: </span>
@@ -97,28 +98,27 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
             Coordinate system: <code>{coordinateSystem ?? '—'}</code>
           </div>
         )}
-        {layerOrder.length > 0 ? (
+        {renderStack.entries.length > 0 ? (
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
             <span style={{ color: '#999' }}>Layers</span>
-            {layerOrder.map((layerId) => {
-              const config = layers[layerId];
-              if (!config) return null;
+            {renderStack.entries.map((entry) => {
+              if (entry.kind !== 'spatial') return null;
               return (
-                <label key={layerId} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <label key={entry.id} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                   <input
                     type="checkbox"
-                    checked={config.visible}
-                    onChange={() => toggleLayerVisibility(layerId)}
+                    checked={entry.visible}
+                    onChange={() => toggleLayerVisibility(entry.id)}
                   />
                   <span>
-                    {config.type}:{config.elementKey}
+                    {entry.source.elementType}:{entry.source.elementKey}
                   </span>
                 </label>
               );
             })}
           </div>
         ) : null}
-        {lastShapeHover ? (
+        {lastFeatureHover ? (
           <pre
             style={{
               marginTop: 8,
@@ -132,9 +132,10 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
           >
             {JSON.stringify(
               {
-                featureId: lastShapeHover.featureId,
-                featureIndex: lastShapeHover.featureIndex,
-                rowIndex: lastShapeHover.rowIndex,
+                elementType: lastFeatureHover.elementType,
+                elementKey: lastFeatureHover.elementKey,
+                featureId: lastFeatureHover.featureId,
+                rowIndex: lastFeatureHover.rowIndex,
               },
               null,
               2
@@ -159,11 +160,9 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
             {statusMessage}
             {error ? (
               <div style={{ marginTop: 12, fontSize: 11, color: '#a88' }}>
-                Ensure fixtures exist:{' '}
-                <code>pnpm test:fixtures:generate:0.7.2</code>
+                Ensure fixtures exist: <code>pnpm test:fixtures:generate:0.7.2</code>
                 <br />
-                The dev script also starts a fixture server proxied at{' '}
-                <code>/test-fixtures</code>.
+                The dev script also starts a fixture server proxied at <code>/test-fixtures</code>.
               </div>
             ) : null}
           </div>
@@ -171,12 +170,11 @@ function HeadlessBlobsViewer({ fixtureUrl }: { fixtureUrl: string }) {
           <SpatialCanvasViewer
             spatialData={spatialData}
             coordinateSystem={coordinateSystem}
-            layers={layers}
-            layerOrder={layerOrder}
+            renderStack={renderStack}
             viewState={viewState}
             onViewStateChange={setViewState}
             renderTooltip={false}
-            onShapeHover={setLastShapeHover}
+            onFeatureHover={setLastFeatureHover}
             style={{ width: '100%', height: '100%' }}
           />
         )}

--- a/packages/vis/demo/src/buildHeadlessLayers.ts
+++ b/packages/vis/demo/src/buildHeadlessLayers.ts
@@ -1,8 +1,8 @@
 import type { SpatialData } from '@spatialdata/core';
-import type { LayerConfig, LayerType } from '../../src/SpatialCanvas/types';
+import type { RenderStack, RenderStackSpatialElementType } from '../../src/index';
 import { generateLayerId, getAvailableElements } from '../../src/SpatialCanvas/utils';
 
-const STACK_ORDER: LayerType[] = ['image', 'labels', 'shapes', 'points'];
+const STACK_ORDER: RenderStackSpatialElementType[] = ['image', 'labels', 'shapes', 'points'];
 
 const COLLECTION_BY_TYPE = {
   image: 'images',
@@ -11,42 +11,40 @@ const COLLECTION_BY_TYPE = {
   points: 'points',
 } as const;
 
-export function buildHeadlessLayersForCoordinateSystem(
+export function buildHeadlessRenderStackForCoordinateSystem(
   spatialData: SpatialData,
   coordinateSystem: string
-): { layers: Record<string, LayerConfig>; layerOrder: string[] } {
+): RenderStack {
   const available = getAvailableElements(spatialData, coordinateSystem);
-  const layers: Record<string, LayerConfig> = {};
-  const layerOrder: string[] = [];
+  const entries: RenderStack['entries'] = [];
 
   for (const type of STACK_ORDER) {
     const collection = COLLECTION_BY_TYPE[type];
     for (const element of available[collection]) {
       const layerId = generateLayerId(element.type, element.key);
-      const base = {
+      entries.push({
+        kind: 'spatial',
         id: layerId,
-        elementKey: element.key,
         visible: true,
-        opacity: 1,
-      };
-      // in future we might have some more type-helpers
-      const config: LayerConfig =
-        type === 'shapes'
-          ? {
-              ...base,
-              type: 'shapes',
-              fillColor: [70, 130, 180, 180],
-              strokeColor: [255, 255, 255, 220],
-              strokeWidth: 1,
-            }
-          : {
-              ...base,
-              type,
-            };
-      layers[layerId] = config;
-      layerOrder.push(layerId);
+        source: {
+          elementType: type,
+          elementKey: element.key,
+          coordinateSystem,
+        },
+        props:
+          type === 'shapes'
+            ? {
+                opacity: 1,
+                fillColor: [70, 130, 180, 180],
+                strokeColor: [255, 255, 255, 220],
+                strokeWidth: 1,
+              }
+            : {
+                opacity: 1,
+              },
+      });
     }
   }
 
-  return { layers, layerOrder };
+  return { schemaVersion: 1, entries };
 }

--- a/packages/vis/demo/tsconfig.json
+++ b/packages/vis/demo/tsconfig.json
@@ -17,8 +17,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
 
     "paths": {

--- a/packages/vis/src/SpatialCanvas/SpatialCanvasViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/SpatialCanvasViewer.tsx
@@ -30,17 +30,30 @@ import {
   type UnknownRenderStackHostLayerHandler,
 } from './renderStackAdapters';
 import type { ElementsByType, LayerConfig, ShapesLayerPickEvent, ViewState } from './types';
-import { type SpatialFeaturePickEventData, useLayerData } from './useLayerData';
+import {
+  type LabelFeaturePickEventData,
+  type ShapeFeaturePickEventData,
+  useLayerData,
+} from './useLayerData';
 import { getAvailableElements } from './utils';
 
 export type SpatialCanvasViewerRenderTooltip =
   | false
   | ((props: SpatialCanvasTooltipRenderProps) => ReactNode);
 
-export type SpatialFeaturePickEvent = SpatialFeaturePickEventData & {
+type SpatialFeaturePickEventRuntimeFields = {
   coordinateSystem: string | null;
+  spatialData?: SpatialData | null;
   pickInfo: PickingInfo;
 };
+
+export type ShapesSpatialFeaturePickEvent = ShapeFeaturePickEventData &
+  SpatialFeaturePickEventRuntimeFields;
+
+export type LabelsSpatialFeaturePickEvent = LabelFeaturePickEventData &
+  SpatialFeaturePickEventRuntimeFields;
+
+export type SpatialFeaturePickEvent = ShapesSpatialFeaturePickEvent | LabelsSpatialFeaturePickEvent;
 
 export interface SpatialCanvasViewerProps {
   spatialData?: SpatialData | null;
@@ -188,13 +201,7 @@ export function useSpatialCanvasRendererFromLayerInputs({
       ...(externalDeckLayers ?? []),
     ]);
     return sortDeckLayers ? sortLayersByRenderStackOrder(composed, resolvedLayerOrder) : composed;
-  }, [
-    externalDeckLayers,
-    generatedDeckLayers,
-    hostDeckLayers,
-    resolvedLayerOrder,
-    sortDeckLayers,
-  ]);
+  }, [externalDeckLayers, generatedDeckLayers, hostDeckLayers, resolvedLayerOrder, sortDeckLayers]);
   const vivLayerProps = layerData.getVivLayerProps();
 
   const enabledLayerIds = useMemo(() => {
@@ -401,6 +408,7 @@ function SpatialCanvasViewerInner({
         onFeatureHover?.({
           ...featurePickEvent,
           coordinateSystem,
+          spatialData,
           pickInfo: info,
         });
       }
@@ -434,6 +442,7 @@ function SpatialCanvasViewerInner({
       onShapeHover,
       renderTooltip,
       renderer,
+      spatialData,
     ]
   );
 
@@ -453,6 +462,7 @@ function SpatialCanvasViewerInner({
         onFeatureClick?.({
           ...featurePickEvent,
           coordinateSystem,
+          spatialData,
           pickInfo: info,
         });
       }
@@ -468,7 +478,7 @@ function SpatialCanvasViewerInner({
         });
       }
     },
-    [coordinateSystem, onClick, onFeatureClick, onShapeClick, renderer]
+    [coordinateSystem, onClick, onFeatureClick, onShapeClick, renderer, spatialData]
   );
 
   const handleViewerRef = useCallback(

--- a/packages/vis/src/SpatialCanvas/SpatialCanvasViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/SpatialCanvasViewer.tsx
@@ -1,4 +1,5 @@
 import { type SpatialData, viewStateFromBounds } from '@spatialdata/core';
+import type { RenderStack } from '@spatialdata/layers';
 import { useMeasure } from '@uidotdev/usehooks';
 import type { DeckGLProps, DeckGLRef, Layer, PickingInfo } from 'deck.gl';
 import {
@@ -19,6 +20,14 @@ import {
 import { SpatialViewer } from './SpatialViewer';
 import { VivLoaderRegistryProvider } from './VivLoaderRegistry';
 import { getDeckFromDeckGlRef, resolveHoverFeatureTooltip } from './featureTooltipHover';
+import {
+  renderStackOrder,
+  renderStackToLayerInputs,
+  resolveRenderStackHostLayers,
+  sortLayersByRenderStackOrder,
+  type RenderStackHostLayerResolver,
+  type UnknownRenderStackHostLayerHandler,
+} from './renderStackAdapters';
 import type { ElementsByType, LayerConfig, ShapesLayerPickEvent, ViewState } from './types';
 import { useLayerData } from './useLayerData';
 import { getAvailableElements } from './utils';
@@ -30,10 +39,16 @@ export type SpatialCanvasViewerRenderTooltip =
 export interface SpatialCanvasViewerProps {
   spatialData?: SpatialData | null;
   coordinateSystem: string | null;
-  layers: Record<string, LayerConfig>;
-  layerOrder: string[];
+  renderStack?: RenderStack;
+  /** @deprecated Prefer `renderStack.entries`. */
+  layers?: Record<string, LayerConfig>;
+  /** @deprecated Prefer `renderStack.entries`. */
+  layerOrder?: string[];
   viewState: ViewState | null;
   onViewStateChange: (viewState: ViewState) => void;
+  hostLayerResolver?: RenderStackHostLayerResolver;
+  onUnknownHostLayer?: UnknownRenderStackHostLayerHandler;
+  /** @deprecated Prefer host entries with `hostLayerResolver`. */
   deckLayers?: Layer[];
   deckProps?: Partial<DeckGLProps>;
   onHover?: (info: PickingInfo) => void;
@@ -93,8 +108,11 @@ export function shouldRenderInternalTooltip(
 export interface UseSpatialCanvasRendererOptions {
   spatialData?: SpatialData | null;
   coordinateSystem: string | null;
-  layers: Record<string, LayerConfig>;
-  layerOrder: string[];
+  renderStack?: RenderStack;
+  /** @deprecated Prefer `renderStack.entries`. */
+  layers?: Record<string, LayerConfig>;
+  /** @deprecated Prefer `renderStack.entries`. */
+  layerOrder?: string[];
   /**
    * Current view state.  When `undefined` the auto-fit effect is skipped
    * entirely, letting the caller manage auto-fit externally (e.g. in a
@@ -108,6 +126,9 @@ export interface UseSpatialCanvasRendererOptions {
   onViewStateChange?: (viewState: ViewState) => void;
   width: number;
   height: number;
+  hostLayerResolver?: RenderStackHostLayerResolver;
+  onUnknownHostLayer?: UnknownRenderStackHostLayerHandler;
+  /** @deprecated Prefer host entries with `hostLayerResolver`. */
   deckLayers?: Layer[];
   autoFit?: boolean;
 }
@@ -115,12 +136,15 @@ export interface UseSpatialCanvasRendererOptions {
 export function useSpatialCanvasRenderer({
   spatialData,
   coordinateSystem,
+  renderStack,
   layers,
   layerOrder,
   viewState,
   onViewStateChange,
   width,
   height,
+  hostLayerResolver,
+  onUnknownHostLayer,
   deckLayers: externalDeckLayers,
   autoFit = true,
 }: UseSpatialCanvasRendererOptions) {
@@ -131,26 +155,46 @@ export function useSpatialCanvasRenderer({
     return getAvailableElements(spatialData, coordinateSystem);
   }, [spatialData, coordinateSystem]);
 
+  const layerInputs = useMemo(() => {
+    if (renderStack) {
+      return renderStackToLayerInputs(renderStack);
+    }
+    return { layers: layers ?? {}, layerOrder: layerOrder ?? [] };
+  }, [layerOrder, layers, renderStack]);
+
+  const hostDeckLayers = useMemo(
+    () => resolveRenderStackHostLayers(renderStack, hostLayerResolver, onUnknownHostLayer),
+    [hostLayerResolver, onUnknownHostLayer, renderStack]
+  );
+
+  const resolvedLayerOrder = useMemo(
+    () => renderStackOrder(renderStack, layerInputs.layerOrder),
+    [layerInputs.layerOrder, renderStack]
+  );
+
   const layerData = useLayerData(
-    layers,
-    layerOrder,
+    layerInputs.layers,
+    layerInputs.layerOrder,
     availableElements,
     coordinateSystem,
     spatialData ?? undefined
   );
 
   const generatedDeckLayers = layerData.getLayers();
-  const deckLayers = useMemo(
-    () => composeSpatialDeckLayers(generatedDeckLayers, externalDeckLayers),
-    [generatedDeckLayers, externalDeckLayers]
-  );
+  const deckLayers = useMemo(() => {
+    const composed = composeSpatialDeckLayers(generatedDeckLayers, [
+      ...hostDeckLayers,
+      ...(externalDeckLayers ?? []),
+    ]);
+    return renderStack ? sortLayersByRenderStackOrder(composed, resolvedLayerOrder) : composed;
+  }, [externalDeckLayers, generatedDeckLayers, hostDeckLayers, renderStack, resolvedLayerOrder]);
   const vivLayerProps = layerData.getVivLayerProps();
 
   const enabledLayerIds = useMemo(() => {
-    return new Set(layerOrder.filter((id) => layers[id]?.visible));
-  }, [layers, layerOrder]);
+    return new Set(layerInputs.layerOrder.filter((id) => layerInputs.layers[id]?.visible));
+  }, [layerInputs.layerOrder, layerInputs.layers]);
   const hasEnabledLayers = enabledLayerIds.size > 0;
-  const hasExternalDeckLayers = (externalDeckLayers?.length ?? 0) > 0;
+  const hasExternalDeckLayers = (externalDeckLayers?.length ?? 0) > 0 || hostDeckLayers.length > 0;
   const hasRenderableInputs = hasEnabledLayers || hasExternalDeckLayers;
   const hasLayersDrawn = deckLayers.length > 0 || vivLayerProps.length > 0;
 
@@ -194,6 +238,7 @@ export function useSpatialCanvasRenderer({
     hasExternalDeckLayers,
     hasLayersDrawn,
     hasRenderableInputs,
+    layerOrder: resolvedLayerOrder,
     vivLayerProps,
   };
 }
@@ -230,10 +275,13 @@ const overlayStyle: CSSProperties = {
 function SpatialCanvasViewerInner({
   spatialData,
   coordinateSystem,
+  renderStack,
   layers,
   layerOrder,
   viewState,
   onViewStateChange,
+  hostLayerResolver,
+  onUnknownHostLayer,
   deckLayers: externalDeckLayers,
   deckProps,
   onHover,
@@ -259,12 +307,15 @@ function SpatialCanvasViewerInner({
   const renderer = useSpatialCanvasRenderer({
     spatialData,
     coordinateSystem,
+    renderStack,
     layers,
     layerOrder,
     viewState,
     onViewStateChange,
     width: vw,
     height: vh,
+    hostLayerResolver,
+    onUnknownHostLayer,
     deckLayers: externalDeckLayers,
     autoFit,
   });
@@ -402,7 +453,7 @@ function SpatialCanvasViewerInner({
               viewState={viewState}
               onViewStateChange={onViewStateChange}
               layers={renderer.deckLayers}
-              layerOrder={layerOrder}
+              layerOrder={renderer.layerOrder}
               vivLayerProps={renderer.vivLayerProps.length > 0 ? renderer.vivLayerProps : undefined}
               onHover={handleHover}
               onClick={handleClick}

--- a/packages/vis/src/SpatialCanvas/SpatialCanvasViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/SpatialCanvasViewer.tsx
@@ -26,15 +26,21 @@ import {
   resolveRenderStackHostLayers,
   sortLayersByRenderStackOrder,
   type RenderStackHostLayerResolver,
+  type RenderStackLayerInputs,
   type UnknownRenderStackHostLayerHandler,
 } from './renderStackAdapters';
 import type { ElementsByType, LayerConfig, ShapesLayerPickEvent, ViewState } from './types';
-import { useLayerData } from './useLayerData';
+import { type SpatialFeaturePickEventData, useLayerData } from './useLayerData';
 import { getAvailableElements } from './utils';
 
 export type SpatialCanvasViewerRenderTooltip =
   | false
   | ((props: SpatialCanvasTooltipRenderProps) => ReactNode);
+
+export type SpatialFeaturePickEvent = SpatialFeaturePickEventData & {
+  coordinateSystem: string | null;
+  pickInfo: PickingInfo;
+};
 
 export interface SpatialCanvasViewerProps {
   spatialData?: SpatialData | null;
@@ -53,6 +59,8 @@ export interface SpatialCanvasViewerProps {
   deckProps?: Partial<DeckGLProps>;
   onHover?: (info: PickingInfo) => void;
   onClick?: (info: PickingInfo) => void;
+  onFeatureHover?: (event: SpatialFeaturePickEvent) => void;
+  onFeatureClick?: (event: SpatialFeaturePickEvent) => void;
   onShapeHover?: (event: ShapesLayerPickEvent) => void;
   onShapeClick?: (event: ShapesLayerPickEvent) => void;
   renderTooltip?: SpatialCanvasViewerRenderTooltip;
@@ -108,11 +116,7 @@ export function shouldRenderInternalTooltip(
 export interface UseSpatialCanvasRendererOptions {
   spatialData?: SpatialData | null;
   coordinateSystem: string | null;
-  renderStack?: RenderStack;
-  /** @deprecated Prefer `renderStack.entries`. */
-  layers?: Record<string, LayerConfig>;
-  /** @deprecated Prefer `renderStack.entries`. */
-  layerOrder?: string[];
+  renderStack: RenderStack;
   /**
    * Current view state.  When `undefined` the auto-fit effect is skipped
    * entirely, letting the caller manage auto-fit externally (e.g. in a
@@ -128,26 +132,38 @@ export interface UseSpatialCanvasRendererOptions {
   height: number;
   hostLayerResolver?: RenderStackHostLayerResolver;
   onUnknownHostLayer?: UnknownRenderStackHostLayerHandler;
-  /** @deprecated Prefer host entries with `hostLayerResolver`. */
-  deckLayers?: Layer[];
   autoFit?: boolean;
 }
 
-export function useSpatialCanvasRenderer({
+interface UseSpatialCanvasRendererFromLayerInputsOptions {
+  spatialData?: SpatialData | null;
+  coordinateSystem: string | null;
+  layerInputs: RenderStackLayerInputs;
+  renderOrder?: string[];
+  viewState?: ViewState | null;
+  onViewStateChange?: (viewState: ViewState) => void;
+  width: number;
+  height: number;
+  hostDeckLayers?: Layer[];
+  externalDeckLayers?: Layer[];
+  sortDeckLayers?: boolean;
+  autoFit?: boolean;
+}
+
+export function useSpatialCanvasRendererFromLayerInputs({
   spatialData,
   coordinateSystem,
-  renderStack,
-  layers,
-  layerOrder,
+  layerInputs,
+  renderOrder,
   viewState,
   onViewStateChange,
   width,
   height,
-  hostLayerResolver,
-  onUnknownHostLayer,
-  deckLayers: externalDeckLayers,
+  hostDeckLayers,
+  externalDeckLayers,
+  sortDeckLayers,
   autoFit = true,
-}: UseSpatialCanvasRendererOptions) {
+}: UseSpatialCanvasRendererFromLayerInputsOptions) {
   const availableElements = useMemo(() => {
     if (!spatialData || !coordinateSystem) {
       return getEmptyElementsByType();
@@ -155,22 +171,7 @@ export function useSpatialCanvasRenderer({
     return getAvailableElements(spatialData, coordinateSystem);
   }, [spatialData, coordinateSystem]);
 
-  const layerInputs = useMemo(() => {
-    if (renderStack) {
-      return renderStackToLayerInputs(renderStack);
-    }
-    return { layers: layers ?? {}, layerOrder: layerOrder ?? [] };
-  }, [layerOrder, layers, renderStack]);
-
-  const hostDeckLayers = useMemo(
-    () => resolveRenderStackHostLayers(renderStack, hostLayerResolver, onUnknownHostLayer),
-    [hostLayerResolver, onUnknownHostLayer, renderStack]
-  );
-
-  const resolvedLayerOrder = useMemo(
-    () => renderStackOrder(renderStack, layerInputs.layerOrder),
-    [layerInputs.layerOrder, renderStack]
-  );
+  const resolvedLayerOrder = renderOrder ?? layerInputs.layerOrder;
 
   const layerData = useLayerData(
     layerInputs.layers,
@@ -183,18 +184,25 @@ export function useSpatialCanvasRenderer({
   const generatedDeckLayers = layerData.getLayers();
   const deckLayers = useMemo(() => {
     const composed = composeSpatialDeckLayers(generatedDeckLayers, [
-      ...hostDeckLayers,
+      ...(hostDeckLayers ?? []),
       ...(externalDeckLayers ?? []),
     ]);
-    return renderStack ? sortLayersByRenderStackOrder(composed, resolvedLayerOrder) : composed;
-  }, [externalDeckLayers, generatedDeckLayers, hostDeckLayers, renderStack, resolvedLayerOrder]);
+    return sortDeckLayers ? sortLayersByRenderStackOrder(composed, resolvedLayerOrder) : composed;
+  }, [
+    externalDeckLayers,
+    generatedDeckLayers,
+    hostDeckLayers,
+    resolvedLayerOrder,
+    sortDeckLayers,
+  ]);
   const vivLayerProps = layerData.getVivLayerProps();
 
   const enabledLayerIds = useMemo(() => {
     return new Set(layerInputs.layerOrder.filter((id) => layerInputs.layers[id]?.visible));
   }, [layerInputs.layerOrder, layerInputs.layers]);
   const hasEnabledLayers = enabledLayerIds.size > 0;
-  const hasExternalDeckLayers = (externalDeckLayers?.length ?? 0) > 0 || hostDeckLayers.length > 0;
+  const hasExternalDeckLayers =
+    (externalDeckLayers?.length ?? 0) > 0 || (hostDeckLayers?.length ?? 0) > 0;
   const hasRenderableInputs = hasEnabledLayers || hasExternalDeckLayers;
   const hasLayersDrawn = deckLayers.length > 0 || vivLayerProps.length > 0;
 
@@ -243,6 +251,43 @@ export function useSpatialCanvasRenderer({
   };
 }
 
+export function useSpatialCanvasRenderer({
+  spatialData,
+  coordinateSystem,
+  renderStack,
+  viewState,
+  onViewStateChange,
+  width,
+  height,
+  hostLayerResolver,
+  onUnknownHostLayer,
+  autoFit = true,
+}: UseSpatialCanvasRendererOptions) {
+  const layerInputs = useMemo(() => renderStackToLayerInputs(renderStack), [renderStack]);
+  const hostDeckLayers = useMemo(
+    () => resolveRenderStackHostLayers(renderStack, hostLayerResolver, onUnknownHostLayer),
+    [hostLayerResolver, onUnknownHostLayer, renderStack]
+  );
+  const resolvedLayerOrder = useMemo(
+    () => renderStackOrder(renderStack, layerInputs.layerOrder),
+    [layerInputs.layerOrder, renderStack]
+  );
+
+  return useSpatialCanvasRendererFromLayerInputs({
+    spatialData,
+    coordinateSystem,
+    layerInputs,
+    renderOrder: resolvedLayerOrder,
+    viewState,
+    onViewStateChange,
+    width,
+    height,
+    hostDeckLayers,
+    sortDeckLayers: true,
+    autoFit,
+  });
+}
+
 const viewerRootStyle: CSSProperties = {
   width: '100%',
   height: '100%',
@@ -286,6 +331,8 @@ function SpatialCanvasViewerInner({
   deckProps,
   onHover,
   onClick,
+  onFeatureHover,
+  onFeatureClick,
   onShapeHover,
   onShapeClick,
   renderTooltip,
@@ -304,19 +351,32 @@ function SpatialCanvasViewerInner({
 
   const vw = width ?? 0;
   const vh = height ?? 0;
-  const renderer = useSpatialCanvasRenderer({
+  const layerInputs = useMemo(() => {
+    if (renderStack) {
+      return renderStackToLayerInputs(renderStack);
+    }
+    return { layers: layers ?? {}, layerOrder: layerOrder ?? [] };
+  }, [layerOrder, layers, renderStack]);
+  const hostDeckLayers = useMemo(
+    () => resolveRenderStackHostLayers(renderStack, hostLayerResolver, onUnknownHostLayer),
+    [hostLayerResolver, onUnknownHostLayer, renderStack]
+  );
+  const resolvedLayerOrder = useMemo(
+    () => renderStackOrder(renderStack, layerInputs.layerOrder),
+    [layerInputs.layerOrder, renderStack]
+  );
+  const renderer = useSpatialCanvasRendererFromLayerInputs({
     spatialData,
     coordinateSystem,
-    renderStack,
-    layers,
-    layerOrder,
+    layerInputs,
+    renderOrder: resolvedLayerOrder,
     viewState,
     onViewStateChange,
     width: vw,
     height: vh,
-    hostLayerResolver,
-    onUnknownHostLayer,
-    deckLayers: externalDeckLayers,
+    hostDeckLayers,
+    externalDeckLayers,
+    sortDeckLayers: Boolean(renderStack),
     autoFit,
   });
   const hoverPickLayerIds = useMemo(
@@ -333,6 +393,17 @@ function SpatialCanvasViewerInner({
       }
       const rawLayerId = typeof info.layer?.id === 'string' ? info.layer.id : '';
       const normalizedLayerId = rawLayerId.replace(/-#.*#$/, '');
+      const featurePickEvent = renderer.getFeaturePickEvent(normalizedLayerId, {
+        index: info.index,
+        object: info.object,
+      });
+      if (featurePickEvent) {
+        onFeatureHover?.({
+          ...featurePickEvent,
+          coordinateSystem,
+          pickInfo: info,
+        });
+      }
       const shapePickEvent = renderer.getShapePickEvent(normalizedLayerId, {
         index: info.index,
         object: info.object,
@@ -358,6 +429,7 @@ function SpatialCanvasViewerInner({
       aggregateHoverTooltips,
       coordinateSystem,
       hoverPickLayerIds,
+      onFeatureHover,
       onHover,
       onShapeHover,
       renderTooltip,
@@ -373,6 +445,17 @@ function SpatialCanvasViewerInner({
       }
       const rawLayerId = typeof info.layer?.id === 'string' ? info.layer.id : '';
       const normalizedLayerId = rawLayerId.replace(/-#.*#$/, '');
+      const featurePickEvent = renderer.getFeaturePickEvent(normalizedLayerId, {
+        index: info.index,
+        object: info.object,
+      });
+      if (featurePickEvent) {
+        onFeatureClick?.({
+          ...featurePickEvent,
+          coordinateSystem,
+          pickInfo: info,
+        });
+      }
       const shapePickEvent = renderer.getShapePickEvent(normalizedLayerId, {
         index: info.index,
         object: info.object,
@@ -385,7 +468,7 @@ function SpatialCanvasViewerInner({
         });
       }
     },
-    [coordinateSystem, onClick, onShapeClick, renderer]
+    [coordinateSystem, onClick, onFeatureClick, onShapeClick, renderer]
   );
 
   const handleViewerRef = useCallback(

--- a/packages/vis/src/SpatialCanvas/VivSpatialViewer.tsx
+++ b/packages/vis/src/SpatialCanvas/VivSpatialViewer.tsx
@@ -39,6 +39,18 @@ export type View = { id: string } & any; // Viv View type
 export type VivPickInfo = PickingInfo<any, any> & { tile?: any };
 type VivZoom = number | readonly number[] | null | undefined;
 type VivLoader = { meta?: { physicalSizes?: { x?: { size: number; unit: string } } } };
+type VivDefaultInitialViewStateWithModelMatrix = (
+  loader: object,
+  viewSize: { width: number; height: number },
+  zoomBackOff?: number,
+  use3d?: boolean,
+  modelMatrix?: ImageLayerConfig['modelMatrix']
+) => object;
+
+// Viv's 0.21 declaration says `modelMatrix` is boolean, but the runtime calls
+// Matrix4 methods on it. Keep the compatibility cast at this external boundary.
+const getDefaultInitialViewStateWithModelMatrix =
+  getDefaultInitialViewState as unknown as VivDefaultInitialViewStateWithModelMatrix;
 
 export function normalizeVivZoom(zoom: VivZoom): number {
   if (Array.isArray(zoom)) {
@@ -255,7 +267,7 @@ class VivSpatialViewer extends React.PureComponent<VivSpatialViewerProps, VivSpa
       typeof firstLayerWithLoader.loader === 'object'
     ) {
       try {
-        const defaultState = getDefaultInitialViewState(
+        const defaultState = getDefaultInitialViewStateWithModelMatrix(
           firstLayerWithLoader.loader,
           {
             width: this.props.width,

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -25,7 +25,10 @@ import { ImageChannelPanel } from './ImageChannelPanel';
 import { LabelsChannelPanel } from './LabelsChannelPanel';
 import { LayerOrderList } from './LayerOrderList';
 import { ShapeFillColorPanel } from './ShapeFillColorPanel';
-import { shouldAutoFitSpatialView, useSpatialCanvasRenderer } from './SpatialCanvasViewer';
+import {
+  shouldAutoFitSpatialView,
+  useSpatialCanvasRendererFromLayerInputs,
+} from './SpatialCanvasViewer';
 import {
   type SpatialCanvasTooltipRenderProps,
   SpatialFeatureTooltip,
@@ -414,11 +417,10 @@ function SpatialCanvasInner({
     isBlocking,
     isLoading,
     vivLayerProps,
-  } = useSpatialCanvasRenderer({
+  } = useSpatialCanvasRendererFromLayerInputs({
     spatialData,
     coordinateSystem,
-    layers,
-    layerOrder,
+    layerInputs: { layers, layerOrder },
     // viewState and onViewStateChange are omitted: auto-fit and pan handling
     // are managed entirely by ViewerSection so this hook never re-runs on pan.
     width: vw,

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -40,7 +40,8 @@ import { VivLoaderRegistryProvider } from './VivLoaderRegistry';
 import { SpatialCanvasProvider, useSpatialCanvasActions, useSpatialCanvasStore } from './context';
 import { getDeckFromDeckGlRef, resolveHoverFeatureTooltip } from './featureTooltipHover';
 import type { SpatialCanvasStoreApi } from './stores';
-import type { AvailableElement, ElementsByType, LayerConfig, ViewState } from './types';
+import { layerConfig } from './layerConfig';
+import type { AvailableElement, ElementsByType, ViewState } from './types';
 import type { ImageLayerConfig } from './useLayerData';
 import { generateLayerId, getAllCoordinateSystems } from './utils';
 
@@ -490,13 +491,12 @@ function SpatialCanvasInner({
       if (existing) {
         actions.toggleLayerVisibility(layerId);
       } else {
-        const config: LayerConfig = {
+        const config = layerConfig(element.type, {
           id: layerId,
-          type: element.type,
           elementKey: element.key,
           visible: true,
           opacity: 1,
-        };
+        });
         actions.addLayer(config);
       }
     },

--- a/packages/vis/src/SpatialCanvas/layerConfig.ts
+++ b/packages/vis/src/SpatialCanvas/layerConfig.ts
@@ -1,0 +1,59 @@
+import type {
+  BaseLayerConfig,
+  ImageLayerConfig,
+  LabelsLayerConfig,
+  LayerConfig,
+  LayerType,
+  PointsLayerConfig,
+  ShapesLayerConfig,
+} from './types';
+
+type LayerConfigBase = Pick<BaseLayerConfig, 'id' | 'elementKey' | 'visible' | 'opacity'>;
+
+/**
+ * Build a typed {@link LayerConfig} from a layer discriminant and base fields.
+ *
+ * Required SpatialCanvas fields (`id`, `elementKey`, `visible`, `opacity`) are
+ * supplied via `base`. Optional type-specific props may be passed in `props`;
+ * values in `base` take precedence over `props` when keys overlap.
+ *
+ * When `type` is a string literal, the return type narrows to the matching
+ * member of {@link LayerConfigByType}. When `type` is a runtime {@link LayerType}
+ * union, the return type is the full {@link LayerConfig} union.
+ *
+ * @param type - Layer discriminant (`'image'`, `'shapes'`, `'points'`, or `'labels'`).
+ * @param base - Required layer identity and display fields shared by all layer types.
+ * @param props - Optional extension props (for example render-stack or saved UI state).
+ */
+export function layerConfig(
+  type: 'image',
+  base: LayerConfigBase,
+  props?: Record<string, unknown>
+): ImageLayerConfig;
+export function layerConfig(
+  type: 'shapes',
+  base: LayerConfigBase,
+  props?: Record<string, unknown>
+): ShapesLayerConfig;
+export function layerConfig(
+  type: 'points',
+  base: LayerConfigBase,
+  props?: Record<string, unknown>
+): PointsLayerConfig;
+export function layerConfig(
+  type: 'labels',
+  base: LayerConfigBase,
+  props?: Record<string, unknown>
+): LabelsLayerConfig;
+export function layerConfig(
+  type: LayerType,
+  base: LayerConfigBase,
+  props?: Record<string, unknown>
+): LayerConfig;
+export function layerConfig(
+  type: LayerType,
+  base: LayerConfigBase,
+  props: Record<string, unknown> = {}
+): LayerConfig {
+  return { ...props, ...base, type };
+}

--- a/packages/vis/src/SpatialCanvas/public.ts
+++ b/packages/vis/src/SpatialCanvas/public.ts
@@ -38,6 +38,7 @@ export type {
   UnknownRenderStackHostLayerHandler,
 } from './renderStackAdapters';
 export type {
+  SpatialFeaturePickEvent,
   SpatialCanvasViewerProps,
   SpatialCanvasViewerRenderTooltip,
 } from './SpatialCanvasViewer';

--- a/packages/vis/src/SpatialCanvas/public.ts
+++ b/packages/vis/src/SpatialCanvas/public.ts
@@ -16,6 +16,7 @@ export { useSpatialViewState, useViewStateUrl } from './hooks';
 export { createSpatialCanvasStore } from './stores';
 export type { SpatialCanvasStoreApi } from './stores';
 export type * from './types';
+export { layerConfig } from './layerConfig';
 export { SpatialViewer } from './SpatialViewer';
 export type { SpatialViewerProps } from './SpatialViewer';
 export { VivSpatialViewer } from './VivSpatialViewer';

--- a/packages/vis/src/SpatialCanvas/public.ts
+++ b/packages/vis/src/SpatialCanvas/public.ts
@@ -38,6 +38,8 @@ export type {
   UnknownRenderStackHostLayerHandler,
 } from './renderStackAdapters';
 export type {
+  LabelsSpatialFeaturePickEvent,
+  ShapesSpatialFeaturePickEvent,
   SpatialFeaturePickEvent,
   SpatialCanvasViewerProps,
   SpatialCanvasViewerRenderTooltip,

--- a/packages/vis/src/SpatialCanvas/public.ts
+++ b/packages/vis/src/SpatialCanvas/public.ts
@@ -26,6 +26,17 @@ export {
   SpatialCanvasViewer,
   useSpatialCanvasRenderer,
 } from './SpatialCanvasViewer';
+export {
+  renderStackOrder,
+  renderStackToLayerInputs,
+  resolveRenderStackHostLayers,
+  sortLayersByRenderStackOrder,
+} from './renderStackAdapters';
+export type {
+  RenderStackHostLayerResolver,
+  RenderStackLayerInputs,
+  UnknownRenderStackHostLayerHandler,
+} from './renderStackAdapters';
 export type {
   SpatialCanvasViewerProps,
   SpatialCanvasViewerRenderTooltip,

--- a/packages/vis/src/SpatialCanvas/renderStackAdapters.ts
+++ b/packages/vis/src/SpatialCanvas/renderStackAdapters.ts
@@ -1,0 +1,118 @@
+import type {
+  RenderStack,
+  RenderStackHostEntry,
+  RenderStackSpatialEntry,
+} from '@spatialdata/layers';
+import type { Layer } from 'deck.gl';
+import type {
+  ImageLayerConfig,
+  LabelsLayerConfig,
+  LayerConfig,
+  PointsLayerConfig,
+  ShapesLayerConfig,
+} from './types';
+
+export type RenderStackHostLayerResolver = (
+  entry: RenderStackHostEntry
+) => Layer | Layer[] | null | undefined;
+
+export type UnknownRenderStackHostLayerHandler = (entry: RenderStackHostEntry) => void;
+
+export interface RenderStackLayerInputs {
+  layers: Record<string, LayerConfig>;
+  layerOrder: string[];
+}
+
+function numberProp(props: Record<string, unknown>, key: string, fallback: number): number {
+  const value = props[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function spatialEntryToLayerConfig(entry: RenderStackSpatialEntry): LayerConfig {
+  const base = {
+    ...entry.props,
+    id: entry.id,
+    elementKey: entry.source.elementKey,
+    visible: entry.visible,
+    opacity: numberProp(entry.props, 'opacity', 1),
+  };
+
+  // RenderStack props are JSON/runtime extension data. This is the narrow
+  // adapter boundary where they become the richer SpatialCanvas layer union.
+  switch (entry.source.elementType) {
+    case 'image':
+      return { ...base, type: 'image' } as ImageLayerConfig;
+    case 'shapes':
+      return { ...base, type: 'shapes' } as ShapesLayerConfig;
+    case 'points':
+      return { ...base, type: 'points' } as PointsLayerConfig;
+    case 'labels':
+      return { ...base, type: 'labels' } as LabelsLayerConfig;
+  }
+}
+
+export function renderStackToLayerInputs(renderStack: RenderStack): RenderStackLayerInputs {
+  const layers: Record<string, LayerConfig> = {};
+  const layerOrder: string[] = [];
+
+  for (const entry of renderStack.entries) {
+    if (entry.kind !== 'spatial') continue;
+    layers[entry.id] = spatialEntryToLayerConfig(entry);
+    layerOrder.push(entry.id);
+  }
+
+  return { layers, layerOrder };
+}
+
+export function resolveRenderStackHostLayers(
+  renderStack: RenderStack | undefined,
+  resolver?: RenderStackHostLayerResolver,
+  onUnknownHostLayer?: UnknownRenderStackHostLayerHandler
+): Layer[] {
+  if (!renderStack || !resolver) return [];
+
+  const layers: Layer[] = [];
+  for (const entry of renderStack.entries) {
+    if (entry.kind !== 'host' || !entry.visible) continue;
+    const resolved = resolver(entry);
+    if (!resolved) {
+      onUnknownHostLayer?.(entry);
+      continue;
+    }
+    if (Array.isArray(resolved)) {
+      const compact = resolved.filter(Boolean);
+      layers.push(...(compact.length === 1 ? [compact[0].clone({ id: entry.id })] : compact));
+    } else {
+      layers.push(resolved.clone({ id: entry.id }));
+    }
+  }
+  return layers;
+}
+
+export function renderStackOrder(renderStack: RenderStack | undefined, fallback: string[]): string[] {
+  if (!renderStack) return fallback;
+  return renderStack.entries.flatMap((entry) => {
+    if (entry.kind === 'spatial' || entry.kind === 'host') {
+      return entry.id;
+    }
+    return entry.children;
+  });
+}
+
+export function sortLayersByRenderStackOrder(layers: Layer[], order: string[]): Layer[] {
+  if (order.length === 0) return layers;
+  const orderIndex = new Map(order.map((id, index) => [id, index]));
+  return layers
+    .map((layer, originalIndex) => ({
+      layer,
+      originalIndex,
+      order: orderIndex.get(layer.id),
+    }))
+    .sort((a, b) => {
+      if (a.order === undefined && b.order === undefined) return a.originalIndex - b.originalIndex;
+      if (a.order === undefined) return 1;
+      if (b.order === undefined) return -1;
+      return a.order - b.order;
+    })
+    .map((record) => record.layer);
+}

--- a/packages/vis/src/SpatialCanvas/renderStackAdapters.ts
+++ b/packages/vis/src/SpatialCanvas/renderStackAdapters.ts
@@ -4,13 +4,8 @@ import type {
   RenderStackSpatialEntry,
 } from '@spatialdata/layers';
 import type { Layer } from 'deck.gl';
-import type {
-  ImageLayerConfig,
-  LabelsLayerConfig,
-  LayerConfig,
-  PointsLayerConfig,
-  ShapesLayerConfig,
-} from './types';
+import { layerConfig } from './layerConfig';
+import type { LayerConfig } from './types';
 
 export type RenderStackHostLayerResolver = (
   entry: RenderStackHostEntry
@@ -29,26 +24,18 @@ function numberProp(props: Record<string, unknown>, key: string, fallback: numbe
 }
 
 function spatialEntryToLayerConfig(entry: RenderStackSpatialEntry): LayerConfig {
-  const base = {
-    ...entry.props,
-    id: entry.id,
-    elementKey: entry.source.elementKey,
-    visible: entry.visible,
-    opacity: numberProp(entry.props, 'opacity', 1),
-  };
-
-  // RenderStack props are JSON/runtime extension data. This is the narrow
-  // adapter boundary where they become the richer SpatialCanvas layer union.
-  switch (entry.source.elementType) {
-    case 'image':
-      return { ...base, type: 'image' } as ImageLayerConfig;
-    case 'shapes':
-      return { ...base, type: 'shapes' } as ShapesLayerConfig;
-    case 'points':
-      return { ...base, type: 'points' } as PointsLayerConfig;
-    case 'labels':
-      return { ...base, type: 'labels' } as LabelsLayerConfig;
-  }
+  // RenderStack props are JSON/runtime extension data. This is the narrow adapter
+  // boundary where they merge with typed SpatialCanvas layer fields.
+  return layerConfig(
+    entry.source.elementType,
+    {
+      id: entry.id,
+      elementKey: entry.source.elementKey,
+      visible: entry.visible,
+      opacity: numberProp(entry.props, 'opacity', 1),
+    },
+    entry.props
+  );
 }
 
 export function renderStackToLayerInputs(renderStack: RenderStack): RenderStackLayerInputs {

--- a/packages/vis/src/SpatialCanvas/renderStackAdapters.ts
+++ b/packages/vis/src/SpatialCanvas/renderStackAdapters.ts
@@ -81,7 +81,7 @@ export function resolveRenderStackHostLayers(
     }
     if (Array.isArray(resolved)) {
       const compact = resolved.filter(Boolean);
-      layers.push(...(compact.length === 1 ? [compact[0].clone({ id: entry.id })] : compact));
+      layers.push(...compact.map((layer) => layer.clone({ id: entry.id })));
     } else {
       layers.push(resolved.clone({ id: entry.id }));
     }

--- a/packages/vis/src/SpatialCanvas/types.ts
+++ b/packages/vis/src/SpatialCanvas/types.ts
@@ -112,11 +112,14 @@ export interface LabelsLayerConfig extends BaseLayerConfig {
   };
 }
 
-export type LayerConfig =
-  | ImageLayerConfig
-  | ShapesLayerConfig
-  | PointsLayerConfig
-  | LabelsLayerConfig;
+export interface LayerConfigByType {
+  image: ImageLayerConfig;
+  shapes: ShapesLayerConfig;
+  points: PointsLayerConfig;
+  labels: LabelsLayerConfig;
+}
+
+export type LayerConfig<T extends LayerType = LayerType> = LayerConfigByType[T];
 
 // ============================================
 // Element Availability Types

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -159,7 +159,7 @@ export interface LabelsLoaderData extends LabelsTooltipMetadata {
 export interface ShapeFeaturePickEventData {
   elementKind: 'shapes';
   layerId: string;
-  element: ShapesElement;
+  spatialElement: ShapesElement;
   featureId: string;
   featureIndex: number;
   rowIndex?: number;
@@ -170,7 +170,7 @@ export interface ShapeFeaturePickEventData {
 export interface LabelFeaturePickEventData {
   elementKind: 'labels';
   layerId: string;
-  element: LabelsElement;
+  spatialElement: LabelsElement;
   featureId: string;
   labelId: string;
   channelIndex?: number;
@@ -1476,7 +1476,7 @@ export function useLayerData(
         return {
           elementKind: 'labels',
           layerId,
-          element: elem.element,
+          spatialElement: elem.element,
           featureId: pickedLabel.labelId,
           labelId: pickedLabel.labelId,
           channelIndex: pickedLabel.channelIndex,
@@ -1497,7 +1497,7 @@ export function useLayerData(
       return {
         elementKind: 'shapes',
         layerId: shapeEvent.layerId,
-        element: elem.element,
+        spatialElement: elem.element,
         featureId: shapeEvent.featureId,
         featureIndex: shapeEvent.featureIndex,
         rowIndex: shapeEvent.rowIndex,

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -157,9 +157,9 @@ export interface LabelsLoaderData extends LabelsTooltipMetadata {
 }
 
 export interface ShapeFeaturePickEventData {
-  elementType: 'shapes';
+  elementKind: 'shapes';
   layerId: string;
-  elementKey: string;
+  element: ShapesElement;
   featureId: string;
   featureIndex: number;
   rowIndex?: number;
@@ -168,9 +168,9 @@ export interface ShapeFeaturePickEventData {
 }
 
 export interface LabelFeaturePickEventData {
-  elementType: 'labels';
+  elementKind: 'labels';
   layerId: string;
-  elementKey: string;
+  element: LabelsElement;
   featureId: string;
   labelId: string;
   channelIndex?: number;
@@ -289,6 +289,26 @@ function serializeRasterSelections(selections: RasterSelection[]): string {
 
 function getElementMapKey(config: Pick<LayerConfig, 'type' | 'elementKey'>): string {
   return `${config.type}:${config.elementKey}`;
+}
+
+function isLabelsAvailableElement(element: AvailableElement): element is Omit<
+  AvailableElement,
+  'type' | 'element'
+> & {
+  type: 'labels';
+  element: LabelsElement;
+} {
+  return element.type === 'labels' && element.element.kind === 'labels';
+}
+
+function isShapesAvailableElement(element: AvailableElement): element is Omit<
+  AvailableElement,
+  'type' | 'element'
+> & {
+  type: 'shapes';
+  element: ShapesElement;
+} {
+  return element.type === 'shapes' && element.element.kind === 'shapes';
 }
 
 function getWorldBoundsCacheKey(elem: AvailableElement): string {
@@ -1317,7 +1337,7 @@ export function useLayerData(
         layerId,
       };
 
-      if (elem.type === 'labels') {
+      if (isLabelsAvailableElement(elem)) {
         const pickedLabel = getPickedLabelObject(pickInfo.object);
         if (!pickedLabel) {
           return undefined;
@@ -1356,7 +1376,7 @@ export function useLayerData(
         );
       }
 
-      if (elem.type !== 'shapes') {
+      if (!isShapesAvailableElement(elem)) {
         return undefined;
       }
 
@@ -1445,7 +1465,7 @@ export function useLayerData(
         return undefined;
       }
 
-      if (elem.type === 'labels') {
+      if (isLabelsAvailableElement(elem)) {
         const pickedLabel = getPickedLabelObject(pickInfo.object);
         if (!pickedLabel) {
           return undefined;
@@ -1454,9 +1474,9 @@ export function useLayerData(
           .get(elem.key)
           ?.tooltipRowIndexByFeatureId?.get(pickedLabel.labelId);
         return {
-          elementType: 'labels',
+          elementKind: 'labels',
           layerId,
-          elementKey: elem.key,
+          element: elem.element,
           featureId: pickedLabel.labelId,
           labelId: pickedLabel.labelId,
           channelIndex: pickedLabel.channelIndex,
@@ -1466,7 +1486,7 @@ export function useLayerData(
         };
       }
 
-      if (elem.type !== 'shapes') {
+      if (!isShapesAvailableElement(elem)) {
         return undefined;
       }
 
@@ -1475,8 +1495,13 @@ export function useLayerData(
         return undefined;
       }
       return {
-        elementType: 'shapes',
-        ...shapeEvent,
+        elementKind: 'shapes',
+        layerId: shapeEvent.layerId,
+        element: elem.element,
+        featureId: shapeEvent.featureId,
+        featureIndex: shapeEvent.featureIndex,
+        rowIndex: shapeEvent.rowIndex,
+        object: shapeEvent.object,
         tooltip: getFeatureTooltip(layerId, pickInfo),
       };
     },

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -156,6 +156,31 @@ export interface LabelsLoaderData extends LabelsTooltipMetadata {
   selectionAxisSizes?: Partial<Record<'z' | 'c' | 't', number>>;
 }
 
+export interface ShapeFeaturePickEventData {
+  elementType: 'shapes';
+  layerId: string;
+  elementKey: string;
+  featureId: string;
+  featureIndex: number;
+  rowIndex?: number;
+  object: ShapeFeatureRenderDatum;
+  tooltip?: SpatialFeatureTooltipData;
+}
+
+export interface LabelFeaturePickEventData {
+  elementType: 'labels';
+  layerId: string;
+  elementKey: string;
+  featureId: string;
+  labelId: string;
+  channelIndex?: number;
+  rowIndex?: number;
+  object?: unknown;
+  tooltip?: SpatialFeatureTooltipData;
+}
+
+export type SpatialFeaturePickEventData = ShapeFeaturePickEventData | LabelFeaturePickEventData;
+
 interface UseLayerDataResult {
   /** Get deck.gl layers ready for rendering (shapes, points, etc.) */
   getLayers: () => Layer[];
@@ -174,6 +199,11 @@ interface UseLayerDataResult {
     layerId: string,
     pickInfo: Pick<{ index?: number; object?: unknown }, 'index' | 'object'>
   ) => SpatialFeatureTooltipData | undefined;
+  /** Resolve stable feature metadata from a picked deck object for runtime listeners. */
+  getFeaturePickEvent: (
+    layerId: string,
+    pickInfo: Pick<{ index?: number; object?: unknown }, 'index' | 'object'>
+  ) => SpatialFeaturePickEventData | undefined;
   /** Resolve stable shape feature metadata from a picked deck object. */
   getShapePickEvent: (
     layerId: string,
@@ -230,6 +260,25 @@ function serializeColorByFeatureId(
   if (!colors || Object.keys(colors).length === 0) return '';
   const entries = Object.entries(colors).sort(([a], [b]) => a.localeCompare(b));
   return `\x02${entries.length}:${JSON.stringify(entries)}`;
+}
+
+function getPickedLabelObject(
+  object: unknown
+): { labelId: string; channelIndex?: number; object: unknown } | undefined {
+  if (!object || typeof object !== 'object') {
+    return undefined;
+  }
+  const rawLabelId = Reflect.get(object, 'labelId');
+  const labelId = rawLabelId === undefined || rawLabelId === null ? '' : String(rawLabelId);
+  if (!labelId) {
+    return undefined;
+  }
+  const rawChannelIndex = Reflect.get(object, 'channelIndex');
+  const channelIndex =
+    typeof rawChannelIndex === 'number' && Number.isFinite(rawChannelIndex)
+      ? rawChannelIndex
+      : undefined;
+  return { labelId, channelIndex, object };
 }
 
 function serializeRasterSelections(selections: RasterSelection[]): string {
@@ -1269,14 +1318,11 @@ export function useLayerData(
       };
 
       if (elem.type === 'labels') {
-        const pickedObject = pickInfo.object as
-          | { labelId?: number | string; channelIndex?: number }
-          | undefined;
-        const rawLabelId = pickedObject?.labelId;
-        const labelId = rawLabelId === undefined || rawLabelId === null ? '' : String(rawLabelId);
-        if (!labelId) {
+        const pickedLabel = getPickedLabelObject(pickInfo.object);
+        if (!pickedLabel) {
           return undefined;
         }
+        const { labelId } = pickedLabel;
 
         const loadedLabelData = loadedDataRef.current.labels.get(elem.key);
         const config = layersRef.current[layerId];
@@ -1389,6 +1435,54 @@ export function useLayerData(
     []
   );
 
+  const getFeaturePickEvent = useCallback(
+    (
+      layerId: string,
+      pickInfo: Pick<{ index?: number; object?: unknown }, 'index' | 'object'>
+    ): SpatialFeaturePickEventData | undefined => {
+      const elem = resolveLayerElement(layerId, layersRef.current[layerId], elementMap.current);
+      if (!elem) {
+        return undefined;
+      }
+
+      if (elem.type === 'labels') {
+        const pickedLabel = getPickedLabelObject(pickInfo.object);
+        if (!pickedLabel) {
+          return undefined;
+        }
+        const rowIndex = loadedDataRef.current.labels
+          .get(elem.key)
+          ?.tooltipRowIndexByFeatureId?.get(pickedLabel.labelId);
+        return {
+          elementType: 'labels',
+          layerId,
+          elementKey: elem.key,
+          featureId: pickedLabel.labelId,
+          labelId: pickedLabel.labelId,
+          channelIndex: pickedLabel.channelIndex,
+          rowIndex,
+          object: pickedLabel.object,
+          tooltip: getFeatureTooltip(layerId, pickInfo),
+        };
+      }
+
+      if (elem.type !== 'shapes') {
+        return undefined;
+      }
+
+      const shapeEvent = getShapePickEvent(layerId, pickInfo);
+      if (!shapeEvent) {
+        return undefined;
+      }
+      return {
+        elementType: 'shapes',
+        ...shapeEvent,
+        tooltip: getFeatureTooltip(layerId, pickInfo),
+      };
+    },
+    [getFeatureTooltip, getShapePickEvent]
+  );
+
   const getVivLayerProps = useCallback((): ImageLayerConfig[] => {
     const vivProps: ImageLayerConfig[] = [];
     const loaded = loadedDataRef.current;
@@ -1476,6 +1570,7 @@ export function useLayerData(
     getLayerLoadState,
     hasRenderableLayerData,
     getFeatureTooltip,
+    getFeaturePickEvent,
     getShapePickEvent,
     isLoading,
     isBlocking,

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -49,6 +49,7 @@ export {
   shouldAutoFitSpatialView,
   sortLayersByRenderStackOrder,
   useSpatialCanvasRenderer,
+  layerConfig,
 } from './SpatialCanvas/public';
 export type {
   SpatialCanvasStoreApi,
@@ -57,6 +58,7 @@ export type {
   SpatialCanvasStore,
   ViewState,
   LayerConfig,
+  LayerConfigByType,
   LayerType,
   AvailableElement,
   ElementsByType,

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -1,9 +1,26 @@
 export {
   SpatialLayer,
+  getRenderStackEntryIds,
+  getRenderStackHostLayerIds,
   migrateSpatialLayerProps,
+  renderStackEntrySchema,
+  renderStackGroupEntrySchema,
+  renderStackHostEntrySchema,
+  renderStackSchema,
+  renderStackSpatialElementTypeSchema,
+  renderStackSpatialEntrySchema,
   spatialLayerPropsSchema,
+  RENDER_STACK_SCHEMA_VERSION,
 } from '@spatialdata/layers';
-export type { SpatialLayerProps } from '@spatialdata/layers';
+export type {
+  RenderStack,
+  RenderStackEntry,
+  RenderStackGroupEntry,
+  RenderStackHostEntry,
+  RenderStackSpatialElementType,
+  RenderStackSpatialEntry,
+  SpatialLayerProps,
+} from '@spatialdata/layers';
 
 export { default as Sketch } from './Sketch';
 export { default as SpatialDataTree } from './Tree';
@@ -25,8 +42,12 @@ export {
   useViewStateUrl,
   SpatialViewer,
   composeSpatialDeckLayers,
+  renderStackOrder,
+  renderStackToLayerInputs,
+  resolveRenderStackHostLayers,
   shouldRenderInternalTooltip,
   shouldAutoFitSpatialView,
+  sortLayersByRenderStackOrder,
   useSpatialCanvasRenderer,
 } from './SpatialCanvas/public';
 export type {
@@ -48,5 +69,8 @@ export type {
   SpatialFeatureTooltipSection,
   SpatialCanvasTooltipRenderProps,
   SpatialFeatureTooltipProps,
+  RenderStackHostLayerResolver,
+  RenderStackLayerInputs,
+  UnknownRenderStackHostLayerHandler,
 } from './SpatialCanvas/public';
 export { SpatialFeatureTooltip } from './SpatialCanvas/public';

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -64,6 +64,8 @@ export type {
   SpatialViewerProps,
   SpatialCanvasViewerProps,
   SpatialCanvasViewerRenderTooltip,
+  LabelsSpatialFeaturePickEvent,
+  ShapesSpatialFeaturePickEvent,
   SpatialFeaturePickEvent,
   SpatialFeatureTooltipData,
   SpatialFeatureTooltipItem,

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -64,6 +64,7 @@ export type {
   SpatialViewerProps,
   SpatialCanvasViewerProps,
   SpatialCanvasViewerRenderTooltip,
+  SpatialFeaturePickEvent,
   SpatialFeatureTooltipData,
   SpatialFeatureTooltipItem,
   SpatialFeatureTooltipSection,

--- a/packages/vis/tests/spatialCanvasViewer.spec.ts
+++ b/packages/vis/tests/spatialCanvasViewer.spec.ts
@@ -77,6 +77,29 @@ describe('render stack adapters', () => {
     expect(resolved.map((layer) => layer.id)).toEqual(['deck:scatter']);
   });
 
+  it('resolves multi-layer host descriptors into deck layers with stack ids', () => {
+    const stack = renderStackSchema.parse({
+      entries: [{ kind: 'host', id: 'deck:selection', source: { hostLayerId: 'selection' } }],
+    });
+    const resolved = resolveRenderStackHostLayers(stack, () => {
+      return [
+        new ScatterplotLayer({ id: 'runtime-selection-fill', data: [], getPosition: [0, 0] }),
+        new ScatterplotLayer({ id: 'runtime-selection-outline', data: [], getPosition: [0, 0] }),
+      ];
+    });
+
+    expect(resolved.map((layer) => layer.id)).toEqual(['deck:selection', 'deck:selection']);
+    expect(
+      sortLayersByRenderStackOrder(
+        [
+          new ScatterplotLayer({ id: 'spatial-labels', data: [], getPosition: [0, 0] }),
+          ...resolved,
+        ],
+        ['deck:selection', 'spatial-labels']
+      ).map((layer) => layer.id)
+    ).toEqual(['deck:selection', 'deck:selection', 'spatial-labels']);
+  });
+
   it('reports unknown host descriptors', () => {
     const stack = renderStackSchema.parse({
       entries: [{ kind: 'host', id: 'deck:missing', source: { hostLayerId: 'missing' } }],

--- a/packages/vis/tests/spatialCanvasViewer.spec.ts
+++ b/packages/vis/tests/spatialCanvasViewer.spec.ts
@@ -5,6 +5,13 @@ import {
   shouldAutoFitSpatialView,
   shouldRenderInternalTooltip,
 } from '../src/SpatialCanvas/SpatialCanvasViewer.js';
+import {
+  renderStackOrder,
+  renderStackToLayerInputs,
+  resolveRenderStackHostLayers,
+  sortLayersByRenderStackOrder,
+} from '../src/SpatialCanvas/renderStackAdapters.js';
+import { renderStackSchema } from '@spatialdata/layers';
 
 describe('composeSpatialDeckLayers', () => {
   it('places caller-provided deck layers after generated SpatialData layers', () => {
@@ -15,6 +22,103 @@ describe('composeSpatialDeckLayers', () => {
       'generated',
       'external',
     ]);
+  });
+});
+
+describe('render stack adapters', () => {
+  it('normalizes spatial entries into existing layer inputs', () => {
+    const stack = renderStackSchema.parse({
+      entries: [
+        {
+          kind: 'spatial',
+          id: 'image-morphology',
+          source: { elementType: 'image', elementKey: 'morphology_focus' },
+          props: { opacity: 0.4 },
+        },
+        {
+          kind: 'host',
+          id: 'deck:scatter',
+          source: { hostLayerId: 'deck:scatter' },
+        },
+        {
+          kind: 'spatial',
+          id: 'shapes-cells',
+          visible: false,
+          source: { elementType: 'shapes', elementKey: 'cell_boundaries' },
+        },
+      ],
+    });
+
+    const inputs = renderStackToLayerInputs(stack);
+    expect(inputs.layerOrder).toEqual(['image-morphology', 'shapes-cells']);
+    expect(inputs.layers['image-morphology']).toMatchObject({
+      id: 'image-morphology',
+      type: 'image',
+      elementKey: 'morphology_focus',
+      opacity: 0.4,
+      visible: true,
+    });
+    expect(inputs.layers['shapes-cells']).toMatchObject({
+      id: 'shapes-cells',
+      type: 'shapes',
+      elementKey: 'cell_boundaries',
+      visible: false,
+    });
+  });
+
+  it('resolves host descriptors into deck layers with stack ids', () => {
+    const stack = renderStackSchema.parse({
+      entries: [{ kind: 'host', id: 'deck:scatter', source: { hostLayerId: 'scatter' } }],
+    });
+    const resolved = resolveRenderStackHostLayers(stack, () => {
+      return new ScatterplotLayer({ id: 'runtime-scatter', data: [], getPosition: [0, 0] });
+    });
+
+    expect(resolved.map((layer) => layer.id)).toEqual(['deck:scatter']);
+  });
+
+  it('reports unknown host descriptors', () => {
+    const stack = renderStackSchema.parse({
+      entries: [{ kind: 'host', id: 'deck:missing', source: { hostLayerId: 'missing' } }],
+    });
+    const unknown: string[] = [];
+
+    const resolved = resolveRenderStackHostLayers(
+      stack,
+      () => undefined,
+      (entry) => unknown.push(entry.id)
+    );
+
+    expect(resolved).toEqual([]);
+    expect(unknown).toEqual(['deck:missing']);
+  });
+
+  it('sorts materialized deck layers by render stack order', () => {
+    const layers = [
+      new ScatterplotLayer({ id: 'shapes-cells', data: [], getPosition: [0, 0] }),
+      new ScatterplotLayer({ id: 'deck:scatter', data: [], getPosition: [0, 0] }),
+      new ScatterplotLayer({ id: 'unmanaged', data: [], getPosition: [0, 0] }),
+    ];
+
+    expect(
+      sortLayersByRenderStackOrder(layers, ['deck:scatter', 'shapes-cells']).map(
+        (layer) => layer.id
+      )
+    ).toEqual(['deck:scatter', 'shapes-cells', 'unmanaged']);
+  });
+
+  it('uses group child ids as reserved ordering slots', () => {
+    const stack = renderStackSchema.parse({
+      entries: [
+        {
+          kind: 'group',
+          id: 'group:blend',
+          children: ['image-a', 'labels-a'],
+        },
+      ],
+    });
+
+    expect(renderStackOrder(stack, [])).toEqual(['image-a', 'labels-a']);
   });
 });
 


### PR DESCRIPTION
## Summary
- Clarifies the prop-to-layer contract across docs and architecture notes.
- Moves render stack ownership into `@spatialdata/layers` and adapts `@spatialdata/vis` to consume it.
- Updates SpatialCanvas, demos, and tests to reflect the new layer-driven flow.
- Adds/updates documentation for headless viewer and MDV integration guidance.

## Testing
- Added and updated unit coverage for render stack behavior.
- Updated SpatialCanvas viewer tests to validate the new prop routing and layer-driven rendering flow.
- Performed local validation of the affected demos and viewer paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a `RenderStack`-based rendering API to replace separate layer configuration, providing a unified model for spatial and overlay layers with explicit ordering control.
  * Added support for custom "host overlays" that interleave seamlessly with spatial data layers through a resolver callback.
  * Implemented feature-level pick events (`onFeatureHover`, `onFeatureClick`) for improved runtime event handling.
  * Expanded documentation with architecture decisions, integration guides, and API migration examples.

* **Documentation**
  * Updated comprehensive guides on headless rendering, layer configuration, and MDV integration reflecting the new stack-based architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->