### PR TITLE
Switch OpenJPH codec to openjph-wasm

### DIFF
--- a/packages/vis/package.json
+++ b/packages/vis/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@vivjs/constants": "catalog:",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cornerstonejs/codec-openjph": "^2.4.7",
+    "openjph-wasm": "^0.1.0",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/zarrextra/README.md
+++ b/packages/zarrextra/README.md
@@ -78,8 +78,8 @@ registerExperimentalHtj2kCodec({ decoder: createOpenJphDecoder(openJphDecode) })
 samples. Unlike the older `@cornerstonejs/codec-openjph` build, it round-trips
 genuine multi-component data losslessly (the repo's `multi-component-codec-findings.md`
 has the details), so a multi-component codestream maps directly onto a Zarr
-chunk's `[..., z, y, x]` layout. The writer currently emits one 2D plane per
-chunk; end-to-end `z > 1` multi-component chunks are planned follow-up work.
+chunk's `[..., z, y, x]` layout. The `mandelbulb` test fixture exercises this:
+each chunk is a single codestream spanning 4 z-planes (`(1, 1, 4, 128, 128)`).
 
 For offline encode (fixtures, recompress), use `encodeHtj2kPlane()` or
 `createOpenJphEncoder()` from the same package. Python `spatialdata-codec-writer`

--- a/packages/zarrextra/README.md
+++ b/packages/zarrextra/README.md
@@ -74,9 +74,12 @@ import { createOpenJphDecoder, registerExperimentalHtj2kCodec } from 'zarrextra'
 registerExperimentalHtj2kCodec({ decoder: createOpenJphDecoder(openJphDecode) });
 ```
 
-`openjph-wasm` decodes J2K/HTJ2K codestreams (including multi-component) and
-returns planar, component-major samples, so a chunk's components map directly to
-a Zarr chunk laid out as `[..., z, y, x]`.
+`openjph-wasm` decodes J2K/HTJ2K codestreams and returns planar, component-major
+samples. Unlike the older `@cornerstonejs/codec-openjph` build, it round-trips
+genuine multi-component data losslessly (the repo's `multi-component-codec-findings.md`
+has the details), so a multi-component codestream maps directly onto a Zarr
+chunk's `[..., z, y, x]` layout. The writer currently emits one 2D plane per
+chunk; end-to-end `z > 1` multi-component chunks are planned follow-up work.
 
 For offline encode (fixtures, recompress), use `encodeHtj2kPlane()` or
 `createOpenJphEncoder()` from the same package. Python `spatialdata-codec-writer`

--- a/packages/zarrextra/README.md
+++ b/packages/zarrextra/README.md
@@ -68,11 +68,15 @@ registerJpeg2kCodec({ decoder: createOpenJpegDecoder(OpenJPEGJS) });
 using either id clearly labelled until there is community/registry alignment.
 
 ```typescript
-import OpenJPHJS from '@cornerstonejs/codec-openjph';
+import { decode as openJphDecode } from 'openjph-wasm';
 import { createOpenJphDecoder, registerExperimentalHtj2kCodec } from 'zarrextra';
 
-registerExperimentalHtj2kCodec({ decoder: createOpenJphDecoder(OpenJPHJS) });
+registerExperimentalHtj2kCodec({ decoder: createOpenJphDecoder(openJphDecode) });
 ```
+
+`openjph-wasm` decodes J2K/HTJ2K codestreams (including multi-component) and
+returns planar, component-major samples, so a chunk's components map directly to
+a Zarr chunk laid out as `[..., z, y, x]`.
 
 For offline encode (fixtures, recompress), use `encodeHtj2kPlane()` or
 `createOpenJphEncoder()` from the same package. Python `spatialdata-codec-writer`
@@ -125,9 +129,9 @@ required for that path.
 | Browser without `@spatialdata/vis` | `enableWorkerChunkDecode()` from `zarrextra/workers` before loading JP2K or HTJ2K data |
 
 Optional dependencies: `@fideus-labs/fizarrita`, `@fideus-labs/worker-pool`,
-`@cornerstonejs/codec-openjpeg`, and `@cornerstonejs/codec-openjph` (bundled into
-the default worker script). Future worker entries may let applications opt into
-lighter worker bundles when JP2K or HTJ2K codecs are not needed.
+`@cornerstonejs/codec-openjpeg`, and `openjph-wasm` (bundled into the default
+worker script). Future worker entries may let applications opt into lighter
+worker bundles when JP2K or HTJ2K codecs are not needed.
 
 Contributor note: new worker-backed entry points should follow the documented
 [worker bundling pattern](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/docs/docs/worker-bundling.mdx)

--- a/packages/zarrextra/package.json
+++ b/packages/zarrextra/package.json
@@ -52,7 +52,7 @@
   },
   "optionalDependencies": {
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cornerstonejs/codec-openjph": "^2.4.7",
+    "openjph-wasm": "^0.1.0",
     "@fideus-labs/fizarrita": "^1.4.1",
     "@fideus-labs/worker-pool": "^1.0.0"
   }

--- a/packages/zarrextra/src/codecs.ts
+++ b/packages/zarrextra/src/codecs.ts
@@ -67,11 +67,13 @@ export type OpenJpegFactory = (opts?: {
 }) => Promise<Record<string, unknown>> | Record<string, unknown>;
 
 /**
- * Init options passed to the `openjph-wasm` `decode`/`encode` functions.
+ * The subset of `openjph-wasm` init options that the zarrextra wrappers forward.
  *
- * Only `locateFile` is forwarded by zarrextra (bundlers use it to resolve the
- * WASM url). The package also supports a `moduleFactory`; callers that need it
- * can pass it to `decode`/`encode` directly.
+ * Only `locateFile` is modelled here (bundlers use it to resolve the WASM url).
+ * `openjph-wasm` also accepts a `moduleFactory`, but it is intentionally omitted
+ * from this wrapper-facing type — callers that need it should call the package's
+ * `decode`/`encode` directly. {@link OpenJphDecode}/{@link OpenJphEncode}
+ * therefore describe only the call shape zarrextra relies on.
  */
 export type OpenJphInitOptions = {
   locateFile?: RegisterImageCodecOptions['locateFile'];
@@ -112,6 +114,21 @@ const HTJ2K_CODEC_IDS = [HTJ2K_OPENJPH_CODEC_ID, ...HTJ2K_LEGACY_CODEC_IDS];
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<Record<string, unknown>>;
+
+/**
+ * Resolve a named export from a dynamically imported (untyped) module, falling
+ * back to a `default` namespace object. The `default` value is narrowed to an
+ * object before its property is read. Returns `unknown`; callers must validate
+ * the result (e.g. `typeof === 'function'`) before using it.
+ */
+export function resolveDynamicExport(mod: Record<string, unknown>, name: string): unknown {
+  if (mod[name] !== undefined) return mod[name];
+  const fallback = mod.default;
+  if (fallback && typeof fallback === 'object') {
+    return (fallback as Record<string, unknown>)[name];
+  }
+  return undefined;
+}
 
 function unsupportedEncode(codecName: string): never {
   throw new Error(`${codecName} encode is not implemented in zarrextra; decode-only for now.`);
@@ -293,8 +310,9 @@ async function loadOpenJpegDecoder(options: RegisterImageCodecOptions): Promise<
  * Adapt the `openjph-wasm` `decode` function to an {@link ImageCodecDecoder}.
  *
  * `decode` returns planar, component-major samples (`data[(c*h + y)*w + x]`),
- * which already match a Zarr chunk laid out as `[..., z, y, x]` in C order, so
- * the planar buffer is returned verbatim and validated against the chunk shape.
+ * which already match a Zarr chunk laid out as `[..., z, y, x]` in C order. This
+ * wrapper just calls `decode` and returns its planar buffer; shape validation
+ * against the chunk metadata happens downstream in the codec entry.
  */
 export function createOpenJphDecoder(
   decode: OpenJphDecode,
@@ -309,12 +327,13 @@ export function createOpenJphDecoder(
 
 async function loadOpenJphDecoder(options: RegisterImageCodecOptions): Promise<ImageCodecDecoder> {
   const mod = await dynamicImport('openjph-wasm');
-  const decode = (mod.decode ??
-    (mod.default as Record<string, unknown> | undefined)?.decode) as OpenJphDecode | undefined;
+  const decode = resolveDynamicExport(mod, 'decode');
   if (typeof decode !== 'function') {
     throw new Error('Could not find a decode() export in openjph-wasm.');
   }
-  return createOpenJphDecoder(decode, options);
+  // External boundary: the dynamic import is untyped, so assert the validated
+  // function to the expected signature.
+  return createOpenJphDecoder(decode as OpenJphDecode, options);
 }
 
 function registerImageCodec(
@@ -353,10 +372,5 @@ export function registerJpeg2kCodec(options: RegisterImageCodecOptions = {}) {
  * `experimental.imagecodecs_htj2k`; both decode through the same OpenJPH WASM path.
  */
 export function registerExperimentalHtj2kCodec(options: RegisterImageCodecOptions = {}) {
-  registerImageCodec(
-    HTJ2K_OPENJPH_CODEC_ID,
-    HTJ2K_CODEC_IDS,
-    loadOpenJphDecoder,
-    options
-  );
+  registerImageCodec(HTJ2K_OPENJPH_CODEC_ID, HTJ2K_CODEC_IDS, loadOpenJphDecoder, options);
 }

--- a/packages/zarrextra/src/codecs.ts
+++ b/packages/zarrextra/src/codecs.ts
@@ -66,9 +66,32 @@ export type OpenJpegFactory = (opts?: {
   locateFile?: RegisterImageCodecOptions['locateFile'];
 }) => Promise<Record<string, unknown>> | Record<string, unknown>;
 
-export type OpenJphFactory = (opts?: {
+/**
+ * Init options passed to the `openjph-wasm` `decode`/`encode` functions.
+ *
+ * Only `locateFile` is forwarded by zarrextra (bundlers use it to resolve the
+ * WASM url). The package also supports a `moduleFactory`; callers that need it
+ * can pass it to `decode`/`encode` directly.
+ */
+export type OpenJphInitOptions = {
   locateFile?: RegisterImageCodecOptions['locateFile'];
-}) => Promise<Record<string, unknown>> | Record<string, unknown>;
+};
+
+/** Planar, component-major decode result returned by `openjph-wasm` `decode`. */
+export type OpenJphDecodedImage = {
+  width: number;
+  height: number;
+  components: number;
+  bitDepth: number;
+  isSigned: boolean;
+  data: ArrayBufferView;
+};
+
+/** The `decode` function exported by `openjph-wasm`. */
+export type OpenJphDecode = (
+  codestream: Uint8Array,
+  options?: OpenJphInitOptions
+) => Promise<OpenJphDecodedImage>;
 
 /** Emscripten locateFile hook that resolves bundled codec WASM to a bundler URL. */
 export function createWasmLocateFile(
@@ -266,55 +289,32 @@ async function loadOpenJpegDecoder(options: RegisterImageCodecOptions): Promise<
   return createOpenJpegDecoder(factory as OpenJpegFactory, options);
 }
 
-type Htj2kDecoderClass = new () => {
-  getEncodedBuffer(length: number): Uint8Array;
-  decode(): void;
-  getDecodedBuffer(): DecodedImageBytes;
-};
-
+/**
+ * Adapt the `openjph-wasm` `decode` function to an {@link ImageCodecDecoder}.
+ *
+ * `decode` returns planar, component-major samples (`data[(c*h + y)*w + x]`),
+ * which already match a Zarr chunk laid out as `[..., z, y, x]` in C order, so
+ * the planar buffer is returned verbatim and validated against the chunk shape.
+ */
 export function createOpenJphDecoder(
-  factory: OpenJphFactory,
+  decode: OpenJphDecode,
   options: Pick<RegisterImageCodecOptions, 'locateFile'> = {}
 ): ImageCodecDecoder {
-  let runtimePromise: Promise<Record<string, unknown>> | undefined;
-  async function getRuntime() {
-    runtimePromise ??= Promise.resolve(
-      factory({
-        locateFile: options.locateFile,
-      })
-    );
-    return await runtimePromise;
-  }
+  const initOptions = options.locateFile ? { locateFile: options.locateFile } : undefined;
   return async (encoded) => {
-    const runtime = await getRuntime();
-    const Decoder = (runtime.HTJ2KDecoder ?? runtime.JPHDecoder ?? runtime.J2KDecoder) as
-      | Htj2kDecoderClass
-      | undefined;
-    if (!Decoder) {
-      throw new Error(
-        'OpenJPH runtime does not expose a known decoder class; pass a custom decoder option.'
-      );
-    }
-    const decoder = new Decoder();
-    decoder.getEncodedBuffer(encoded.length).set(encoded);
-    decoder.decode();
-    return decoder.getDecodedBuffer();
+    const result = await decode(encoded, initOptions);
+    return result.data;
   };
 }
 
 async function loadOpenJphDecoder(options: RegisterImageCodecOptions): Promise<ImageCodecDecoder> {
-  const factoryMod = await dynamicImport('@cornerstonejs/codec-openjph/wasmjs').catch(() =>
-    dynamicImport('@cornerstonejs/codec-openjph')
-  );
-  const factory = (factoryMod.default ?? factoryMod.OpenJPHJS ?? factoryMod) as unknown;
-  if (typeof factory !== 'function') {
-    throw new Error('Could not find an OpenJPH factory export in @cornerstonejs/codec-openjph.');
+  const mod = await dynamicImport('openjph-wasm');
+  const decode = (mod.decode ??
+    (mod.default as Record<string, unknown> | undefined)?.decode) as OpenJphDecode | undefined;
+  if (typeof decode !== 'function') {
+    throw new Error('Could not find a decode() export in openjph-wasm.');
   }
-  const wasmMod = await dynamicImport('@cornerstonejs/codec-openjph/wasm').catch(() => null);
-  const wasmAsset = wasmMod ? ((wasmMod.default ?? wasmMod) as string | undefined) : undefined;
-  const locateFile =
-    options.locateFile ?? (wasmAsset ? createWasmLocateFile(wasmAsset) : undefined);
-  return createOpenJphDecoder(factory as OpenJphFactory, { locateFile });
+  return createOpenJphDecoder(decode, options);
 }
 
 function registerImageCodec(

--- a/packages/zarrextra/src/htj2k-encode.ts
+++ b/packages/zarrextra/src/htj2k-encode.ts
@@ -1,4 +1,4 @@
-import { createWasmLocateFile, type OpenJphFactory, type RegisterImageCodecOptions } from './codecs';
+import { type OpenJphInitOptions, type RegisterImageCodecOptions } from './codecs';
 
 export type Htj2kPlaneDtype = 'uint8' | 'int8' | 'uint16' | 'int16';
 
@@ -10,25 +10,31 @@ export type Htj2kEncodeOptions = {
   locateFile?: RegisterImageCodecOptions['locateFile'];
 };
 
-type Htj2kFrameInfo = {
+type Htj2kPlane = Uint8Array | Uint16Array | Int8Array | Int16Array;
+
+/** Encode input accepted by the `openjph-wasm` `encode` function. */
+export type OpenJphEncodeInput = {
+  /** Planar, component-major samples; `length === components*width*height`. */
+  data: Htj2kPlane | Int32Array;
   width: number;
   height: number;
-  bitsPerSample: 8 | 16;
-  isSigned: boolean;
-  componentCount: 1;
-  isUsingColorTransform: false;
+  components?: number;
+  bitDepth?: number;
+  isSigned?: boolean;
+  reversible?: boolean;
+  quality?: number;
+  decompositions?: number;
+  blockSize?: [number, number];
 };
 
-type Htj2kEncoderClass = new () => {
-  /** OpenJPH WASM API: `setQuality(reversible, quality)`; quality is a quantization factor (lower = better). */
-  setQuality(reversible: boolean, quality: number): void;
-  getDecodedBuffer(frame: Htj2kFrameInfo): ArrayBufferView;
-  encode(): void;
-  getEncodedBuffer(): Uint8Array;
-};
+/** The `encode` function exported by `openjph-wasm`. */
+export type OpenJphEncode = (
+  input: OpenJphEncodeInput,
+  options?: OpenJphInitOptions
+) => Promise<Uint8Array>;
 
 export type OpenJphEncoder = (
-  plane: Uint8Array | Uint16Array | Int8Array | Int16Array,
+  plane: Htj2kPlane,
   size: { width: number; height: number },
   options?: Pick<Htj2kEncodeOptions, 'reversible' | 'quality'>
 ) => Promise<Uint8Array>;
@@ -37,93 +43,46 @@ const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<Record<string, unknown>>;
 
-function bitsPerSampleForPlane(
-  plane: Uint8Array | Uint16Array | Int8Array | Int16Array
-): 8 | 16 {
-  return plane instanceof Uint16Array || plane instanceof Int16Array ? 16 : 8;
-}
-
-function isSignedPlane(plane: Uint8Array | Uint16Array | Int8Array | Int16Array): boolean {
-  return plane instanceof Int8Array || plane instanceof Int16Array;
-}
-
-function frameInfoForPlane(
-  plane: Uint8Array | Uint16Array | Int8Array | Int16Array,
-  size: { width: number; height: number }
-): Htj2kFrameInfo {
-  const { width, height } = size;
-  const expectedValues = width * height;
-  if (plane.length !== expectedValues) {
-    throw new Error(
-      `HTJ2K plane has ${plane.length} samples, expected ${expectedValues} for ${width}x${height}.`
-    );
-  }
-  return {
-    width,
-    height,
-    bitsPerSample: bitsPerSampleForPlane(plane),
-    isSigned: isSignedPlane(plane),
-    componentCount: 1,
-    isUsingColorTransform: false,
-  };
-}
-
-/** Create an HTJ2K encoder backed by an OpenJPH WASM factory. */
+/** Create an HTJ2K encoder backed by the `openjph-wasm` `encode` function. */
 export function createOpenJphEncoder(
-  factory: OpenJphFactory,
+  encode: OpenJphEncode,
   options: Pick<Htj2kEncodeOptions, 'locateFile'> = {}
 ): OpenJphEncoder {
-  let runtimePromise: Promise<Record<string, unknown>> | undefined;
-
-  async function getRuntime() {
-    runtimePromise ??= Promise.resolve(
-      factory({
-        locateFile: options.locateFile,
-      })
-    );
-    return await runtimePromise;
-  }
-
+  const initOptions = options.locateFile ? { locateFile: options.locateFile } : undefined;
   return async (plane, size, encodeOptions = {}) => {
-    const runtime = await getRuntime();
-    const Encoder = runtime.HTJ2KEncoder as Htj2kEncoderClass | undefined;
-    if (!Encoder) {
-      throw new Error('OpenJPH runtime does not expose HTJ2KEncoder.');
+    const expectedValues = size.width * size.height;
+    if (plane.length !== expectedValues) {
+      throw new Error(
+        `HTJ2K plane has ${plane.length} samples, expected ${expectedValues} for ${size.width}x${size.height}.`
+      );
     }
-
     const reversible = encodeOptions.reversible ?? true;
-    const quality = encodeOptions.quality ?? 0;
-    const frame = frameInfoForPlane(plane, size);
-    const encoder = new Encoder();
-    encoder.setQuality(reversible, quality);
-
-    const buffer = encoder.getDecodedBuffer(frame);
-    const target =
-      frame.bitsPerSample === 16
-        ? new Uint16Array(buffer.buffer, buffer.byteOffset, plane.length)
-        : new Uint8Array(buffer.buffer, buffer.byteOffset, plane.length);
-    target.set(plane);
-    encoder.encode();
-    return encoder.getEncodedBuffer();
+    // bitDepth / isSigned are inferred from the typed array by openjph-wasm.
+    const input: OpenJphEncodeInput = {
+      data: plane,
+      width: size.width,
+      height: size.height,
+      components: 1,
+      reversible,
+    };
+    if (!reversible) {
+      input.quality = encodeOptions.quality ?? 0;
+    }
+    return await encode(input, initOptions);
   };
 }
 
-/** Load the optional OpenJPH WASM encoder from @cornerstonejs/codec-openjph. */
+/** Load the optional OpenJPH WASM encoder from openjph-wasm. */
 export async function loadOpenJphEncoder(
   options: Htj2kEncodeOptions = {}
 ): Promise<OpenJphEncoder> {
-  const factoryMod = await dynamicImport('@cornerstonejs/codec-openjph/wasmjs').catch(() =>
-    dynamicImport('@cornerstonejs/codec-openjph')
-  );
-  const factory = (factoryMod.default ?? factoryMod.OpenJPHJS ?? factoryMod) as unknown;
-  if (typeof factory !== 'function') {
-    throw new Error('Could not find an OpenJPH factory export in @cornerstonejs/codec-openjph.');
+  const mod = await dynamicImport('openjph-wasm');
+  const encode = (mod.encode ??
+    (mod.default as Record<string, unknown> | undefined)?.encode) as OpenJphEncode | undefined;
+  if (typeof encode !== 'function') {
+    throw new Error('Could not find an encode() export in openjph-wasm.');
   }
-  const wasmMod = await dynamicImport('@cornerstonejs/codec-openjph/wasm').catch(() => null);
-  const wasmAsset = wasmMod ? ((wasmMod.default ?? wasmMod) as string | undefined) : undefined;
-  const locateFile =
-    options.locateFile ?? (wasmAsset ? createWasmLocateFile(wasmAsset) : undefined);
-  return createOpenJphEncoder(factory as OpenJphFactory, { locateFile });
+  return createOpenJphEncoder(encode, options);
 }
 
 export function planeArrayForDtype(

--- a/packages/zarrextra/src/htj2k-encode.ts
+++ b/packages/zarrextra/src/htj2k-encode.ts
@@ -1,4 +1,8 @@
-import { type OpenJphInitOptions, type RegisterImageCodecOptions } from './codecs';
+import {
+  type OpenJphInitOptions,
+  type RegisterImageCodecOptions,
+  resolveDynamicExport,
+} from './codecs';
 
 export type Htj2kPlaneDtype = 'uint8' | 'int8' | 'uint16' | 'int16';
 
@@ -10,7 +14,7 @@ export type Htj2kEncodeOptions = {
   locateFile?: RegisterImageCodecOptions['locateFile'];
 };
 
-type Htj2kPlane = Uint8Array | Uint16Array | Int8Array | Int16Array;
+export type Htj2kPlane = Uint8Array | Uint16Array | Int8Array | Int16Array;
 
 /** Encode input accepted by the `openjph-wasm` `encode` function. */
 export type OpenJphEncodeInput = {
@@ -77,18 +81,16 @@ export async function loadOpenJphEncoder(
   options: Htj2kEncodeOptions = {}
 ): Promise<OpenJphEncoder> {
   const mod = await dynamicImport('openjph-wasm');
-  const encode = (mod.encode ??
-    (mod.default as Record<string, unknown> | undefined)?.encode) as OpenJphEncode | undefined;
+  const encode = resolveDynamicExport(mod, 'encode');
   if (typeof encode !== 'function') {
     throw new Error('Could not find an encode() export in openjph-wasm.');
   }
-  return createOpenJphEncoder(encode, options);
+  // External boundary: the dynamic import is untyped, so assert the validated
+  // function to the expected signature.
+  return createOpenJphEncoder(encode as OpenJphEncode, options);
 }
 
-export function planeArrayForDtype(
-  dtype: Htj2kPlaneDtype,
-  bytes: Uint8Array
-) {
+export function planeArrayForDtype(dtype: Htj2kPlaneDtype, bytes: Uint8Array) {
   switch (dtype) {
     case 'uint8':
       return bytes;

--- a/packages/zarrextra/src/index.ts
+++ b/packages/zarrextra/src/index.ts
@@ -213,7 +213,9 @@ export {
   registerExperimentalHtj2kCodec,
   type ImageCodecDecoder,
   type OpenJpegFactory,
-  type OpenJphFactory,
+  type OpenJphDecode,
+  type OpenJphDecodedImage,
+  type OpenJphInitOptions,
   type RegisterImageCodecOptions,
 } from './codecs';
 export {
@@ -223,6 +225,8 @@ export {
   planeArrayForDtype,
   type Htj2kEncodeOptions,
   type Htj2kPlaneDtype,
+  type OpenJphEncode,
+  type OpenJphEncodeInput,
   type OpenJphEncoder,
 } from './htj2k-encode';
 export {

--- a/packages/zarrextra/src/index.ts
+++ b/packages/zarrextra/src/index.ts
@@ -224,6 +224,7 @@ export {
   loadOpenJphEncoder,
   planeArrayForDtype,
   type Htj2kEncodeOptions,
+  type Htj2kPlane,
   type Htj2kPlaneDtype,
   type OpenJphEncode,
   type OpenJphEncodeInput,

--- a/packages/zarrextra/src/workers/codec-worker-init.ts
+++ b/packages/zarrextra/src/workers/codec-worker-init.ts
@@ -1,5 +1,5 @@
-import OpenJPHJS from '@cornerstonejs/codec-openjph';
-import openJphWasmUrl from '@cornerstonejs/codec-openjph/wasm?url';
+import { decode as openJphDecode } from 'openjph-wasm';
+import openJphWasmUrl from 'openjph-wasm/wasm/libopenjph.wasm?url';
 import OpenJPEGJS from '@cornerstonejs/codec-openjpeg/decode';
 import openJpegWasmUrl from '@cornerstonejs/codec-openjpeg/decodewasm?url';
 import {
@@ -18,7 +18,7 @@ registerJpeg2kCodec({
   }),
 });
 registerExperimentalHtj2kCodec({
-  decoder: createOpenJphDecoder(OpenJPHJS, {
+  decoder: createOpenJphDecoder(openJphDecode, {
     locateFile: createWasmLocateFile(openJphWasmUrl),
   }),
 });

--- a/packages/zarrextra/tests/codecs.spec.ts
+++ b/packages/zarrextra/tests/codecs.spec.ts
@@ -86,11 +86,14 @@ describe('codec registration', () => {
       if (!factory) throw new Error('Expected codec factory to be registered.');
 
       const entry = await factory();
-      const codec = entry.fromConfig({}, {
-        data_type: 'uint8',
-        chunk_shape: [2, 2],
-        codecs: [{ name: codecName, configuration: {} }],
-      });
+      const codec = entry.fromConfig(
+        {},
+        {
+          data_type: 'uint8',
+          chunk_shape: [2, 2],
+          codecs: [{ name: codecName, configuration: {} }],
+        }
+      );
 
       const chunk = await codec.decode(new Uint8Array([99]));
       expect(Array.from((chunk as zarr.Chunk<'uint8'>).data)).toEqual([5, 6, 7, 8]);
@@ -153,11 +156,14 @@ describe('codec registration', () => {
       if (!factory) throw new Error('Expected codec factory to be registered.');
 
       const entry = await factory();
-      const codec = entry.fromConfig({}, {
-        data_type: 'uint8',
-        chunk_shape: [2, 2],
-        codecs: [{ name: codecName, configuration: {} }],
-      });
+      const codec = entry.fromConfig(
+        {},
+        {
+          data_type: 'uint8',
+          chunk_shape: [2, 2],
+          codecs: [{ name: codecName, configuration: {} }],
+        }
+      );
 
       const chunk = await codec.decode(new Uint8Array([99]));
       expect(Array.from((chunk as zarr.Chunk<'uint8'>).data)).toEqual([13, 14, 15, 16]);
@@ -210,9 +216,16 @@ describe('codec registration', () => {
     }
 
     const { createOpenJphEncoder } = await import('../src/htj2k-encode');
-    const { createOpenJphDecoder } = await import('../src/codecs');
-    const encode = openjph.encode as Parameters<typeof createOpenJphEncoder>[0];
-    const decode = openjph.decode as Parameters<typeof createOpenJphDecoder>[0];
+    const { createOpenJphDecoder, resolveDynamicExport } = await import('../src/codecs');
+    // Mirror the production loaders: resolve named exports with a `default` fallback.
+    const encodeExport = resolveDynamicExport(openjph, 'encode');
+    const decodeExport = resolveDynamicExport(openjph, 'decode');
+    if (typeof encodeExport !== 'function' || typeof decodeExport !== 'function') {
+      console.warn('Skipping HTJ2K encode round-trip: openjph-wasm encode/decode not found.');
+      return;
+    }
+    const encode = encodeExport as Parameters<typeof createOpenJphEncoder>[0];
+    const decode = decodeExport as Parameters<typeof createOpenJphDecoder>[0];
     const width = 64;
     const height = 64;
     const plane = new Uint16Array(width * height);
@@ -227,12 +240,14 @@ describe('codec registration', () => {
     expect(encoded.byteLength).toBeGreaterThan(0);
 
     const decoder = createOpenJphDecoder(decode);
-    const decoded = toUint16Array(await decoder(encoded, {
-      dataType: 'uint16',
-      shape: [height, width],
-      codecs: [{ name: 'experimental.openjph_htj2k', configuration: {} }],
-      fillValue: 0,
-    }));
+    const decoded = toUint16Array(
+      await decoder(encoded, {
+        dataType: 'uint16',
+        shape: [height, width],
+        codecs: [{ name: 'experimental.openjph_htj2k', configuration: {} }],
+        fillValue: 0,
+      })
+    );
     expect(decoded).toEqual(plane);
   });
 
@@ -246,7 +261,14 @@ describe('codec registration', () => {
     }
 
     const { createOpenJphEncoder } = await import('../src/htj2k-encode');
-    const encode = openjph.encode as Parameters<typeof createOpenJphEncoder>[0];
+    const { resolveDynamicExport } = await import('../src/codecs');
+    // Mirror the production loader: resolve the named export with a `default` fallback.
+    const encodeExport = resolveDynamicExport(openjph, 'encode');
+    if (typeof encodeExport !== 'function') {
+      console.warn('Skipping HTJ2K lossy quality test: openjph-wasm encode not found.');
+      return;
+    }
+    const encode = encodeExport as Parameters<typeof createOpenJphEncoder>[0];
     const width = 64;
     const height = 64;
     const plane = new Uint16Array(width * height);

--- a/packages/zarrextra/tests/codecs.spec.ts
+++ b/packages/zarrextra/tests/codecs.spec.ts
@@ -203,19 +203,16 @@ describe('codec registration', () => {
   it('encodes and decodes a small HTJ2K plane with OpenJPH WASM', async () => {
     let openjph: Record<string, unknown>;
     try {
-      openjph = await import('@cornerstonejs/codec-openjph');
+      openjph = await import('openjph-wasm');
     } catch {
-      console.warn(
-        'Skipping HTJ2K encode round-trip: @cornerstonejs/codec-openjph is not installed.'
-      );
+      console.warn('Skipping HTJ2K encode round-trip: openjph-wasm is not installed.');
       return;
     }
 
     const { createOpenJphEncoder } = await import('../src/htj2k-encode');
     const { createOpenJphDecoder } = await import('../src/codecs');
-    const factory = (openjph.default ?? openjph.OpenJPHJS ?? openjph) as Parameters<
-      typeof createOpenJphEncoder
-    >[0];
+    const encode = openjph.encode as Parameters<typeof createOpenJphEncoder>[0];
+    const decode = openjph.decode as Parameters<typeof createOpenJphDecoder>[0];
     const width = 64;
     const height = 64;
     const plane = new Uint16Array(width * height);
@@ -225,11 +222,11 @@ describe('codec registration', () => {
       }
     }
 
-    const encoder = createOpenJphEncoder(factory);
+    const encoder = createOpenJphEncoder(encode);
     const encoded = await encoder(plane, { width, height }, { reversible: true, quality: 0 });
     expect(encoded.byteLength).toBeGreaterThan(0);
 
-    const decoder = createOpenJphDecoder(factory);
+    const decoder = createOpenJphDecoder(decode);
     const decoded = toUint16Array(await decoder(encoded, {
       dataType: 'uint16',
       shape: [height, width],
@@ -242,18 +239,14 @@ describe('codec registration', () => {
   it('lossy OpenJPH quality changes encoded size on a fractal plane', async () => {
     let openjph: Record<string, unknown>;
     try {
-      openjph = await import('@cornerstonejs/codec-openjph');
+      openjph = await import('openjph-wasm');
     } catch {
-      console.warn(
-        'Skipping HTJ2K lossy quality test: @cornerstonejs/codec-openjph is not installed.'
-      );
+      console.warn('Skipping HTJ2K lossy quality test: openjph-wasm is not installed.');
       return;
     }
 
     const { createOpenJphEncoder } = await import('../src/htj2k-encode');
-    const factory = (openjph.default ?? openjph.OpenJPHJS ?? openjph) as Parameters<
-      typeof createOpenJphEncoder
-    >[0];
+    const encode = openjph.encode as Parameters<typeof createOpenJphEncoder>[0];
     const width = 64;
     const height = 64;
     const plane = new Uint16Array(width * height);
@@ -274,7 +267,7 @@ describe('codec registration', () => {
       }
     }
 
-    const encoder = createOpenJphEncoder(factory);
+    const encoder = createOpenJphEncoder(encode);
     const high = await encoder(plane, { width, height }, { reversible: false, quality: 0.001 });
     const mid = await encoder(plane, { width, height }, { reversible: false, quality: 0.01 });
     const low = await encoder(plane, { width, height }, { reversible: false, quality: 0.1 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,9 +413,6 @@ importers:
       '@cornerstonejs/codec-openjpeg':
         specifier: ^1.3.0
         version: 1.3.0
-      '@cornerstonejs/codec-openjph':
-        specifier: ^2.4.7
-        version: 2.4.7
       '@types/node':
         specifier: 'catalog:'
         version: 22.18.8
@@ -434,6 +431,9 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 27.4.0
+      openjph-wasm:
+        specifier: ^0.1.0
+        version: 0.1.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -475,15 +475,15 @@ importers:
       '@cornerstonejs/codec-openjpeg':
         specifier: ^1.3.0
         version: 1.3.0
-      '@cornerstonejs/codec-openjph':
-        specifier: ^2.4.7
-        version: 2.4.7
       '@fideus-labs/fizarrita':
         specifier: ^1.4.1
         version: 1.4.1(zarrita@0.7.1)
       '@fideus-labs/worker-pool':
         specifier: ^1.0.0
         version: 1.0.0
+      openjph-wasm:
+        specifier: ^0.1.0
+        version: 0.1.0
 
 packages:
 
@@ -1313,10 +1313,6 @@ packages:
 
   '@cornerstonejs/codec-openjpeg@1.3.0':
     resolution: {integrity: sha512-hP8WAZ63AcaDYmHbBVTY04x424AglXsRHrI6VBdW4eTiJ76f0heWrEodT9Sb3sNwazzYuyMOIZNndJPeVSeHcw==}
-    engines: {node: '>=0.14'}
-
-  '@cornerstonejs/codec-openjph@2.4.7':
-    resolution: {integrity: sha512-qvP4q4JDib7mi9r7LqKOwqz7YZ8gjtDX4ZCezeYf8+eb7MBXCz5uXAMeVF3yz9Axw4XiIMdB/pqXkm8tqCl13w==}
     engines: {node: '>=0.14'}
 
   '@csstools/cascade-layer-name-parser@2.0.5':
@@ -6034,6 +6030,9 @@ packages:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
 
+  openjph-wasm@0.1.0:
+    resolution: {integrity: sha512-0AD6EYf6yt762Q3Pu6g0xVGOeK4XRyZ39zIf2YpfzZUBblHVv3hwJsaxpnLWvSmZLXRp61GA7hg2vQ+ssZngRw==}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -9139,8 +9138,6 @@ snapshots:
     optional: true
 
   '@cornerstonejs/codec-openjpeg@1.3.0': {}
-
-  '@cornerstonejs/codec-openjph@2.4.7': {}
 
   '@csstools/cascade-layer-name-parser@2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -15206,6 +15203,8 @@ snapshots:
       is-wsl: 2.2.0
 
   opener@1.5.2: {}
+
+  openjph-wasm@0.1.0: {}
 
   outdent@0.5.0: {}
 

--- a/python/spatialdata-codec-writer/README.md
+++ b/python/spatialdata-codec-writer/README.md
@@ -27,8 +27,8 @@ For local development in this monorepo:
 pnpm test:codec-writer
 ```
 
-(`openjphjs.js` / `openjphjs.wasm` are gitignored; the script vendors them from
-`@cornerstonejs/codec-openjph` before pytest.)
+(The vendored `vendor/openjph/` assets are gitignored; the script vendors them
+from `openjph-wasm` before pytest.)
 
 Before building or running HTJ2K tests manually:
 

--- a/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
+++ b/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
@@ -14,11 +14,13 @@ The encoder/decoder is the [`openjph-wasm`](https://www.npmjs.com/package/openjp
 package. Earlier versions used `@cornerstonejs/codec-openjph`, whose WASM build
 could not round-trip independent multi-component data
 (see [multi-component-codec-findings.md](./multi-component-codec-findings.md));
-`openjph-wasm` does round-trip multi-component, planar, component-major buffers
-losslessly. That makes `z > 1` multi-component chunks *possible*, but they are
-not yet wired up end-to-end: the writer still encodes **one 2D plane per chunk**
-(chunk shapes begin `(1, 1, 1, ...)`), so volumetric `z > 1` chunk support
-remains future work.
+`openjph-wasm` round-trips multi-component, planar, component-major buffers
+losslessly, so a chunk's leading dims (e.g. z) are encoded as **codestream
+components**. `z > 1` chunks are now wired up end-to-end: the writer encodes a
+chunk's z-planes as one multi-component codestream, and the JS reader decodes it
+back to planar `[..., z, y, x]`. The `mandelbulb` fixture uses
+`(1, 1, 4, 128, 128)` chunks (4 z-planes per codestream). Chunk shapes must begin
+`(1, 1)` (t and c are not chunked across components).
 
 ## Contracts
 
@@ -28,7 +30,7 @@ remains future work.
 | Zarr codec id (legacy decode) | `experimental.imagecodecs_htj2k` |
 | Encoder label | `openjph-wasm` (manifest `encoder` field) |
 | Array metadata | Zarr v3; `codecs: [{ name, configuration: {} }]` |
-| Chunk bytes | Raw HTJ2K bitstream per 2D spatial plane (last two axes) |
+| Chunk bytes | One HTJ2K codestream per chunk; the chunk's leading dims (z) are codestream components, the last two axes are the y/x plane |
 | Browser read | `registerExperimentalHtj2kCodec()` registers both ids |
 
 ## Encode flow

--- a/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
+++ b/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
@@ -13,9 +13,12 @@ We may re-evaluate native encode later; the frontend still decodes the legacy id
 The encoder/decoder is the [`openjph-wasm`](https://www.npmjs.com/package/openjph-wasm)
 package. Earlier versions used `@cornerstonejs/codec-openjph`, whose WASM build
 could not round-trip independent multi-component data
-(see [multi-component-codec-findings.md](./multi-component-codec-findings.md)).
-`openjph-wasm` decodes/encodes multi-component codestreams with planar,
-component-major buffers.
+(see [multi-component-codec-findings.md](./multi-component-codec-findings.md));
+`openjph-wasm` does round-trip multi-component, planar, component-major buffers
+losslessly. That makes `z > 1` multi-component chunks *possible*, but they are
+not yet wired up end-to-end: the writer still encodes **one 2D plane per chunk**
+(chunk shapes begin `(1, 1, 1, ...)`), so volumetric `z > 1` chunk support
+remains future work.
 
 ## Contracts
 

--- a/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
+++ b/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
@@ -5,10 +5,17 @@ of persistent Node.js workers (`spatialdata_codec_writer/vendor/encode-plane.mjs
 New stores are labelled `experimental.openjph_htj2k`.
 
 Native `imagecodecs` HTJ2K encode is intentionally **not** used: PyPI wheels are
-often stub-only, conda installs are awkward, and the WASM encoder exposes
-`setQuality(reversible, quality)` for preset control. We may re-evaluate native
-encode later; the frontend still decodes the legacy id
+often stub-only, conda installs are awkward, and the WASM encoder exposes a
+simple `encode({ data, width, height, components, reversible, quality })` call.
+We may re-evaluate native encode later; the frontend still decodes the legacy id
 `experimental.imagecodecs_htj2k` for older fixtures.
+
+The encoder/decoder is the [`openjph-wasm`](https://www.npmjs.com/package/openjph-wasm)
+package. Earlier versions used `@cornerstonejs/codec-openjph`, whose WASM build
+could not round-trip independent multi-component data
+(see [multi-component-codec-findings.md](./multi-component-codec-findings.md)).
+`openjph-wasm` decodes/encodes multi-component codestreams with planar,
+component-major buffers.
 
 ## Contracts
 
@@ -27,22 +34,22 @@ encode later; the frontend still decodes the legacy id
 Python spatialdata-codec-writer
   → EncoderPool (N persistent Node workers)
   → vendored encode-plane.mjs --worker
-  → OpenJPH HTJ2KEncoder.setQuality(reversible, quality).encode()
+  → openjph-wasm encode({ data, width, height, components, reversible, quality })
   → HTJ2K bytes per chunk
 ```
 
 Vendoring: run `node scripts/vendor-openjph-for-python.mjs` at the monorepo root
-to copy `@cornerstonejs/codec-openjph` dist assets into the Python package wheel.
-The copied `vendor/openjph/` blobs are gitignored; CI and `pnpm test:codec-writer`
-run the vendor step after `pnpm install`.
+to copy `openjph-wasm` dist assets (`index.mjs` + `wasm/`) into the Python package
+wheel. The copied `vendor/openjph/` blobs are gitignored; CI and
+`pnpm test:codec-writer` run the vendor step after `pnpm install`.
 
 Preset mapping:
 
-| Preset | `setQuality(reversible, quality)` |
+| Preset | `encode({ reversible, quality })` |
 |--------|-----------------------------------|
-| `lossless` | `(true, 0)` |
-| `balanced` | `(false, 0.0002)` |
-| `small` | `(false, 0.001)` |
+| `lossless` | `{ reversible: true }` |
+| `balanced` | `{ reversible: false, quality: 0.0002 }` |
+| `small` | `{ reversible: false, quality: 0.001 }` |
 
 `quality` is a float quantization factor (lower = better fidelity, larger output).
 Integer values above ~15 with `reversible=false` produce degenerate output.

--- a/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
+++ b/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
@@ -1,0 +1,127 @@
+# Multi-component (volumetric) codec findings
+
+Status: **investigation** — captured to inform an alternative codec implementation.
+
+## Question
+
+Can a single zarr chunk span more than one z-plane (`z > 1` per chunk) by
+encoding the planes as **components of one codestream**, rather than one 2D
+codestream per chunk?
+
+The JPEG 2000 family supports this in principle. HTJ2K / JPEG 2000 Part 2 define
+efficient coding of multi-component, hyperspectral, and volumetric content
+(see the HTJ2K white paper, <https://htj2k.com/wp-content/uploads/white-paper.pdf>).
+So the *format* is not the limitation. The question is whether the WASM
+codecs this repo ships can actually round-trip independent multi-component data.
+
+## TL;DR
+
+The standard supports multi-component coding, but **neither WASM decoder this
+repo currently depends on round-trips independent multi-component data**:
+
+- `@cornerstonejs/codec-openjph` 2.4.7 (HTJ2K): silently keeps only component 0
+  and replicates it across all output components; planes 2..N are lost.
+- `@cornerstonejs/codec-openjpeg` 1.3.0 (JPEG 2000): multi-component decode
+  throws an internal binding error for `componentCount >= 2`.
+
+Encoding z-planes as components today would therefore **silently lose data** on
+this stack. An alternative implementation needs a decoder verified to round-trip
+multi-component before the writer can rely on it. OpenJPH (the C++/reference
+library) is a reasonable target, but the **cornerstone WASM build of it is not a
+working reference for multi-component** — see below.
+
+## How it was tested
+
+Each codec was exercised directly through its own encode → decode API (not via
+zarr), with:
+
+- `componentCount = N`, `isUsingColorTransform = false`
+- 16-bit unsigned samples
+- the encoder's `getDecodedBuffer(frame)` confirmed to return `N · width ·
+  height` samples, with every sample filled before `encode()`
+- inputs tried in both **planar** (`comp0` plane, then `comp1` plane, …) and
+  **pixel-interleaved** (`c0p0, c1p0, …`) order
+
+Round-trip identity (`decode(encode(x)) == x`) was the pass criterion. For
+single-component (`N = 1`) both codecs round-trip cleanly, which confirms the
+harness itself is correct.
+
+## OpenJPH (HTJ2K) — `@cornerstonejs/codec-openjph` 2.4.7
+
+| componentCount | round-trips? | observed |
+|----------------|--------------|----------|
+| 1 | ✅ | `[1,2,3,4]` → `[1,2,3,4]` |
+| 2 | ❌ | `[1,2,3,4,5,6,7,8]` → `[1,1,2,2,3,3,4,4]` |
+| 3 | ❌ | `…` → `[1,1,1,2,2,2,3,3,3,4,4,4]` |
+| 4 | ❌ | `…` → `[1,1,1,1,2,2,2,2,…]` |
+
+Interpreting the `N = 2`, 2×2 case (planar input
+`comp0 = [1,2,3,4]`, `comp1 = [5,6,7,8]`):
+
+- The output is **pixel-interleaved** (`out[pixel*C + comp]`).
+- Every output component equals the **first input plane** (`[1,2,3,4]`); the
+  second plane (`[5,6,7,8]`) is gone.
+
+Feeding **interleaved** input instead does not help — the encoder reads the first
+`N` samples as component 0 and discards the rest:
+
+```
+interleaved input: 10,200,11,201,12,202,13,203
+decoded output   : 10,10,200,200,11,11,201,201   (plane 1 lost, comp0 replicated)
+```
+
+So the cornerstone wrapper effectively encodes a single component and replicates
+it on decode. It is built for grayscale (1 component) and RGB-with-color-transform
+(3 components, MCT on); arbitrary independent N-component planar data is not
+supported by this build. **It cannot serve as a multi-component reference.**
+
+## OpenJPEG (JPEG 2000) — `@cornerstonejs/codec-openjpeg` 1.3.0
+
+- `componentCount = 1`: round-trips.
+- `componentCount >= 2`: decode fails with an internal binding error
+  (`Ea[F[((f + 4) >> 2)]] is not a function`) — i.e. the multi-component decode
+  path is not wired up in this WASM build.
+
+Note: very small planes (e.g. 2×2) also fail to *encode* with
+"Number of resolutions is too high in comparison to the size of tiles"; use
+`setDecompositions(<=3)` or a larger plane (≥32×32) when probing. This is
+unrelated to the multi-component failure but worth knowing for test fixtures.
+
+## Implications for an alternative implementation
+
+1. **The decoder is the gate.** Before writing multi-component codestreams,
+   verify the target decoder round-trips independent N-component data with the
+   probe pattern above (planar in, planar out, identity). Do not assume a build
+   supports it because the format does.
+
+2. **OpenJPH the library vs. the cornerstone WASM build.** The cornerstone build
+   is not a usable multi-component reference. If OpenJPH is the intended
+   reference, build/bind it directly (or use the C++ tools / `imagecodecs` native
+   HTJ2K) and confirm multi-component round-trip there first.
+
+3. **Component layout matters.** When a working multi-component decoder is in
+   place, pin down its buffer convention (planar vs. pixel-interleaved) on both
+   encode input and decode output, and map zarr's planar `[…, z, y, x]` C-order
+   chunk buffer accordingly. Lossless masks layout mistakes as long as encode and
+   decode use the *same* convention, but mismatches wreck component decorrelation
+   and lossy fidelity.
+
+4. **Fallback if no multi-component decoder lands:** pack N standard 2D
+   codestreams into one chunk behind a small length-prefixed container. This
+   works on the current decoders and is lossless/lossy-safe, but it is a custom
+   container, not a single standards-compliant volumetric codestream, so external
+   tools reading the chunk as a raw codestream will not understand it.
+
+## Current writer behaviour (for reference)
+
+The writer encodes **one 2D codestream per chunk** and enforces it:
+
+- `_validate_codec_chunks` requires chunk shape to begin `(1, 1, 1, …)`
+  (`scripts/fixture_writer.py`).
+- `_write_array_chunks` reshapes each chunk to `(y, x)` and calls
+  `encode_image_plane` (`scripts/fixture_writer.py`).
+- The volumetric `mandelbulb` fixture is `t=2, c=1, z=8, 128×128` chunked at
+  `(1, 1, 1, 128, 128)` — one z-plane per chunk (`scripts/mandelbulb_fixtures.py`).
+
+On the read side, `packages/zarrextra/src/codecs.ts` decodes one codestream per
+chunk and validates `decoded length === product(chunk_shape)`.

--- a/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
+++ b/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
@@ -65,7 +65,7 @@ Interpreting the `N = 2`, 2×2 case (planar input
 Feeding **interleaved** input instead does not help — the encoder reads the first
 `N` samples as component 0 and discards the rest:
 
-```
+```text
 interleaved input: 10,200,11,201,12,202,13,203
 decoded output   : 10,10,200,200,11,11,201,201   (plane 1 lost, comp0 replicated)
 ```

--- a/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
+++ b/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
@@ -112,16 +112,24 @@ unrelated to the multi-component failure but worth knowing for test fixtures.
    container, not a single standards-compliant volumetric codestream, so external
    tools reading the chunk as a raw codestream will not understand it.
 
-## Current writer behaviour (for reference)
+## Resolution (implemented)
 
-The writer encodes **one 2D codestream per chunk** and enforces it:
+Switching to `openjph-wasm` (which round-trips multi-component data losslessly,
+verified for several component counts) resolved the blocker, and `z > 1` chunks
+are now implemented end-to-end:
 
-- `_validate_codec_chunks` requires chunk shape to begin `(1, 1, 1, …)`
-  (`scripts/fixture_writer.py`).
-- `_write_array_chunks` reshapes each chunk to `(y, x)` and calls
-  `encode_image_plane` (`scripts/fixture_writer.py`).
+- `_validate_codec_chunks` now only requires chunk shape to begin `(1, 1)` (t/c)
+  — z may be > 1 (`scripts/fixture_writer.py`).
+- `_write_array_chunks` reshapes each chunk to `(components, y, x)` and calls
+  `encode_image_chunk`, encoding the z-planes as one multi-component codestream;
+  it self-validates losslessly via `decode_image_chunk` (openjph-wasm worker).
 - The volumetric `mandelbulb` fixture is `t=2, c=1, z=8, 128×128` chunked at
-  `(1, 1, 1, 128, 128)` — one z-plane per chunk (`scripts/mandelbulb_fixtures.py`).
+  `(1, 1, 4, 128, 128)` — 4 z-planes per codestream (`scripts/mandelbulb_fixtures.py`).
 
-On the read side, `packages/zarrextra/src/codecs.ts` decodes one codestream per
-chunk and validates `decoded length === product(chunk_shape)`.
+On the read side, `packages/zarrextra/src/codecs.ts` decodes the codestream to a
+planar component-major buffer and validates `decoded length === product(chunk_shape)`,
+so a multi-component chunk maps straight onto `[..., z, y, x]`.
+
+`imagecodecs` is no longer on the HTJ2K path (encode and decode both go through
+the openjph-wasm worker — the same WASM as the JS reader); it remains only for
+the JPEG2000 fixture path.

--- a/python/spatialdata-codec-writer/scripts/fixture_writer.py
+++ b/python/spatialdata-codec-writer/scripts/fixture_writer.py
@@ -13,8 +13,8 @@ from spatialdata_codec_writer.codecs import (
     HTJ2K_ENCODER,
     CodecName,
     chunk_grid,
-    decode_image_plane,
-    encode_image_plane,
+    decode_image_chunk,
+    encode_image_chunk,
     is_htj2k_codec,
     package_version,
     sha256,
@@ -220,28 +220,36 @@ def _write_array_chunks(
 ) -> list[dict[str, Any]]:
     is_lossless = _is_lossless_encode(codec, encode_options)
     refs: list[dict[str, Any]] = []
+    # Each chunk's leading (t, c, z) dims become codestream components; the last
+    # two axes are the y/x plane. For z>1 chunks this is a multi-component codestream.
+    n_components = 1
+    for size in chunks[:-2]:
+        n_components *= int(size)
+    plane_h, plane_w = int(chunks[-2]), int(chunks[-1])
     for coords in chunk_grid(image.shape, chunks):
         chunk = _extract_chunk(image, chunks, coords)
-        encoded = encode_image_plane(
-            chunk.reshape(chunk.shape[-2], chunk.shape[-1]), codec, encode_options or {}
-        )
+        volume = chunk.reshape(n_components, plane_h, plane_w)
+        encoded = encode_image_chunk(volume, codec, encode_options or {})
         chunk_rel = f"{array_path}/c/" + "/".join(str(c) for c in coords)
         chunk_path = store_path / chunk_rel
         chunk_path.parent.mkdir(parents=True, exist_ok=True)
         chunk_path.write_bytes(encoded)
 
-        expected_plane = chunk.reshape(chunk.shape[-2], chunk.shape[-1])
         if len(refs) < 4:
-            decoded = decode_image_plane(encoded, codec).reshape(expected_plane.shape)
-            if is_lossless and not np.array_equal(decoded, expected_plane):
+            decoded = decode_image_chunk(
+                encoded, codec, components=n_components, height=plane_h, width=plane_w
+            )
+            if is_lossless and not np.array_equal(decoded, volume):
                 raise RuntimeError(f"Codec self-validation failed for chunk {coords}")
-            sample_plane = expected_plane if is_lossless else decoded
+            sample = volume if is_lossless else decoded
+            sample_plane = sample[0]
             refs.append(
                 {
                     "coords": list(coords),
                     "path": chunk_rel,
                     "encoded_sha256": sha256(encoded),
-                    "decoded_sha256": sha256(sample_plane.tobytes()),
+                    "decoded_sha256": sha256(sample.tobytes()),
+                    "components": n_components,
                     "samples": [
                         int(sample_plane[0, 0]),
                         int(sample_plane[0, min(1, sample_plane.shape[1] - 1)]),
@@ -255,8 +263,8 @@ def _write_array_chunks(
 def _validate_codec_chunks(chunks: tuple[int, int, int, int, int]) -> None:
     if len(chunks) != 5:
         raise ValueError("chunks must have shape [t, c, z, y, x]")
-    if chunks[:3] != (1, 1, 1):
-        raise ValueError("v1 codec fixtures require chunks beginning with (1, 1, 1)")
+    if chunks[:2] != (1, 1):
+        raise ValueError("codec fixtures require chunks beginning with (1, 1) for t and c")
 
 
 def _multiscale_levels(base: np.ndarray, multiscale: bool) -> list[np.ndarray]:

--- a/python/spatialdata-codec-writer/scripts/mandelbulb_fixtures.py
+++ b/python/spatialdata-codec-writer/scripts/mandelbulb_fixtures.py
@@ -11,7 +11,9 @@ MANDELBULB_FIXTURE_SIZE = 128
 MANDELBULB_FIXTURE_T = 2
 MANDELBULB_FIXTURE_C = 1
 MANDELBULB_FIXTURE_Z = 8
-MANDELBULB_FIXTURE_CHUNKS: tuple[int, int, int, int, int] = (1, 1, 1, 128, 128)
+# z>1 per chunk: each chunk is a 4-plane multi-component HTJ2K codestream, and z
+# (8) spans two chunks — exercising both multi-component and multi-z-chunk reads.
+MANDELBULB_FIXTURE_CHUNKS: tuple[int, int, int, int, int] = (1, 1, 4, 128, 128)
 MANDELBULB_FIXTURE_IMAGE_KEY = "mandelbulb"
 MANDELBULB_ENCODE_OPTIONS = {"reversible": True}
 

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/codecs.py
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/codecs.py
@@ -6,6 +6,13 @@ from importlib import metadata
 from pathlib import Path
 from typing import Any, Literal
 
+# `imagecodecs` is used only for the JPEG2000 (`imagecodecs_jpeg2k`) path. The
+# HTJ2K path goes through the vendored openjph-wasm worker (the same WASM the JS
+# reader uses), so it round-trips genuine multi-component (volumetric) data and
+# stays consistent encode-vs-decode. We deliberately do not maintain extra HTJ2K
+# backends here: native `imagecodecs` HTJ2K is build-fragile, and `itkwasm-htj2k`
+# (https://pypi.org/project/itkwasm-htj2k/) has been unmaintained for ~2 years.
+# If we ever drop the JPEG2000 fixture path, `imagecodecs` can be removed too.
 import imagecodecs
 import numpy as np
 
@@ -44,13 +51,15 @@ def sha256(data: bytes | bytearray) -> str:
 
 
 def decode_htj2k_plane(encoded: bytes | bytearray) -> np.ndarray:
-    """Decode an HTJ2K plane for validation (native imagecodecs when available)."""
-    htj2k = getattr(imagecodecs, "HTJ2K", None)
-    if htj2k is not None and getattr(htj2k, "available", False):
-        decoder = getattr(imagecodecs, "htj2k_decode", None)
-        if decoder is not None:
-            return decoder(encoded)
-    return imagecodecs.jpeg2k_decode(encoded)
+    """Decode an HTJ2K codestream via the vendored openjph-wasm worker.
+
+    Returns a 2D ``(y, x)`` array for single-component codestreams, otherwise a
+    ``(components, y, x)`` array.
+    """
+    from .htj2k_encode import decode_htj2k
+
+    array = decode_htj2k(encoded)
+    return array[0] if array.shape[0] == 1 else array
 
 
 def decode_image_plane(encoded: bytes | bytearray, codec: str) -> np.ndarray:
@@ -61,17 +70,21 @@ def decode_image_plane(encoded: bytes | bytearray, codec: str) -> np.ndarray:
     raise ValueError(f"Unsupported image codec: {codec}")
 
 
-def encode_htj2k_plane_with_options(
-    plane: np.ndarray, encode_options: dict[str, Any] | None = None
+def _htj2k_components(array: np.ndarray) -> int:
+    return int(np.prod(array.shape[:-2])) if array.ndim > 2 else 1
+
+
+def _encode_htj2k_with_options(
+    volume: np.ndarray, encode_options: dict[str, Any] | None = None
 ) -> bytes | bytearray:
-    from .htj2k_encode import encode_htj2k_plane, htj2k_encode_available, openjph_encode_options
+    from .htj2k_encode import encode_htj2k, htj2k_encode_available, openjph_encode_options
 
     if not htj2k_encode_available():
         raise RuntimeError(
             "HTJ2K encode is not available. Install spatialdata-codec-writer with Node.js on PATH."
         )
     reversible, quality = openjph_encode_options(encode_options or {})
-    return encode_htj2k_plane(plane, reversible=reversible, quality=quality)
+    return encode_htj2k(volume, reversible=reversible, quality=quality)
 
 
 def encode_image_plane(
@@ -81,7 +94,46 @@ def encode_image_plane(
     if codec == CODEC_JPEG2K:
         return imagecodecs.jpeg2k_encode(array, **encode_options)
     if codec == CODEC_HTJ2K_OPENJPH:
-        return encode_htj2k_plane_with_options(array, encode_options)
+        return _encode_htj2k_with_options(array, encode_options)
+    raise ValueError(f"Unsupported image codec: {codec}")
+
+
+def encode_image_chunk(
+    volume: np.ndarray, codec: str, encode_options: dict[str, Any]
+) -> bytes | bytearray:
+    """Encode a chunk of one or more planar components to a single codestream.
+
+    ``volume`` is ``(components, y, x)`` (or 2D for a single component). HTJ2K
+    encodes the planes as codestream components (e.g. z-planes of a volumetric
+    chunk); multi-component JPEG2K chunks are not produced by this writer.
+    """
+    array = np.ascontiguousarray(np.asarray(volume))
+    components = _htj2k_components(array)
+    if codec == CODEC_HTJ2K_OPENJPH:
+        return _encode_htj2k_with_options(array, encode_options)
+    if codec == CODEC_JPEG2K:
+        if components == 1:
+            plane = array.reshape(array.shape[-2], array.shape[-1])
+            return imagecodecs.jpeg2k_encode(plane, **encode_options)
+        raise NotImplementedError(
+            "Multi-component JPEG2K chunks are not supported; use HTJ2K (openjph)."
+        )
+    raise ValueError(f"Unsupported image codec: {codec}")
+
+
+def decode_image_chunk(
+    encoded: bytes | bytearray, codec: str, *, components: int, height: int, width: int
+) -> np.ndarray:
+    """Decode a chunk codestream to a ``(components, y, x)`` array."""
+    if is_htj2k_codec(codec):
+        from .htj2k_encode import decode_htj2k
+
+        return decode_htj2k(encoded).reshape(components, height, width)
+    if codec == CODEC_JPEG2K:
+        decoded = np.asarray(imagecodecs.jpeg2k_decode(encoded))
+        if decoded.ndim == 2:
+            return decoded.reshape(1, height, width)
+        return np.moveaxis(decoded, -1, 0).reshape(components, height, width)
     raise ValueError(f"Unsupported image codec: {codec}")
 
 

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
@@ -61,7 +61,7 @@ class OpenJphEncoderWorker:
             raise RuntimeError("Node.js is required for HTJ2K encode but was not found on PATH.")
         if not _ENCODE_SCRIPT.is_file():
             raise RuntimeError(f"HTJ2K encode script not found: {_ENCODE_SCRIPT}")
-        if not (openjph_vendor_dir() / "openjphjs.wasm").is_file():
+        if not (openjph_vendor_dir() / "wasm" / "libopenjph.wasm").is_file():
             raise RuntimeError(
                 f"Vendored OpenJPH WASM not found under {openjph_vendor_dir()}. "
                 "Run scripts/vendor-openjph-for-python.mjs before building the package."

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
@@ -61,10 +61,17 @@ class OpenJphEncoderWorker:
             raise RuntimeError("Node.js is required for HTJ2K encode but was not found on PATH.")
         if not _ENCODE_SCRIPT.is_file():
             raise RuntimeError(f"HTJ2K encode script not found: {_ENCODE_SCRIPT}")
-        if not (openjph_vendor_dir() / "wasm" / "libopenjph.wasm").is_file():
+        vendor_dir = openjph_vendor_dir()
+        missing = [
+            str(path.relative_to(vendor_dir))
+            for path in (vendor_dir / "index.mjs", vendor_dir / "wasm" / "libopenjph.wasm")
+            if not path.is_file()
+        ]
+        if missing:
             raise RuntimeError(
-                f"Vendored OpenJPH WASM not found under {openjph_vendor_dir()}. "
-                "Run scripts/vendor-openjph-for-python.mjs before building the package."
+                f"Vendored openjph-wasm assets missing under {vendor_dir}: {', '.join(missing)}. "
+                "Both index.mjs and wasm/libopenjph.wasm are required; "
+                "run scripts/vendor-openjph-for-python.mjs before building the package."
             )
 
         self._lock = threading.Lock()

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
@@ -35,21 +35,44 @@ def openjph_encode_options(encode_options: dict[str, Any]) -> tuple[bool, float]
     return False, float(quality)
 
 
-def _plane_request_payload(
-    plane: np.ndarray, *, reversible: bool, quality: float
+def _encode_request_payload(
+    volume: np.ndarray, *, reversible: bool, quality: float
 ) -> dict[str, Any]:
-    array = np.ascontiguousarray(np.asarray(plane))
-    if array.ndim != 2:
-        raise ValueError(f"HTJ2K encode expects a 2D plane, got shape {array.shape}.")
-    height, width = (int(value) for value in array.shape)
+    """Build an encode request for a 2D plane or a 3D (components, y, x) volume.
+
+    The samples are sent planar / component-major (C-order of the array), which
+    is exactly the layout openjph-wasm expects for multi-component codestreams.
+    """
+    array = np.ascontiguousarray(np.asarray(volume))
+    if array.ndim == 2:
+        components, (height, width) = 1, (int(array.shape[0]), int(array.shape[1]))
+    elif array.ndim == 3:
+        components, height, width = (int(value) for value in array.shape)
+    else:
+        raise ValueError(
+            f"HTJ2K encode expects a 2D plane or 3D (components, y, x) volume, got shape {array.shape}."
+        )
     return {
         "width": width,
         "height": height,
+        "components": components,
         "dtype": array.dtype.name,
         "reversible": reversible,
         "quality": quality,
         "plane": base64.b64encode(array.tobytes(order="C")).decode("ascii"),
     }
+
+
+# Decode response header (see vendor/encode-plane.mjs): little-endian
+# u32 components, u32 height, u32 width, u8 bytesPerSample, u8 isSigned.
+_DECODE_HEADER = struct.Struct("<IIIBB")
+
+
+def _decode_response_to_array(resp: bytes) -> np.ndarray:
+    components, height, width, bytes_per_sample, is_signed = _DECODE_HEADER.unpack_from(resp, 0)
+    body = resp[_DECODE_HEADER.size :]
+    dtype = np.dtype(f"{'i' if is_signed else 'u'}{bytes_per_sample}")
+    return np.frombuffer(body, dtype=dtype).reshape(components, height, width)
 
 
 class OpenJphEncoderWorker:
@@ -99,29 +122,37 @@ class OpenJphEncoderWorker:
                         self._proc.kill()
             self._proc = None  # type: ignore[assignment]
 
-    def encode_plane(
-        self, plane: np.ndarray, *, reversible: bool = True, quality: float = 0.0
-    ) -> bytes:
+    def _request(self, payload: dict[str, Any]) -> bytes:
         with self._lock:
             if self._proc is None or self._proc.poll() is not None:
-                raise RuntimeError("HTJ2K encoder worker is not running.")
-            payload = json.dumps(
-                _plane_request_payload(plane, reversible=reversible, quality=quality)
-            ).encode("utf-8")
+                raise RuntimeError("HTJ2K worker is not running.")
+            body = json.dumps(payload).encode("utf-8")
             assert self._proc.stdin is not None
             assert self._proc.stdout is not None
-            self._proc.stdin.write(struct.pack(">I", len(payload)))
-            self._proc.stdin.write(payload)
+            self._proc.stdin.write(struct.pack(">I", len(body)))
+            self._proc.stdin.write(body)
             self._proc.stdin.flush()
 
             header = self._read_exact(self._proc.stdout, 5)
             status = header[0]
             length = struct.unpack(">I", header[1:5])[0]
-            body = self._read_exact(self._proc.stdout, length)
+            resp = self._read_exact(self._proc.stdout, length)
             if status != 0:
-                message = body.decode("utf-8", errors="replace")
-                raise RuntimeError(message or "HTJ2K encode failed.")
-            return bytes(body)
+                message = resp.decode("utf-8", errors="replace")
+                raise RuntimeError(message or "HTJ2K worker failed.")
+            return bytes(resp)
+
+    def encode(self, volume: np.ndarray, *, reversible: bool = True, quality: float = 0.0) -> bytes:
+        return self._request(
+            _encode_request_payload(volume, reversible=reversible, quality=quality)
+        )
+
+    def decode(self, codestream: bytes | bytearray) -> np.ndarray:
+        payload = {
+            "op": "decode",
+            "codestream": base64.b64encode(bytes(codestream)).decode("ascii"),
+        }
+        return _decode_response_to_array(self._request(payload))
 
     @staticmethod
     def _read_exact(stream: Any, length: int) -> bytes:
@@ -145,13 +176,17 @@ class EncoderPool:
         self._next = 0
         self._lock = threading.Lock()
 
-    def encode_plane(
-        self, plane: np.ndarray, *, reversible: bool = True, quality: float = 0.0
-    ) -> bytes:
+    def _next_worker(self) -> OpenJphEncoderWorker:
         with self._lock:
             worker = self._workers[self._next]
             self._next = (self._next + 1) % len(self._workers)
-        return worker.encode_plane(plane, reversible=reversible, quality=quality)
+        return worker
+
+    def encode(self, volume: np.ndarray, *, reversible: bool = True, quality: float = 0.0) -> bytes:
+        return self._next_worker().encode(volume, reversible=reversible, quality=quality)
+
+    def decode(self, codestream: bytes | bytearray) -> np.ndarray:
+        return self._next_worker().decode(codestream)
 
     def close(self) -> None:
         for worker in self._workers:
@@ -208,6 +243,16 @@ def htj2k_encode_available() -> bool:
     return True
 
 
+def encode_htj2k(
+    volume: np.ndarray,
+    *,
+    reversible: bool = True,
+    quality: float = 0.0,
+) -> bytes:
+    """Encode a 2D plane or 3D (components, y, x) volume to an HTJ2K codestream."""
+    return get_encoder_pool().encode(volume, reversible=reversible, quality=quality)
+
+
 def encode_htj2k_plane(
     plane: np.ndarray,
     *,
@@ -215,4 +260,9 @@ def encode_htj2k_plane(
     quality: float = 0.0,
 ) -> bytes:
     """Encode one 2D plane through the vendored OpenJPH WASM worker pool."""
-    return get_encoder_pool().encode_plane(plane, reversible=reversible, quality=quality)
+    return encode_htj2k(plane, reversible=reversible, quality=quality)
+
+
+def decode_htj2k(codestream: bytes | bytearray) -> np.ndarray:
+    """Decode an HTJ2K codestream to a (components, y, x) array via openjph-wasm."""
+    return get_encoder_pool().decode(codestream)

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/vendor/encode-plane.mjs
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/vendor/encode-plane.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Encode one 2D image plane to HTJ2K via vendored OpenJPH WASM.
+ * Encode one 2D image plane to HTJ2K via vendored openjph-wasm.
  *
  * One-shot mode (default):
  *   stdin: JSON { width, height, dtype, reversible?, quality?, plane: base64 }
@@ -17,7 +17,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const vendorDir = dirname(fileURLToPath(import.meta.url));
-const openjphDir = join(vendorDir, 'openjph');
+const openjphIndex = join(vendorDir, 'openjph', 'index.mjs');
 const workerMode = process.argv.includes('--worker');
 
 async function readStdin() {
@@ -44,23 +44,14 @@ function planeArrayForDtype(dtype, bytes) {
 }
 
 async function loadEncoder() {
-  const mod = await import(pathToFileURL(join(openjphDir, 'openjphjs.js')).href);
-  const factory = mod.default ?? mod.OpenJPHJS ?? mod;
-  if (typeof factory !== 'function') {
-    throw new Error('Could not load OpenJPH WASM factory.');
+  const mod = await import(pathToFileURL(openjphIndex).href);
+  if (typeof mod.encode !== 'function') {
+    throw new Error('Vendored openjph-wasm does not expose encode().');
   }
-  const wasmPath = join(openjphDir, 'openjphjs.wasm');
-  return await factory({
-    locateFile: (path) => (path.endsWith('.wasm') ? wasmPath : path),
-  });
+  return mod;
 }
 
 async function encodePlane(runtime, request) {
-  const Encoder = runtime.HTJ2KEncoder;
-  if (!Encoder) {
-    throw new Error('OpenJPH runtime does not expose HTJ2KEncoder.');
-  }
-
   const { width, height, dtype } = request;
   const reversible = request.reversible ?? true;
   const quality = request.quality ?? 0;
@@ -71,25 +62,12 @@ async function encodePlane(runtime, request) {
     throw new Error(`Plane has ${plane.length} samples, expected ${expectedValues}.`);
   }
 
-  const frame = {
-    width,
-    height,
-    bitsPerSample: dtype === 'uint8' || dtype === 'int8' ? 8 : 16,
-    isSigned: dtype === 'int8' || dtype === 'int16',
-    componentCount: 1,
-    isUsingColorTransform: false,
-  };
-
-  const encoder = new Encoder();
-  encoder.setQuality(reversible, quality);
-  const buffer = encoder.getDecodedBuffer(frame);
-  const target =
-    frame.bitsPerSample === 16
-      ? new Uint16Array(buffer.buffer, buffer.byteOffset, plane.length)
-      : new Uint8Array(buffer.buffer, buffer.byteOffset, plane.length);
-  target.set(plane);
-  encoder.encode();
-  return encoder.getEncodedBuffer();
+  // bitDepth / isSigned are inferred from the typed array by openjph-wasm.
+  const input = { data: plane, width, height, components: 1, reversible };
+  if (!reversible) {
+    input.quality = quality;
+  }
+  return await runtime.encode(input);
 }
 
 function writeResponse(status, payload) {

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/vendor/encode-plane.mjs
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/vendor/encode-plane.mjs
@@ -1,20 +1,28 @@
 #!/usr/bin/env node
+import { dirname, join } from 'node:path';
 /**
- * Encode one 2D image plane to HTJ2K via vendored openjph-wasm.
+ * Encode/decode HTJ2K chunks via vendored openjph-wasm.
  *
- * One-shot mode (default):
- *   stdin: JSON { width, height, dtype, reversible?, quality?, plane: base64 }
+ * A chunk is one or more planar, component-major planes (e.g. z-planes of a
+ * volumetric chunk) encoded as a single multi-component codestream.
+ *
+ * One-shot mode (default): encode only.
+ *   stdin: JSON { width, height, components?, dtype, reversible?, quality?, plane: base64 }
  *   stdout: raw HTJ2K bytes
  *
  * Worker mode (--worker):
  *   Repeated length-prefixed requests on stdin; length-prefixed responses on stdout.
  *   Request:  [u32 BE length][JSON utf8]
+ *     encode (default): { width, height, components?, dtype, reversible?, quality?, plane: base64 }
+ *     decode:           { op: "decode", codestream: base64 }
  *   Response: [u8 status][u32 BE length][payload]
- *     status 0 = HTJ2K bytes
+ *     status 0 = payload (encode: HTJ2K bytes; decode: 14-byte header + planar samples)
  *     status 1 = UTF-8 error message
+ *
+ *   Decode header (little-endian): u32 components, u32 height, u32 width,
+ *     u8 bytesPerSample, u8 isSigned — followed by the raw component-major samples.
  */
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { dirname, join } from 'node:path';
 
 const vendorDir = dirname(fileURLToPath(import.meta.url));
 const openjphIndex = join(vendorDir, 'openjph', 'index.mjs');
@@ -43,31 +51,53 @@ function planeArrayForDtype(dtype, bytes) {
   }
 }
 
-async function loadEncoder() {
+async function loadRuntime() {
   const mod = await import(pathToFileURL(openjphIndex).href);
-  if (typeof mod.encode !== 'function') {
-    throw new Error('Vendored openjph-wasm does not expose encode().');
+  if (typeof mod.encode !== 'function' || typeof mod.decode !== 'function') {
+    throw new Error('Vendored openjph-wasm does not expose encode()/decode().');
   }
   return mod;
 }
 
-async function encodePlane(runtime, request) {
+async function encodeChunk(runtime, request) {
   const { width, height, dtype } = request;
+  const components = request.components ?? 1;
   const reversible = request.reversible ?? true;
   const quality = request.quality ?? 0;
   const planeBytes = Buffer.from(request.plane, 'base64');
-  const plane = planeArrayForDtype(dtype, planeBytes);
-  const expectedValues = width * height;
-  if (plane.length !== expectedValues) {
-    throw new Error(`Plane has ${plane.length} samples, expected ${expectedValues}.`);
+  const data = planeArrayForDtype(dtype, planeBytes);
+  const expectedValues = width * height * components;
+  if (data.length !== expectedValues) {
+    throw new Error(`Chunk has ${data.length} samples, expected ${expectedValues}.`);
   }
 
   // bitDepth / isSigned are inferred from the typed array by openjph-wasm.
-  const input = { data: plane, width, height, components: 1, reversible };
+  const input = { data, width, height, components, reversible };
   if (!reversible) {
     input.quality = quality;
   }
   return await runtime.encode(input);
+}
+
+async function decodeChunk(runtime, request) {
+  const codestream = Buffer.from(request.codestream, 'base64');
+  const result = await runtime.decode(new Uint8Array(codestream));
+  const samples = result.data;
+  const bytesPerSample = samples.BYTES_PER_ELEMENT;
+  const header = Buffer.alloc(14);
+  header.writeUInt32LE(result.components, 0);
+  header.writeUInt32LE(result.height, 4);
+  header.writeUInt32LE(result.width, 8);
+  header.writeUInt8(bytesPerSample, 12);
+  header.writeUInt8(result.isSigned ? 1 : 0, 13);
+  const body = Buffer.from(samples.buffer, samples.byteOffset, samples.byteLength);
+  return Buffer.concat([header, body]);
+}
+
+async function handleRequest(runtime, request) {
+  return request.op === 'decode'
+    ? await decodeChunk(runtime, request)
+    : await encodeChunk(runtime, request);
 }
 
 function writeResponse(status, payload) {
@@ -99,8 +129,8 @@ async function* readLengthPrefixedJson(stream) {
 async function runWorker(runtime) {
   for await (const request of readLengthPrefixedJson(process.stdin)) {
     try {
-      const encoded = await encodePlane(runtime, request);
-      writeResponse(0, Buffer.from(encoded));
+      const payload = await handleRequest(runtime, request);
+      writeResponse(0, Buffer.from(payload));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       writeResponse(1, Buffer.from(message, 'utf8'));
@@ -110,12 +140,12 @@ async function runWorker(runtime) {
 
 async function runOnce(runtime) {
   const request = JSON.parse((await readStdin()).toString('utf8'));
-  const encoded = await encodePlane(runtime, request);
+  const encoded = await encodeChunk(runtime, request);
   process.stdout.write(Buffer.from(encoded));
 }
 
 async function main() {
-  const runtime = await loadEncoder();
+  const runtime = await loadRuntime();
   if (workerMode) {
     await runWorker(runtime);
     return;

--- a/python/spatialdata-codec-writer/tests/test_htj2k_encode.py
+++ b/python/spatialdata-codec-writer/tests/test_htj2k_encode.py
@@ -28,10 +28,35 @@ def test_encoder_pool_round_trip() -> None:
     pool = EncoderPool(workers=2)
     try:
         plane = np.arange(16, dtype=np.uint16).reshape(4, 4)
-        encoded_a = pool.encode_plane(plane, reversible=True, quality=0.0)
-        encoded_b = pool.encode_plane(plane, reversible=True, quality=0.0)
+        encoded_a = pool.encode(plane, reversible=True, quality=0.0)
+        encoded_b = pool.encode(plane, reversible=True, quality=0.0)
         assert len(encoded_a) > 0
         assert len(encoded_b) > 0
+    finally:
+        pool.close()
+        shutdown_encoder_pool()
+
+
+@pytest.mark.skipif(
+    not htj2k_encode_available(),
+    reason="No HTJ2K encoder is available in this environment.",
+)
+def test_multi_component_round_trip() -> None:
+    """A z>1 chunk encodes to one multi-component codestream and round-trips losslessly."""
+    shutdown_encoder_pool()
+    pool = EncoderPool(workers=1)
+    try:
+        components, height, width = 4, 8, 8
+        volume = (
+            np.arange(components * height * width, dtype=np.uint16).reshape(
+                components, height, width
+            )
+            % 4096
+        )
+        encoded = pool.encode(volume, reversible=True, quality=0.0)
+        decoded = pool.decode(encoded)
+        assert decoded.shape == (components, height, width)
+        assert np.array_equal(decoded, volume)
     finally:
         pool.close()
         shutdown_encoder_pool()

--- a/python/spatialdata-codec-writer/tests/test_htj2k_encode.py
+++ b/python/spatialdata-codec-writer/tests/test_htj2k_encode.py
@@ -15,8 +15,8 @@ from spatialdata_codec_writer.htj2k_encode import (
 
 def test_vendored_encode_assets_exist() -> None:
     assert encode_script_path().is_file()
-    assert (openjph_vendor_dir() / "openjphjs.js").is_file()
-    assert (openjph_vendor_dir() / "openjphjs.wasm").is_file()
+    assert (openjph_vendor_dir() / "index.mjs").is_file()
+    assert (openjph_vendor_dir() / "wasm" / "libopenjph.wasm").is_file()
 
 
 @pytest.mark.skipif(

--- a/python/spatialdata-codec-writer/tests/test_writer.py
+++ b/python/spatialdata-codec-writer/tests/test_writer.py
@@ -88,11 +88,13 @@ def test_write_mandelbulb_fixture(tmp_path: Path) -> None:
     assert list(fixture.manifest["chunks"]) == list(MANDELBULB_FIXTURE_CHUNKS)
 
     first_chunk = fixture.manifest["chunks_checked"][0]
+    assert first_chunk["components"] == 4
     encoded = (fixture.store_path / first_chunk["path"]).read_bytes()
     decoded = decode_htj2k_plane(encoded)
 
-    assert decoded.shape == (128, 128)
-    assert int(decoded[0, 0]) == first_chunk["samples"][0]
+    # z>1 chunk: one multi-component codestream (4 z-planes) -> (components, y, x).
+    assert decoded.shape == (4, 128, 128)
+    assert int(decoded[0, 0, 0]) == first_chunk["samples"][0]
 
 
 def test_image_to_tczyx_uses_named_dimensions() -> None:

--- a/scripts/encode-htj2k-plane.mjs
+++ b/scripts/encode-htj2k-plane.mjs
@@ -14,17 +14,16 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 function resolveOpenJphRoot() {
   const candidates = [
-    join(repoRoot, 'node_modules', '@cornerstonejs', 'codec-openjph'),
-    join(repoRoot, 'packages', 'zarrextra', 'node_modules', '@cornerstonejs', 'codec-openjph'),
+    join(repoRoot, 'node_modules', 'openjph-wasm'),
+    join(repoRoot, 'packages', 'zarrextra', 'node_modules', 'openjph-wasm'),
+    join(repoRoot, 'packages', 'vis', 'node_modules', 'openjph-wasm'),
   ];
   for (const candidate of candidates) {
-    if (existsSync(join(candidate, 'dist', 'openjphjs.js'))) {
+    if (existsSync(join(candidate, 'dist', 'index.js'))) {
       return candidate;
     }
   }
-  throw new Error(
-    'Could not find @cornerstonejs/codec-openjph. Install monorepo dependencies with pnpm install.'
-  );
+  throw new Error('Could not find openjph-wasm. Install monorepo dependencies with pnpm install.');
 }
 
 async function readStdin() {
@@ -51,24 +50,15 @@ function planeArrayForDtype(dtype, bytes) {
 }
 
 async function loadEncoder() {
-  const openjphRoot = resolveOpenJphRoot();
-  const mod = await import(pathToFileURL(join(openjphRoot, 'dist/openjphjs.js')).href);
-  const factory = mod.default ?? mod.OpenJPHJS ?? mod;
-  if (typeof factory !== 'function') {
-    throw new Error('Could not load OpenJPH WASM factory.');
+  const indexPath = join(resolveOpenJphRoot(), 'dist', 'index.js');
+  const mod = await import(pathToFileURL(indexPath).href);
+  if (typeof mod.encode !== 'function') {
+    throw new Error('openjph-wasm does not expose encode().');
   }
-  const wasmPath = join(openjphRoot, 'dist/openjphjs.wasm');
-  return await factory({
-    locateFile: (path) => (path.endsWith('.wasm') ? wasmPath : path),
-  });
+  return mod;
 }
 
 async function encodePlane(runtime, request) {
-  const Encoder = runtime.HTJ2KEncoder;
-  if (!Encoder) {
-    throw new Error('OpenJPH runtime does not expose HTJ2KEncoder.');
-  }
-
   const { width, height, dtype } = request;
   const reversible = request.reversible ?? true;
   const quality = request.quality ?? 0;
@@ -79,25 +69,12 @@ async function encodePlane(runtime, request) {
     throw new Error(`Plane has ${plane.length} samples, expected ${expectedValues}.`);
   }
 
-  const frame = {
-    width,
-    height,
-    bitsPerSample: dtype === 'uint8' || dtype === 'int8' ? 8 : 16,
-    isSigned: dtype === 'int8' || dtype === 'int16',
-    componentCount: 1,
-    isUsingColorTransform: false,
-  };
-
-  const encoder = new Encoder();
-  encoder.setQuality(reversible, quality);
-  const buffer = encoder.getDecodedBuffer(frame);
-  const target =
-    frame.bitsPerSample === 16
-      ? new Uint16Array(buffer.buffer, buffer.byteOffset, plane.length)
-      : new Uint8Array(buffer.buffer, buffer.byteOffset, plane.length);
-  target.set(plane);
-  encoder.encode();
-  return encoder.getEncodedBuffer();
+  // bitDepth / isSigned are inferred from the typed array by openjph-wasm.
+  const input = { data: plane, width, height, components: 1, reversible };
+  if (!reversible) {
+    input.quality = quality;
+  }
+  return await runtime.encode(input);
 }
 
 async function main() {

--- a/scripts/vendor-openjph-for-python.mjs
+++ b/scripts/vendor-openjph-for-python.mjs
@@ -54,8 +54,21 @@ const wasmSource = join(distDir, 'wasm');
 if (!existsSync(wasmSource)) {
   throw new Error(`Required openjph-wasm wasm directory not found: ${wasmSource}`);
 }
-for (const name of readdirSync(wasmSource)) {
-  const dest = join(vendorWasmDir, name);
-  copyFileSync(join(wasmSource, name), dest);
-  console.log(`Vendored wasm/${name} -> ${dest}`);
+
+/** Recursively copy a directory tree, copying files and recreating subdirs. */
+function copyTree(srcDir, destDir, relBase) {
+  mkdirSync(destDir, { recursive: true });
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const src = join(srcDir, entry.name);
+    const dest = join(destDir, entry.name);
+    const rel = `${relBase}/${entry.name}`;
+    if (entry.isDirectory()) {
+      copyTree(src, dest, rel);
+    } else {
+      copyFileSync(src, dest);
+      console.log(`Vendored ${rel} -> ${dest}`);
+    }
+  }
 }
+
+copyTree(wasmSource, vendorWasmDir, 'wasm');

--- a/scripts/vendor-openjph-for-python.mjs
+++ b/scripts/vendor-openjph-for-python.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 /**
- * Copy @cornerstonejs/codec-openjph dist assets into spatialdata-codec-writer
- * package data for standalone pip installs (no monorepo checkout required).
+ * Copy openjph-wasm dist assets into spatialdata-codec-writer package data for
+ * standalone pip installs (no monorepo checkout required).
+ *
+ * Vendors `dist/index.js` and the whole `dist/wasm/` directory so the package's
+ * own `new URL("./wasm/libopenjph.mjs", import.meta.url)` resolution keeps
+ * working from the vendored copy.
  */
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -11,20 +15,19 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 function resolveOpenJphRoot() {
   const candidates = [
-    join(repoRoot, 'node_modules', '@cornerstonejs', 'codec-openjph'),
-    join(repoRoot, 'packages', 'zarrextra', 'node_modules', '@cornerstonejs', 'codec-openjph'),
+    join(repoRoot, 'node_modules', 'openjph-wasm'),
+    join(repoRoot, 'packages', 'zarrextra', 'node_modules', 'openjph-wasm'),
+    join(repoRoot, 'packages', 'vis', 'node_modules', 'openjph-wasm'),
   ];
   for (const candidate of candidates) {
-    if (existsSync(join(candidate, 'dist', 'openjphjs.js'))) {
+    if (existsSync(join(candidate, 'dist', 'index.js'))) {
       return candidate;
     }
   }
-  throw new Error(
-    'Could not find @cornerstonejs/codec-openjph. Run pnpm install at the repository root.'
-  );
+  throw new Error('Could not find openjph-wasm. Run pnpm install at the repository root.');
 }
 
-const openjphRoot = resolveOpenJphRoot();
+const distDir = join(resolveOpenJphRoot(), 'dist');
 const vendorRoot = join(
   repoRoot,
   'python',
@@ -34,19 +37,25 @@ const vendorRoot = join(
   'vendor',
   'openjph'
 );
-mkdirSync(vendorRoot, { recursive: true });
+const vendorWasmDir = join(vendorRoot, 'wasm');
+mkdirSync(vendorWasmDir, { recursive: true });
 
-const requiredArtifacts = ['openjphjs.js', 'openjphjs.wasm'];
-for (const name of requiredArtifacts) {
-  const source = join(openjphRoot, 'dist', name);
-  if (!existsSync(source)) {
-    throw new Error(`Required OpenJPH artifact not found: ${source}`);
-  }
+const indexSource = join(distDir, 'index.js');
+if (!existsSync(indexSource)) {
+  throw new Error(`Required openjph-wasm artifact not found: ${indexSource}`);
 }
+// Vendor as .mjs so Node treats it as ESM (import.meta) without a package.json
+// marker in the vendored directory.
+const indexDest = join(vendorRoot, 'index.mjs');
+copyFileSync(indexSource, indexDest);
+console.log(`Vendored index.mjs -> ${indexDest}`);
 
-for (const name of requiredArtifacts) {
-  const source = join(openjphRoot, 'dist', name);
-  const dest = join(vendorRoot, name);
-  copyFileSync(source, dest);
-  console.log(`Vendored ${name} -> ${dest}`);
+const wasmSource = join(distDir, 'wasm');
+if (!existsSync(wasmSource)) {
+  throw new Error(`Required openjph-wasm wasm directory not found: ${wasmSource}`);
+}
+for (const name of readdirSync(wasmSource)) {
+  const dest = join(vendorWasmDir, name);
+  copyFileSync(join(wasmSource, name), dest);
+  console.log(`Vendored wasm/${name} -> ${dest}`);
 }

--- a/tests/integration/codecFixtures.test.ts
+++ b/tests/integration/codecFixtures.test.ts
@@ -104,10 +104,10 @@ describe('codec fixtures', () => {
       return;
     }
     try {
-      await import('@cornerstonejs/codec-openjph');
+      await import('openjph-wasm');
     } catch {
       console.warn(
-        'Skipping Mandelbulb HTJ2K decode smoke test: @cornerstonejs/codec-openjph is not installed.'
+        'Skipping Mandelbulb HTJ2K decode smoke test: openjph-wasm is not installed.'
       );
       return;
     }
@@ -145,10 +145,10 @@ describe('codec fixtures', () => {
       return;
     }
     try {
-      await import('@cornerstonejs/codec-openjph');
+      await import('openjph-wasm');
     } catch {
       console.warn(
-        'Skipping HTJ2K decode smoke test: @cornerstonejs/codec-openjph is not installed.'
+        'Skipping HTJ2K decode smoke test: openjph-wasm is not installed.'
       );
       return;
     }


### PR DESCRIPTION
## What

Replaces `@cornerstonejs/codec-openjph` with the [`openjph-wasm`](https://www.npmjs.com/package/openjph-wasm) npm package as the HTJ2K (OpenJPH) encode/decode backend, across the TS reader and the Python writer pipeline. JPEG2000 stays on `@cornerstonejs/codec-openjpeg`.

This is a **like-for-like swap** — still one 2D plane per chunk. It deliberately unblocks a planned follow-up to support true `z>1` multi-component (volumetric) chunks.

## Why

The cornerstone OpenJPH WASM build cannot round-trip independent multi-component data: on decode it keeps only component 0 and replicates it across all output components, silently dropping planes 2..N. This was verified empirically (probe details and the full write-up are in `python/spatialdata-codec-writer/docs/multi-component-codec-findings.md`, added here). `@cornerstonejs/codec-openjpeg` similarly throws on multi-component decode.

`openjph-wasm` exposes a clean functional API (`encode`/`decode`) that returns **planar, component-major** buffers — which map directly onto a Zarr chunk laid out as `[..., z, y, x]` — and round-trips multi-component data losslessly (verified for `components = 1, 2, 3, 8`). It also ships proper type declarations.

## Changes

- **TS decode/encode** (`packages/zarrextra`): `createOpenJphDecoder`/`loadOpenJphDecoder` and `createOpenJphEncoder`/`loadOpenJphEncoder` rewritten against the new functional API; new `OpenJphDecode`/`OpenJphDecodedImage`/`OpenJphInitOptions`/`OpenJphEncode`/`OpenJphEncodeInput` types; worker init + `index.ts` exports updated.
- **Python encode pipeline**: `scripts/vendor-openjph-for-python.mjs` now vendors `openjph-wasm` (`index.mjs` + `wasm/`); vendored `encode-plane.mjs` (and the unused `scripts/encode-htj2k-plane.mjs`) call `encode()`; artifact-existence checks updated.
- **Deps**: swap `@cornerstonejs/codec-openjph` → `openjph-wasm` in `packages/zarrextra` (optionalDependencies) and `packages/vis` (devDependencies); lockfile updated.
- **Tests + docs**: `codecs.spec.ts`, integration `codecFixtures.test.ts`, and READMEs/design doc updated; new findings doc added.

## Verification

- zarrextra vitest: **36/36 pass** (the OpenJPH encode↔decode round-trip ran against `openjph-wasm`, not skipped).
- `tsc --noEmit`: clean except one **pre-existing** `@cornerstonejs/codec-openjpeg/decode` TS7016 (that import is unchanged).
- `vite build` incl. the codec-worker bundle: **succeeds**.
- Python `pnpm test:codec-writer`: **38 passed, 1 skipped** — HTJ2K encodes via `openjph-wasm`, and `imagecodecs` cross-validates the output as standard HTJ2K.

## Reviewer notes

- The vitest/vite toolchain needs **Node 20+** (`styleText` from `node:util`); default `node` in some envs is 18.x. The Python encode worker runs fine on Node 18.
- No fixtures change shape here; this is purely the codec backend swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched HTJ2K encoding and decoding support to a newer WASM-based implementation.
  * Updated Python and scripting workflows to use the new packaged encoder assets.

* **Bug Fixes**
  * Improved multi-component image handling and round-trip behavior for HTJ2K workflows.
  * Updated worker and integration paths to match the new encoder/decoder interface.

* **Documentation**
  * Refreshed setup and usage docs to reflect the new encoding and vendoring steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->