### PR TITLE
Build the codec worker as a standalone Vite artifact

### DIFF
--- a/.changeset/solid-codec-worker.md
+++ b/.changeset/solid-codec-worker.md
@@ -1,0 +1,5 @@
+---
+"zarrextra": patch
+---
+
+Build the codec worker as a self-contained artifact for Vite consumers.

--- a/packages/zarrextra/README.md
+++ b/packages/zarrextra/README.md
@@ -119,4 +119,5 @@ required for that path.
 
 Optional dependencies: `@fideus-labs/fizarrita`, `@fideus-labs/worker-pool`,
 `@cornerstonejs/codec-openjpeg`, and `@cornerstonejs/codec-openjph` (bundled into
-the worker script).
+the default worker script). Future worker entries may let applications opt into
+lighter worker bundles when JP2K or HTJ2K codecs are not needed.

--- a/packages/zarrextra/package.json
+++ b/packages/zarrextra/package.json
@@ -18,14 +18,12 @@
       "import": "./dist/codec-worker.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vite build --mode codec-worker",
     "dev": "vite build --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/zarrextra/vite.config.ts
+++ b/packages/zarrextra/vite.config.ts
@@ -1,50 +1,60 @@
 import { resolve } from 'node:path';
-import { defineConfig } from 'vitest/config';
 import dts from 'vite-plugin-dts';
+import { defineConfig } from 'vitest/config';
 
 const pkgExternals = ['zarrita', '@fideus-labs/fizarrita', '@fideus-labs/worker-pool'];
 
-export default defineConfig({
-  plugins: [
-    dts({
-      outDir: 'dist',
-      include: ['src'],
-      exclude: ['**/*.test.ts', 'src/workers/codec-worker.ts'],
-    }),
-  ],
-  build: {
-    lib: {
-      entry: {
-        index: resolve(__dirname, 'src/index.ts'),
-        workers: resolve(__dirname, 'src/workers/index.ts'),
-        'codec-worker': resolve(__dirname, 'src/workers/codec-worker.ts'),
+export default defineConfig(({ mode }) => {
+  const isCodecWorkerBuild = mode === 'codec-worker';
+
+  return {
+    plugins: [
+      !isCodecWorkerBuild &&
+        dts({
+          outDir: 'dist',
+          include: ['src'],
+          exclude: [
+            '**/*.test.ts',
+            'src/workers/codec-worker.ts',
+            'src/workers/codec-worker-init.ts',
+          ],
+        }),
+    ],
+    build: {
+      emptyOutDir: !isCodecWorkerBuild,
+      lib: {
+        entry: isCodecWorkerBuild
+          ? resolve(__dirname, 'src/workers/codec-worker.ts')
+          : {
+              index: resolve(__dirname, 'src/index.ts'),
+              workers: resolve(__dirname, 'src/workers/index.ts'),
+            },
+        formats: ['es'],
+        fileName: isCodecWorkerBuild ? () => 'codec-worker.js' : undefined,
       },
-      formats: ['es'],
-    },
-    rollupOptions: {
-      external(id, parentId) {
-        if (parentId?.includes('codec-worker')) {
-          return false;
-        }
-        if (parentId?.includes('workers')) {
+      rollupOptions: {
+        external(id) {
+          if (isCodecWorkerBuild) {
+            return false;
+          }
           return pkgExternals.includes(id);
-        }
-        return id === 'zarrita';
+        },
+        output: {
+          codeSplitting: isCodecWorkerBuild ? false : undefined,
+          entryFileNames: '[name].js',
+        },
       },
-      output: {
-        entryFileNames: '[name].js',
+      sourcemap: true,
+      target: 'es2022',
+    },
+    test: {
+      globals: true,
+      environment: 'node',
+      include: ['tests/**/*.spec.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'html'],
       },
     },
-    sourcemap: true,
-    target: 'es2022',
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['tests/**/*.spec.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-    },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

Previous attempt at fixing https://github.com/Taylor-CCB-Group/SpatialData.js/issues/50 was not adequate. Hopefully this will be.

- Build `codec-worker` in a separate Vite mode so it ships as a self-contained bundle
- Keep the main package build focused on the library entry points
- Update package metadata and README wording to reflect the new worker artifact
- Add a changeset for the `zarrextra` patch release

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codec worker now available as a self-contained artifact optimized for Vite consumers.

* **Documentation**
  * Clarified worker script documentation and added notes on future lightweight bundle options when JP2K/HTJ2K codecs are not required.

* **Chores**
  * Refined package build configuration and publishing structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->