### PR TITLE
Add `pnpm dev:stop` and a port preflight for the vis dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "dev": "pnpm -r --parallel dev",
+    "dev:stop": "node scripts/dev-stop.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "publish:latest": "pnpm build && changeset publish",

--- a/packages/vis/package.json
+++ b/packages/vis/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "vite build && tsc --noEmit",
     "dev": "node scripts/dev.mjs",
+    "dev:stop": "node ../../scripts/dev-stop.mjs",
     "dev:demo": "vite --config vite.config.demo.ts --host 127.0.0.1 --port 5173 --strictPort",
     "watch": "vite build --watch",
     "test": "vitest run",

--- a/packages/vis/scripts/dev.mjs
+++ b/packages/vis/scripts/dev.mjs
@@ -1,8 +1,69 @@
 import { spawn } from 'node:child_process';
+import {
+  describeProcess,
+  isPortInUse,
+  listProcesses,
+  portListeners,
+} from '../../scripts/dev-process-utils.mjs';
+import { FIXTURE_SERVER_PORT } from '../../scripts/fixture-server-port.mjs';
 
+const DEMO_PORT = 5173;
 const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 const children = [];
 let shuttingDown = false;
+
+/** One-line description of whoever is listening on a port, if we can find it. */
+function describePortHolder(port) {
+  const [pid] = portListeners(port);
+  if (!pid) return '';
+  const proc = listProcesses().find((p) => p.pid === pid);
+  return proc ? describeProcess(proc) : `pid ${pid}`;
+}
+
+/** Is the server on `port` our own fixture server (vs. a foreign process)? */
+async function fixtureServerIsOurs(port) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/__fixture-health__`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return res.ok && res.headers.get('x-spatialdata-fixture-server') === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check the ports we need before spawning anything, so a leftover dev server
+ * (often from another checkout) produces a clear message instead of a cryptic
+ * strict-port crash. Returns whether we still need to start the fixture server.
+ */
+async function preflight() {
+  if (await isPortInUse(DEMO_PORT)) {
+    const holder = describePortHolder(DEMO_PORT);
+    console.error(
+      `\n[dev] Demo port ${DEMO_PORT} is already in use${holder ? `:\n  ${holder}` : '.'}`
+    );
+    console.error('[dev] Run `pnpm dev:stop` to clear SpatialData dev processes, then retry.\n');
+    process.exit(1);
+  }
+
+  if (await isPortInUse(FIXTURE_SERVER_PORT)) {
+    if (await fixtureServerIsOurs(FIXTURE_SERVER_PORT)) {
+      console.log(`[dev] Reusing the fixture server already running on :${FIXTURE_SERVER_PORT}.`);
+      return { startFixtures: false };
+    }
+    const holder = describePortHolder(FIXTURE_SERVER_PORT);
+    console.error(
+      `\n[dev] Fixture port ${FIXTURE_SERVER_PORT} is in use by a non-SpatialData process${
+        holder ? `:\n  ${holder}` : '.'
+      }`
+    );
+    console.error('[dev] Stop it, or set SPATIALDATA_FIXTURE_PORT to another port, then retry.\n');
+    process.exit(1);
+  }
+
+  return { startFixtures: true };
+}
 
 function start(name, args) {
   const child = spawn(pnpmCommand, ['exec', ...args], {
@@ -56,8 +117,14 @@ function shutdown(code) {
 process.on('SIGINT', () => shutdown(130));
 process.on('SIGTERM', () => shutdown(143));
 
-console.log('Starting fixture server, vis build watch, and demo server...');
-start('fixtures', ['node', '../../scripts/test-server.js']);
+const { startFixtures } = await preflight();
+
+const startedParts = ['vis build watch', 'demo server'];
+if (startFixtures) {
+  start('fixtures', ['node', '../../scripts/test-server.js']);
+  startedParts.unshift('fixture server');
+}
+console.log(`Starting ${startedParts.join(', ')}...`);
 start('watch', ['vite', 'build', '--watch']);
 start('demo', [
   'vite',
@@ -66,6 +133,6 @@ start('demo', [
   '--host',
   '127.0.0.1',
   '--port',
-  '5173',
+  String(DEMO_PORT),
   '--strictPort',
 ]);

--- a/scripts/dev-process-utils.mjs
+++ b/scripts/dev-process-utils.mjs
@@ -1,0 +1,183 @@
+/**
+ * Shared helpers for inspecting and stopping this repo's dev processes.
+ *
+ * The goal is to be *scoped to SpatialData* — a `vite build --watch` or
+ * `pnpm dev` belonging to a different project (or a foreign process that merely
+ * grabbed one of our ports) must never be matched or killed. Process matching
+ * therefore requires both a known dev-command token AND ownership by a
+ * SpatialData checkout (the repo name appears in the command line or the
+ * process cwd).
+ *
+ * POSIX only (macOS/Linux); relies on `ps` and `lsof`.
+ */
+import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:net';
+
+export const isWindows = process.platform === 'win32';
+
+/** Repo-name marker present in every SpatialData checkout path. */
+export const SPATIALDATA_MARKER = /SpatialData/i;
+
+/** Command substrings that identify a SpatialData dev-stack process. */
+export const DEV_TOKENS = [
+  'scripts/dev.mjs', // vis dev orchestrator
+  'scripts/test-server.js', // fixture server
+  'scripts/cors-proxy.js', // cors proxy
+  'vite.config.demo', // vis demo server
+  'vite/bin/vite.js build --watch', // package build watchers
+  '@docusaurus/core/bin/docusaurus', // docs site
+];
+
+/**
+ * `pnpm ... dev` / `pnpm -r --parallel dev` orchestrators.
+ *
+ * Matches the pnpm binary actually being *invoked* (preceded by `/` or start,
+ * then whitespace + args + a `dev` argument) — not paths that merely contain
+ * the `.pnpm` store directory.
+ */
+const PNPM_DEV = /(?:^|\/)pnpm(?:\.cjs|\.js)?\s+(?:[^\s]+\s+)*dev(?:\s|$)/;
+
+/** List running processes as `{ pid, command }`. POSIX only. */
+export function listProcesses() {
+  if (isWindows) return [];
+  let out = '';
+  try {
+    out = execFileSync('ps', ['-axww', '-o', 'pid=,command='], {
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch {
+    return [];
+  }
+  const procs = [];
+  for (const line of out.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(.*)$/);
+    if (match) procs.push({ pid: Number(match[1]), command: match[2].trim() });
+  }
+  return procs;
+}
+
+/** Working directory of a pid via `lsof`. Returns '' if unknown. */
+export function pidCwd(pid) {
+  if (isWindows) return '';
+  try {
+    const out = execFileSync('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const line = out.split('\n').find((l) => l.startsWith('n'));
+    return line ? line.slice(1) : '';
+  } catch {
+    return '';
+  }
+}
+
+/** PIDs listening on a TCP port via `lsof`. */
+export function portListeners(port) {
+  if (isWindows || !port) return [];
+  try {
+    const out = execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-Fp'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return [
+      ...new Set(
+        out
+          .split('\n')
+          .filter((l) => l.startsWith('p'))
+          .map((l) => Number(l.slice(1)))
+      ),
+    ];
+  } catch {
+    // lsof exits non-zero when nothing is listening on the port.
+    return [];
+  }
+}
+
+/** Whether a TCP port is already bound (best-effort, checks one host). */
+export function isPortInUse(port, host = '127.0.0.1') {
+  return new Promise((resolvePromise) => {
+    const tester = createServer()
+      .once('error', (err) => resolvePromise(err.code === 'EADDRINUSE'))
+      .once('listening', () => tester.close(() => resolvePromise(false)))
+      .listen(port, host);
+  });
+}
+
+/** True when a process clearly belongs to a SpatialData checkout. */
+export function isSpatialDataOwned({ pid, command }) {
+  if (SPATIALDATA_MARKER.test(command)) return true;
+  return SPATIALDATA_MARKER.test(pidCwd(pid));
+}
+
+/** File-consuming tools that may take a dev-script path as an argument. */
+const NON_DEV_RUNNERS = /\b(?:biome|eslint|prettier|vitest|jest|tsc|tsx|tail|grep|less|bat)\b/;
+
+/** Whether the command is a real `node ...` invocation (argv0 is the node binary). */
+function isNodeInvocation(command) {
+  const first = command.trim().split(/\s+/, 1)[0] ?? '';
+  const base = first.split('/').pop();
+  return base === 'node' || base === 'node.exe';
+}
+
+/**
+ * Classify a process as a SpatialData dev process, or return null.
+ *
+ * Requires a real `node` dev invocation (so shell wrappers, editors, and
+ * file-tools that merely mention a dev-script path are never matched), a known
+ * dev-command token (or `pnpm dev` orchestrator), AND SpatialData ownership.
+ */
+export function classifyDevProcess(proc) {
+  if (!isNodeInvocation(proc.command) || NON_DEV_RUNNERS.test(proc.command)) {
+    return null;
+  }
+  const token = DEV_TOKENS.find((t) => proc.command.includes(t));
+  if (token && isSpatialDataOwned(proc)) {
+    return { ...proc, reason: token };
+  }
+  if (PNPM_DEV.test(proc.command) && isSpatialDataOwned(proc)) {
+    return { ...proc, reason: 'pnpm dev' };
+  }
+  return null;
+}
+
+/** One-line description of a process for logging. */
+export function describeProcess(proc) {
+  const cwd = pidCwd(proc.pid);
+  const command = proc.command.length > 100 ? `${proc.command.slice(0, 97)}...` : proc.command;
+  return `pid ${proc.pid}  [${cwd || '?'}]  ${command}`;
+}
+
+/**
+ * SIGTERM the given pids, wait, then SIGKILL any survivors.
+ * Returns `{ killed, survivors }` (arrays of pids).
+ */
+export async function killPids(pids, { graceMs = 800 } = {}) {
+  const unique = [...new Set(pids)].filter((pid) => Number.isInteger(pid) && pid > 1);
+  for (const pid of unique) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      /* already gone */
+    }
+  }
+  if (unique.length > 0) {
+    await new Promise((r) => setTimeout(r, graceMs));
+  }
+  const survivors = unique.filter((pid) => {
+    try {
+      process.kill(pid, 0); // probe: throws if the process is gone
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  for (const pid of survivors) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      /* race: gone between probe and kill */
+    }
+  }
+  return { killed: unique.filter((pid) => !survivors.includes(pid)), survivors };
+}

--- a/scripts/dev-stop.mjs
+++ b/scripts/dev-stop.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import {
+  classifyDevProcess,
+  describeProcess,
+  isSpatialDataOwned,
+  isWindows,
+  killPids,
+  listProcesses,
+  pidCwd,
+  portListeners,
+} from './dev-process-utils.mjs';
+/**
+ * Stop SpatialData dev processes left running in the background.
+ *
+ * Finds and kills this project's dev-stack processes across *all* local
+ * checkouts/worktrees (the usual cause of port conflicts): the vis dev
+ * orchestrator, fixture server, cors proxy, demo server, package build
+ * watchers, the docs site, and `pnpm (-r --parallel) dev` orchestrators.
+ *
+ * It is deliberately scoped to SpatialData — processes from other projects
+ * (and foreign processes that merely hold one of our ports) are reported but
+ * never killed.
+ *
+ * Usage: pnpm dev:stop [--dry-run]
+ */
+import { FIXTURE_SERVER_PORT } from './fixture-server-port.mjs';
+
+if (isWindows) {
+  console.error('pnpm dev:stop is only supported on macOS/Linux for now.');
+  process.exit(1);
+}
+
+const dryRun = process.argv.includes('--dry-run');
+
+// Known fixed dev ports (docs/docusaurus picks a dynamic port, so it is matched
+// by command token instead).
+const DEV_PORTS = [...new Set([5173, FIXTURE_SERVER_PORT, 8081])];
+
+const processes = listProcesses();
+const byPid = new Map(processes.map((p) => [p.pid, p]));
+const selfPid = process.pid;
+
+// 1. Match SpatialData dev processes by command token / orchestrator.
+const targets = new Map(); // pid -> { pid, command, reason }
+for (const proc of processes) {
+  if (proc.pid === selfPid) continue;
+  const hit = classifyDevProcess(proc);
+  if (hit) targets.set(hit.pid, hit);
+}
+
+// 2. Port backstop: catch anything holding a dev port. Kill only if it is ours;
+//    otherwise report it as a foreign holder so the user knows what is blocking.
+const foreign = [];
+for (const port of DEV_PORTS) {
+  for (const pid of portListeners(port)) {
+    if (pid === selfPid || targets.has(pid)) continue;
+    const proc = byPid.get(pid) ?? { pid, command: '(unknown)' };
+    if (isSpatialDataOwned(proc)) {
+      targets.set(pid, { ...proc, reason: `port ${port}` });
+    } else {
+      foreign.push({ port, ...proc, cwd: pidCwd(pid) });
+    }
+  }
+}
+
+const targetList = [...targets.values()].sort((a, b) => a.pid - b.pid);
+
+if (targetList.length === 0) {
+  console.log('No SpatialData dev processes are running.');
+} else {
+  console.log(
+    `${dryRun ? 'Would stop' : 'Stopping'} ${targetList.length} SpatialData dev process${
+      targetList.length === 1 ? '' : 'es'
+    }:`
+  );
+  for (const proc of targetList) {
+    console.log(`  • ${describeProcess(proc)}  (${proc.reason})`);
+  }
+
+  if (!dryRun) {
+    const { killed, survivors } = await killPids(targetList.map((p) => p.pid));
+    console.log(`\nStopped ${killed.length} process${killed.length === 1 ? '' : 'es'}.`);
+    if (survivors.length > 0) {
+      console.log(`Force-killed ${survivors.length}: ${survivors.join(', ')}`);
+    }
+  }
+}
+
+if (foreign.length > 0) {
+  console.log('\nDev ports held by non-SpatialData processes (left untouched):');
+  for (const f of foreign) {
+    const command = f.command.length > 90 ? `${f.command.slice(0, 87)}...` : f.command;
+    console.log(`  • port ${f.port}: pid ${f.pid}  [${f.cwd || '?'}]  ${command}`);
+  }
+  console.log('Stop those manually or use a different port if they conflict.');
+}

--- a/scripts/test-server.js
+++ b/scripts/test-server.js
@@ -6,11 +6,11 @@
  * via HTTP URLs for testing with FetchStore.
  */
 
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { createServer } from 'node:http';
-import { readFile, stat, readdir } from 'node:fs/promises';
-import { join, extname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { extname, join, resolve } from 'node:path';
 import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { FIXTURE_SERVER_PORT } from './fixture-server-port.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,6 +93,18 @@ async function handleRequest(req, res) {
     // Remove query string and normalize path
     const urlPath = new URL(req.url, `http://${req.headers.host}`).pathname;
 
+    // Identity/health endpoint so tooling (e.g. the vis dev preflight) can tell
+    // an already-running SpatialData fixture server apart from a foreign server.
+    if (urlPath === '/__fixture-health__') {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'X-SpatialData-Fixture-Server': '1',
+        'Access-Control-Allow-Origin': '*',
+      });
+      res.end(JSON.stringify({ server: 'spatialdata-fixture-server', port: PORT }));
+      return;
+    }
+
     // Remove leading /test-fixtures if present (for cleaner URLs)
     let filePath = urlPath.startsWith('/test-fixtures')
       ? urlPath.slice('/test-fixtures'.length)
@@ -157,6 +169,16 @@ async function handleRequest(req, res) {
 
 // Create and start server
 const server = createServer(handleRequest);
+
+server.on('error', (error) => {
+  if (error.code === 'EADDRINUSE') {
+    console.error(
+      `Fixture server port ${PORT} is already in use. Run \`pnpm dev:stop\` to clear stale SpatialData dev processes, or set SPATIALDATA_FIXTURE_PORT to another port.`
+    );
+    process.exit(1);
+  }
+  throw error;
+});
 
 server.listen(PORT, () => {
   console.log(`Test fixture server running at http://localhost:${PORT}`);


### PR DESCRIPTION
## What

Tooling to make launching the dev server painless when multiple SpatialData checkouts/worktrees are in play.

- **`pnpm dev:stop`** ([scripts/dev-stop.mjs](scripts/dev-stop.mjs) + [scripts/dev-process-utils.mjs](scripts/dev-process-utils.mjs)) — finds and stops this project's dev-stack processes (the vis dev orchestrator, fixture server, cors proxy, demo server, package `build --watch` watchers, the docs site, and `pnpm (-r --parallel) dev`) across **all** local checkouts. `--dry-run` previews.
- **Port preflight** in [packages/vis/scripts/dev.mjs](packages/vis/scripts/dev.mjs) — checks ports before spawning:
  - Busy demo port (5173) → clear message naming the holder + a `pnpm dev:stop` hint, instead of vite's cryptic strict-port crash.
  - Busy fixture port → **reuse** it if it's our own server; otherwise error with a `SPATIALDATA_FIXTURE_PORT` hint.
- [scripts/test-server.js](scripts/test-server.js) — adds a `/__fixture-health__` identity endpoint (so the preflight can tell our fixture server apart from a foreign one) and an `EADDRINUSE` handler with a clear message.

## Why

With several checkouts open, leftover background dev processes hold the fixed dev ports, so a fresh `pnpm dev` either fails on `--strictPort` or behaves unpredictably. `dev:stop` clears them in one command, and the preflight turns silent/cryptic failures into actionable messages (and avoids a redundant fixture server).

## Safety / scope

- **Scoped to SpatialData.** A process is only killed if it's a real `node` dev invocation **and** owned by a SpatialData checkout (repo name in the command line or process cwd). Other projects (e.g. an unrelated `vite`/`http-server`) and foreign processes that merely hold one of our ports are **reported, never killed**.
- POSIX only (uses `ps`/`lsof`); on Windows `dev:stop` exits with a notice.

## Validation

- `dev:stop --dry-run` against a live multi-process stack: matched exactly the dev-stack processes, no false positives (the matcher rejects shell wrappers, editors, and file-tools like biome/eslint that merely reference a dev-script path).
- Kill path verified on a throwaway process; health endpoint, fixture-reuse detection, `EADDRINUSE` message, and foreign-port reporting all verified in isolation.
- Biome clean.

## Notes

- Independent of #65 (the openjph-wasm swap); branched from `main`.
- The dev tooling needs Node 20+ to actually run the servers (same as the rest of the dev setup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `dev:stop` command to stop local development processes more easily.
  * Development startup now checks for port conflicts and reuses an existing fixture server when available.

* **Bug Fixes**
  * Improved handling when required dev ports are already in use, with clearer guidance on how to resolve conflicts.
  * Added a health endpoint and better error messaging for the fixture server to make local setup more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->