### PR TITLE
Expose codec worker entrypoint for zarrextra

### DIFF
--- a/.changeset/shy-parts-push.md
+++ b/.changeset/shy-parts-push.md
@@ -1,0 +1,5 @@
+---
+"zarrextra": patch
+---
+
+Fix codec worker in published version (🤞)

--- a/packages/zarrextra/package.json
+++ b/packages/zarrextra/package.json
@@ -11,8 +11,11 @@
       "import": "./dist/index.js"
     },
     "./workers": {
-      "types": "./dist/workers.d.ts",
+      "types": "./dist/workers/index.d.ts",
       "import": "./dist/workers.js"
+    },
+    "./codec-worker": {
+      "import": "./dist/codec-worker.js"
     }
   },
   "files": [

--- a/packages/zarrextra/src/workers/index.ts
+++ b/packages/zarrextra/src/workers/index.ts
@@ -21,7 +21,8 @@ function defaultWorkerCount() {
 }
 
 function defaultWorkerUrl() {
-  return new URL('./codec-worker.js', import.meta.url);
+  const workerFile = './codec-worker.js';
+  return new URL(workerFile, import.meta.url);
 }
 
 setFizarritaGetWorker(getWorker);


### PR DESCRIPTION
## Summary
- Add a public `./codec-worker` export from `@spatialdata/zarrextra`
- Point the `./workers` type export at the generated `workers/index.d.ts` file
- Keep the default codec worker URL in a named local variable for clarity

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration for the workers subpath exports to align with build output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->