### PR TITLE
feat(avivatorish): export channel-stats helpers + stateful stats hook (Track B)

### DIFF
--- a/.changeset/avivatorish-channel-stats-helpers.md
+++ b/.changeset/avivatorish-channel-stats-helpers.md
@@ -1,0 +1,5 @@
+---
+"@spatialdata/avivatorish": patch
+---
+
+Export `selectionStatsKey` and `pickDefaultSelectionForAdd` from `@spatialdata/avivatorish`. These are the pure, app-agnostic channel-stats/selection helpers a consumer's runtime stats bridge needs (stats-cache identity keyed by channelId + z/c/t selection, and first-unused-channel default when adding a row), so consumers no longer redefine them locally.

--- a/.changeset/avivatorish-stats-hook.md
+++ b/.changeset/avivatorish-stats-hook.md
@@ -1,0 +1,5 @@
+---
+"@spatialdata/avivatorish": patch
+---
+
+Export `useChannelSelectionStats` hook from `@spatialdata/avivatorish`. Stateful async stats hook that fetches, caches, and returns per-channel stats (domain, contrastLimits, raster) keyed by channelId — plus a positional `statsByIndex` convenience array and per-channel loading flags. Ports the async cache/load/cancel loop from MDV's `useImageLayerRuntime` so consumers no longer reimplement it locally.

--- a/packages/avivatorish/package.json
+++ b/packages/avivatorish/package.json
@@ -34,11 +34,14 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.0.0",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "jsdom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-dts": "catalog:",

--- a/packages/avivatorish/src/channelStats.ts
+++ b/packages/avivatorish/src/channelStats.ts
@@ -1,0 +1,32 @@
+import type { LayerChannelSelection } from './layerChannelState';
+
+/**
+ * Identity for a channel's *loaded stats* (domains / raster / histogram).
+ *
+ * Keyed by `channelId` **and** its `z`/`c`/`t` selection — channelId alone is
+ * insufficient, because changing a row's selection must refetch its stats. The
+ * `c` axis falls back to the row `index` (the conventional default selection),
+ * `z`/`t` to `0`.
+ */
+export function selectionStatsKey(
+  channelId: string,
+  selection: LayerChannelSelection | undefined,
+  index: number
+): string {
+  return `${channelId}:${selection?.z ?? 0}:${selection?.c ?? index}:${selection?.t ?? 0}`;
+}
+
+/**
+ * Pick the `c` index for a newly added channel row: the first channel not
+ * already selected by an existing row, or `0` if every channel is in use.
+ */
+export function pickDefaultSelectionForAdd(
+  selections: LayerChannelSelection[],
+  channelNames: string[]
+): number {
+  const used = new Set(selections.map((selection) => selection.c ?? 0));
+  for (let c = 0; c < channelNames.length; c++) {
+    if (!used.has(c)) return c;
+  }
+  return 0;
+}

--- a/packages/avivatorish/src/index.ts
+++ b/packages/avivatorish/src/index.ts
@@ -5,3 +5,4 @@ export * from './constants';
 export * from './omeZarrMultiscales';
 export * from './layerChannelState';
 export * from './channelStats';
+export * from './useChannelSelectionStats';

--- a/packages/avivatorish/src/index.ts
+++ b/packages/avivatorish/src/index.ts
@@ -4,3 +4,4 @@ export * from './utils';
 export * from './constants';
 export * from './omeZarrMultiscales';
 export * from './layerChannelState';
+export * from './channelStats';

--- a/packages/avivatorish/src/useChannelSelectionStats.ts
+++ b/packages/avivatorish/src/useChannelSelectionStats.ts
@@ -1,0 +1,210 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { LayerChannelSelection } from './layerChannelState';
+import type { SelectionRaster } from './utils';
+import { getSingleSelectionStats } from './utils';
+import { selectionStatsKey } from './channelStats';
+
+export type ChannelSelectionEntry = {
+  domain: [number, number];
+  contrastLimits: [number, number];
+  raster?: SelectionRaster;
+};
+
+export type ChannelSelectionStatsResult = {
+  /** Stats keyed by channelId (populated as each fetch completes). */
+  statsByChannelId: Map<string, ChannelSelectionEntry>;
+  /** Positional convenience: `statsByIndex[i]` === `statsByChannelId.get(channelIds[i])`. */
+  statsByIndex: (ChannelSelectionEntry | undefined)[];
+  /** True while a channel's stats are being fetched. */
+  loadingByChannelId: Map<string, boolean>;
+};
+
+function buildSelectionKeys(channelIds: string[], selections: LayerChannelSelection[]): string[] {
+  return channelIds.map((id, i) => selectionStatsKey(id, selections[i], i));
+}
+
+/**
+ * Stateful async channel-stats hook: fetches, caches, and returns per-channel
+ * stats (domain, contrastLimits, raster) keyed by channelId.
+ *
+ * Ported from MDV's `useImageLayerRuntime` cache/load/cancel loop, but returns
+ * data instead of writing into host stores. MDV adopts this by calling the hook
+ * then projecting its output into its zustand stores.
+ *
+ * - Cache persists across renders via a ref; only changed selection keys refetch.
+ * - In-flight fetches are cancelled on unmount or when deps change.
+ * - `fallbackDomains` (typically the current `contrastLimits`) are shown while
+ *   a channel's stats are loading, matching MDV's pre-fetch display.
+ */
+export function useChannelSelectionStats({
+  loader,
+  channelIds,
+  selections,
+  use3d = false,
+  fallbackDomains,
+}: {
+  loader: unknown;
+  channelIds: string[];
+  selections: LayerChannelSelection[];
+  use3d?: boolean;
+  fallbackDomains?: [number, number][];
+}): ChannelSelectionStatsResult {
+  const statsCacheRef = useRef(new Map<string, ChannelSelectionEntry>());
+  const completedKeysRef = useRef<string[]>([]);
+
+  const [result, setResult] = useState<ChannelSelectionStatsResult>(() => ({
+    statsByChannelId: new Map(),
+    loadingByChannelId: new Map(),
+    statsByIndex: [],
+  }));
+
+  // Stable dep strings — same approach as MDV
+  const channelIdsKey = channelIds.join('\0');
+  const selectionsKey = JSON.stringify(selections);
+  const fallbackDomainsKey = fallbackDomains ? JSON.stringify(fallbackDomains) : '';
+  const selectionSignature = buildSelectionKeys(channelIds, selections).join('\0');
+  const channelCount = channelIds.length;
+
+  // Sync projection of the cache into result state, with fallback for unloaded
+  // channels. Runs before paint so consumers never see a flash of stale data
+  // when inputs change and cache has a hit.
+  useLayoutEffect(() => {
+    const cache = statsCacheRef.current;
+    const statsByChannelId = new Map<string, ChannelSelectionEntry>();
+    const loadingByChannelId = new Map<string, boolean>();
+
+    for (let i = 0; i < channelIds.length; i++) {
+      const id = channelIds[i];
+      if (!id) continue;
+      const key = selectionStatsKey(id, selections[i], i);
+      const cached = cache.get(key);
+      if (cached) {
+        statsByChannelId.set(id, cached);
+      } else if (fallbackDomains?.[i]) {
+        const fb = fallbackDomains[i];
+        statsByChannelId.set(id, { domain: fb, contrastLimits: fb });
+      }
+      loadingByChannelId.set(id, false);
+    }
+
+    const statsByIndex = channelIds.map((id) => statsByChannelId.get(id));
+    setResult({ statsByChannelId, loadingByChannelId, statsByIndex });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelIdsKey, selectionsKey, fallbackDomainsKey, loader]);
+
+  // Async fetch loop for selection keys that differ from the last completed set.
+  useEffect(() => {
+    if (!loader) return;
+
+    const nextKeys = buildSelectionKeys(channelIds, selections);
+
+    // Trim if channels were removed
+    if (completedKeysRef.current.length > nextKeys.length) {
+      completedKeysRef.current = completedKeysRef.current.slice(0, nextKeys.length);
+    }
+
+    const indicesToLoad: number[] = [];
+    for (let i = 0; i < nextKeys.length; i++) {
+      if (nextKeys[i] !== completedKeysRef.current[i]) indicesToLoad.push(i);
+    }
+
+    if (indicesToLoad.length === 0) {
+      setResult((prev) => {
+        const allCleared = channelIds.every((id) => !prev.loadingByChannelId.get(id));
+        if (allCleared) return prev;
+        const loadingByChannelId = new Map(prev.loadingByChannelId);
+        for (const id of channelIds) loadingByChannelId.set(id, false);
+        return { ...prev, loadingByChannelId };
+      });
+      return;
+    }
+
+    let cancelled = false;
+    const cache = statsCacheRef.current;
+
+    setResult((prev) => {
+      const loadingByChannelId = new Map(prev.loadingByChannelId);
+      for (const i of indicesToLoad) {
+        const id = channelIds[i];
+        if (id) loadingByChannelId.set(id, true);
+      }
+      return { ...prev, loadingByChannelId };
+    });
+
+    const markCompleted = (index: number, key: string) => {
+      const completed = [...completedKeysRef.current];
+      while (completed.length <= index) completed.push('');
+      completed[index] = key;
+      completedKeysRef.current = completed;
+    };
+
+    const applyEntry = (channelId: string, entry: ChannelSelectionEntry) => {
+      setResult((prev) => {
+        const statsByChannelId = new Map(prev.statsByChannelId);
+        statsByChannelId.set(channelId, entry);
+        const loadingByChannelId = new Map(prev.loadingByChannelId);
+        loadingByChannelId.set(channelId, false);
+        const statsByIndex = channelIds.map((id) => statsByChannelId.get(id));
+        return { statsByChannelId, loadingByChannelId, statsByIndex };
+      });
+    };
+
+    void (async () => {
+      for (const index of indicesToLoad) {
+        if (cancelled) return;
+
+        const channelId = channelIds[index];
+        const selection = selections[index];
+        if (!channelId) continue;
+
+        const statsKey = nextKeys[index];
+        const cached = cache.get(statsKey);
+        if (cached) {
+          applyEntry(channelId, cached);
+          markCompleted(index, statsKey);
+          continue;
+        }
+
+        const vivSelection = {
+          z: selection?.z ?? 0,
+          c: selection?.c ?? index,
+          t: selection?.t ?? 0,
+        };
+
+        try {
+          const stats = await getSingleSelectionStats({
+            loader,
+            selection: vivSelection,
+            use3d,
+            includeRaster: true,
+          });
+          if (cancelled) return;
+
+          const entry: ChannelSelectionEntry = {
+            domain: stats.domain,
+            contrastLimits: stats.contrastLimits,
+            raster: stats.raster,
+          };
+          cache.set(statsKey, entry);
+          applyEntry(channelId, entry);
+          markCompleted(index, statsKey);
+        } catch (error) {
+          console.error('useChannelSelectionStats: failed to load channel stats', error);
+          if (cancelled) return;
+          setResult((prev) => {
+            const loadingByChannelId = new Map(prev.loadingByChannelId);
+            loadingByChannelId.set(channelId, false);
+            return { ...prev, loadingByChannelId };
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelCount, loader, selectionSignature]);
+
+  return result;
+}

--- a/packages/avivatorish/tests/channelStats.spec.ts
+++ b/packages/avivatorish/tests/channelStats.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { pickDefaultSelectionForAdd, selectionStatsKey } from '../src/channelStats';
+
+describe('selectionStatsKey', () => {
+  it('includes channelId and the full z/c/t selection', () => {
+    expect(selectionStatsKey('ch-a', { z: 2, c: 3, t: 1 }, 0)).toBe('ch-a:2:3:1');
+  });
+
+  it('falls back to the row index for c and 0 for z/t when absent', () => {
+    expect(selectionStatsKey('ch-a', {}, 4)).toBe('ch-a:0:4:0');
+    expect(selectionStatsKey('ch-a', undefined, 4)).toBe('ch-a:0:4:0');
+  });
+
+  it('changes when the selection changes for the same channel', () => {
+    const a = selectionStatsKey('ch-a', { c: 0 }, 0);
+    const b = selectionStatsKey('ch-a', { c: 1 }, 0);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('pickDefaultSelectionForAdd', () => {
+  const names = ['DAPI', 'GFP', 'RFP'];
+
+  it('picks the first unused channel index', () => {
+    expect(pickDefaultSelectionForAdd([{ c: 0 }], names)).toBe(1);
+    expect(pickDefaultSelectionForAdd([{ c: 0 }, { c: 1 }], names)).toBe(2);
+  });
+
+  it('treats an absent c as channel 0', () => {
+    expect(pickDefaultSelectionForAdd([{}], names)).toBe(1);
+  });
+
+  it('returns 0 when every channel is already used', () => {
+    expect(pickDefaultSelectionForAdd([{ c: 0 }, { c: 1 }, { c: 2 }], names)).toBe(0);
+  });
+
+  it('returns 0 when there are no channel names', () => {
+    expect(pickDefaultSelectionForAdd([], [])).toBe(0);
+  });
+});

--- a/packages/avivatorish/tests/useChannelSelectionStats.spec.tsx
+++ b/packages/avivatorish/tests/useChannelSelectionStats.spec.tsx
@@ -1,0 +1,175 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getStatsMock } = vi.hoisted(() => ({
+  getStatsMock: vi.fn(),
+}));
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual<typeof import('../src/utils')>('../src/utils');
+  return { ...actual, getSingleSelectionStats: getStatsMock };
+});
+
+import { useChannelSelectionStats } from '../src/useChannelSelectionStats';
+
+const LOADER = {
+  labels: ['c', 'y', 'x'] as string[],
+  shape: [3, 64, 64],
+  getRaster: vi.fn(),
+};
+
+const makeStats = (domain: [number, number] = [0, 255]) => ({
+  domain,
+  contrastLimits: domain,
+  raster: { width: 4, height: 4, data: new Uint16Array(16) },
+});
+
+describe('useChannelSelectionStats', () => {
+  beforeEach(() => {
+    getStatsMock.mockReset();
+  });
+
+  it('starts empty before any fetch resolves', () => {
+    getStatsMock.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a'],
+        selections: [{ c: 0 }],
+      })
+    );
+    expect(result.current.statsByChannelId.size).toBe(0);
+    expect(result.current.statsByIndex).toHaveLength(1);
+    expect(result.current.statsByIndex[0]).toBeUndefined();
+  });
+
+  it('shows fallbackDomains while loading', () => {
+    getStatsMock.mockReturnValue(new Promise(() => {}));
+    const fallback: [number, number] = [10, 200];
+    const { result } = renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a'],
+        selections: [{ c: 0 }],
+        fallbackDomains: [fallback],
+      })
+    );
+    expect(result.current.statsByChannelId.get('ch-a')?.domain).toEqual(fallback);
+  });
+
+  it('populates statsByChannelId and statsByIndex after fetch', async () => {
+    getStatsMock.mockResolvedValue(makeStats([0, 100]));
+    const { result } = renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a'],
+        selections: [{ c: 0 }],
+      })
+    );
+    await waitFor(() => expect(result.current.statsByChannelId.has('ch-a')).toBe(true));
+    expect(result.current.statsByChannelId.get('ch-a')?.domain).toEqual([0, 100]);
+    expect(result.current.statsByIndex[0]?.domain).toEqual([0, 100]);
+  });
+
+  it('marks loading true while fetching, false after', async () => {
+    let resolve!: (v: unknown) => void;
+    getStatsMock.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    const { result } = renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a'],
+        selections: [{ c: 0 }],
+      })
+    );
+
+    await waitFor(() => expect(result.current.loadingByChannelId.get('ch-a')).toBe(true));
+    act(() => { resolve(makeStats()); });
+    await waitFor(() => expect(result.current.loadingByChannelId.get('ch-a')).toBe(false));
+  });
+
+  it('does not refetch when selection key is unchanged', async () => {
+    getStatsMock.mockResolvedValue(makeStats());
+    const { result, rerender } = renderHook(
+      ({ selections }) =>
+        useChannelSelectionStats({ loader: LOADER, channelIds: ['ch-a'], selections }),
+      { initialProps: { selections: [{ c: 0 }] } }
+    );
+
+    await waitFor(() => expect(result.current.statsByChannelId.has('ch-a')).toBe(true));
+    const callsBefore = getStatsMock.mock.calls.length;
+
+    rerender({ selections: [{ c: 0 }] }); // same key
+    // give the effect a chance to fire
+    await act(async () => {});
+    expect(getStatsMock).toHaveBeenCalledTimes(callsBefore);
+  });
+
+  it('refetches when selection changes and calls with the new selection', async () => {
+    getStatsMock.mockResolvedValue(makeStats());
+    const { rerender } = renderHook(
+      ({ selections }) =>
+        useChannelSelectionStats({ loader: LOADER, channelIds: ['ch-a'], selections }),
+      { initialProps: { selections: [{ c: 0 }] as { c: number }[] } }
+    );
+
+    await waitFor(() => expect(getStatsMock).toHaveBeenCalledTimes(1));
+    rerender({ selections: [{ c: 2 }] });
+    await waitFor(() => expect(getStatsMock).toHaveBeenCalledTimes(2));
+    expect(getStatsMock.mock.calls[1][0]).toMatchObject({ selection: { c: 2 } });
+  });
+
+  it('uses the row index as c fallback when selection.c is absent', async () => {
+    getStatsMock.mockResolvedValue(makeStats());
+    renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a', 'ch-b'],
+        selections: [{}, {}],
+      })
+    );
+    await waitFor(() => expect(getStatsMock).toHaveBeenCalledTimes(2));
+    expect(getStatsMock.mock.calls[0][0]).toMatchObject({ selection: { c: 0 } });
+    expect(getStatsMock.mock.calls[1][0]).toMatchObject({ selection: { c: 1 } });
+  });
+
+  it('does not update state after cancellation on unmount', async () => {
+    let callCount = 0;
+    // fetch never resolves during this test
+    getStatsMock.mockReturnValue(new Promise(() => { callCount++; }));
+
+    const { unmount } = renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a'],
+        selections: [{ c: 0 }],
+      })
+    );
+
+    // wait for fetch to begin
+    await waitFor(() => expect(callCount).toBeGreaterThan(0));
+    // unmount should cancel — no thrown "setState on unmounted component" error
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('replaces fallback with real stats once fetch completes', async () => {
+    let resolve!: (v: unknown) => void;
+    getStatsMock.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    const fallback: [number, number] = [10, 200];
+    const { result } = renderHook(() =>
+      useChannelSelectionStats({
+        loader: LOADER,
+        channelIds: ['ch-a'],
+        selections: [{ c: 0 }],
+        fallbackDomains: [fallback],
+      })
+    );
+
+    expect(result.current.statsByChannelId.get('ch-a')?.domain).toEqual(fallback);
+    act(() => { resolve(makeStats([0, 255])); });
+    await waitFor(() =>
+      expect(result.current.statsByChannelId.get('ch-a')?.domain).toEqual([0, 255])
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,12 +171,6 @@ importers:
       geotiff:
         specifier: 2.1.4-beta.0
         version: 2.1.4-beta.0
-      react:
-        specifier: '>=18 <20'
-        version: 19.2.1
-      react-dom:
-        specifier: '>=18 <20'
-        version: 19.2.1(react@19.2.1)
       zarrextra:
         specifier: workspace:*
         version: link:../zarrextra
@@ -184,6 +178,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.2)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/node':
         specifier: 'catalog:'
         version: 22.18.8
@@ -199,6 +196,12 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 27.4.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.1
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.1(react@19.2.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2675,6 +2678,25 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -2702,6 +2724,9 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -3387,6 +3412,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -3407,6 +3436,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-back@3.1.0:
     resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
@@ -4297,6 +4329,9 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
@@ -5506,6 +5541,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   lz4js@0.2.0:
     resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
 
@@ -6589,6 +6628,10 @@ packages:
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-time@1.1.0:
     resolution: {integrity: sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==}
     engines: {node: '>=4'}
@@ -6701,6 +6744,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-json-view-lite@2.5.0:
     resolution: {integrity: sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==}
@@ -11237,6 +11283,27 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
   '@trysound/sax@0.2.0': {}
 
   '@turf/boolean-clockwise@5.1.5':
@@ -11272,6 +11339,8 @@ snapshots:
     optional: true
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -12147,6 +12216,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
@@ -12173,6 +12244,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-back@3.1.0: {}
 
@@ -13126,6 +13201,8 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-converter@0.2.0:
     dependencies:
@@ -14376,6 +14453,8 @@ snapshots:
       yallist: 4.0.0
 
   luxon@3.7.2: {}
+
+  lz-string@1.5.0: {}
 
   lz4js@0.2.0:
     optional: true
@@ -15764,6 +15843,12 @@ snapshots:
       lodash: 4.17.21
       renderkid: 3.0.0
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-time@1.1.0: {}
 
   prism-react-renderer@2.4.1(react@19.2.1):
@@ -15865,6 +15950,8 @@ snapshots:
   react-fast-compare@3.2.2: {}
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-json-view-lite@2.5.0(react@19.2.1):
     dependencies:


### PR DESCRIPTION
## Summary

- **Slice 1** — Two pure, app-agnostic channel-stats helpers exported from `@spatialdata/avivatorish`:
  - `selectionStatsKey(channelId, selection, index)` — canonical cache identity keyed by `channelId:z:c:t`; `c` falls back to the row `index` (not `0`) matching MDV's actual behaviour.
  - `pickDefaultSelectionForAdd(selections, channelNames)` — first unused `c` index for a new channel row.

- **Slice 2** — `useChannelSelectionStats` stateful hook, also exported from `@spatialdata/avivatorish`:
  - Fetches, caches, and returns per-channel stats (`domain`, `contrastLimits`, `raster`) keyed by `channelId`, plus a positional `statsByIndex` array and per-channel loading flags.
  - Ports the async cache/load/cancel engine from MDV's `useImageLayerRuntime` — same `completedKeysRef` no-refetch fast path, `cancelled` flag cancellation, per-row loading flags — but **returns data** instead of writing into host stores, keeping the library/host boundary clean.
  - `fallbackDomains` (typically the host's current `contrastLimits`) are shown synchronously via `useLayoutEffect` while a channel is loading, preventing a flash of empty state.
  - MDV adoption: replace the inner cache/load/cancel loop in `useImageLayerRuntime` with a call to this hook, then project its output into `channelsStore`/`viewerStore`. The non-stats MDV-side bits (`channelOptions`, `pixelValues`, `toneFromVivLayerProps`) remain host-owned and are not in scope.

- Added `@testing-library/react` as a devDep to `@spatialdata/avivatorish` to enable hook tests. 8 new tests (38 total pass).
- Two patch changesets (`avivatorish-channel-stats-helpers`, `avivatorish-stats-hook`) — both rolled into the `fixed` group bump.

## What a reviewer should know

- **Tone/brightness/contrast helpers stay MDV-side** — deliberately excluded. They're a proxy for the "app brings its own extension" pattern; the library doesn't own that surface.
- **Main-thread only for now** — no stats worker in this PR. The worker (for off-thread binning + future histogram UI) is documented in the external design doc and will follow separately.
- **Worker integration won't change this hook's public API** — the inner `getSingleSelectionStats` call is the only seam; swapping it for a worker-backed call is a follow-up internal change.
- `selectionStatsKey` uses `index` as the `c` fallback (not `0`) — this is intentional and matches MDV's current implementation.

## Test plan

- [ ] `pnpm -C packages/avivatorish test` — 38 tests pass
- [ ] `pnpm -C packages/avivatorish build` — builds clean, no TS errors
- [ ] MDV adoption (separate pass): import `useChannelSelectionStats`, `selectionStatsKey`, `pickDefaultSelectionForAdd` from `@spatialdata/avivatorish`; delete local copies from `image_layer_runtime.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)