### PR TITLE
Use z>1 (multi-component) chunks in the mandelbulb fixture

### DIFF
--- a/packages/zarrextra/README.md
+++ b/packages/zarrextra/README.md
@@ -78,8 +78,8 @@ registerExperimentalHtj2kCodec({ decoder: createOpenJphDecoder(openJphDecode) })
 samples. Unlike the older `@cornerstonejs/codec-openjph` build, it round-trips
 genuine multi-component data losslessly (the repo's `multi-component-codec-findings.md`
 has the details), so a multi-component codestream maps directly onto a Zarr
-chunk's `[..., z, y, x]` layout. The writer currently emits one 2D plane per
-chunk; end-to-end `z > 1` multi-component chunks are planned follow-up work.
+chunk's `[..., z, y, x]` layout. The `mandelbulb` test fixture exercises this:
+each chunk is a single codestream spanning 4 z-planes (`(1, 1, 4, 128, 128)`).
 
 For offline encode (fixtures, recompress), use `encodeHtj2kPlane()` or
 `createOpenJphEncoder()` from the same package. Python `spatialdata-codec-writer`

--- a/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
+++ b/python/spatialdata-codec-writer/docs/htj2k-wasm-encode-design.md
@@ -14,11 +14,13 @@ The encoder/decoder is the [`openjph-wasm`](https://www.npmjs.com/package/openjp
 package. Earlier versions used `@cornerstonejs/codec-openjph`, whose WASM build
 could not round-trip independent multi-component data
 (see [multi-component-codec-findings.md](./multi-component-codec-findings.md));
-`openjph-wasm` does round-trip multi-component, planar, component-major buffers
-losslessly. That makes `z > 1` multi-component chunks *possible*, but they are
-not yet wired up end-to-end: the writer still encodes **one 2D plane per chunk**
-(chunk shapes begin `(1, 1, 1, ...)`), so volumetric `z > 1` chunk support
-remains future work.
+`openjph-wasm` round-trips multi-component, planar, component-major buffers
+losslessly, so a chunk's leading dims (e.g. z) are encoded as **codestream
+components**. `z > 1` chunks are now wired up end-to-end: the writer encodes a
+chunk's z-planes as one multi-component codestream, and the JS reader decodes it
+back to planar `[..., z, y, x]`. The `mandelbulb` fixture uses
+`(1, 1, 4, 128, 128)` chunks (4 z-planes per codestream). Chunk shapes must begin
+`(1, 1)` (t and c are not chunked across components).
 
 ## Contracts
 
@@ -28,7 +30,7 @@ remains future work.
 | Zarr codec id (legacy decode) | `experimental.imagecodecs_htj2k` |
 | Encoder label | `openjph-wasm` (manifest `encoder` field) |
 | Array metadata | Zarr v3; `codecs: [{ name, configuration: {} }]` |
-| Chunk bytes | Raw HTJ2K bitstream per 2D spatial plane (last two axes) |
+| Chunk bytes | One HTJ2K codestream per chunk; the chunk's leading dims (z) are codestream components, the last two axes are the y/x plane |
 | Browser read | `registerExperimentalHtj2kCodec()` registers both ids |
 
 ## Encode flow

--- a/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
+++ b/python/spatialdata-codec-writer/docs/multi-component-codec-findings.md
@@ -112,16 +112,24 @@ unrelated to the multi-component failure but worth knowing for test fixtures.
    container, not a single standards-compliant volumetric codestream, so external
    tools reading the chunk as a raw codestream will not understand it.
 
-## Current writer behaviour (for reference)
+## Resolution (implemented)
 
-The writer encodes **one 2D codestream per chunk** and enforces it:
+Switching to `openjph-wasm` (which round-trips multi-component data losslessly,
+verified for several component counts) resolved the blocker, and `z > 1` chunks
+are now implemented end-to-end:
 
-- `_validate_codec_chunks` requires chunk shape to begin `(1, 1, 1, …)`
-  (`scripts/fixture_writer.py`).
-- `_write_array_chunks` reshapes each chunk to `(y, x)` and calls
-  `encode_image_plane` (`scripts/fixture_writer.py`).
+- `_validate_codec_chunks` now only requires chunk shape to begin `(1, 1)` (t/c)
+  — z may be > 1 (`scripts/fixture_writer.py`).
+- `_write_array_chunks` reshapes each chunk to `(components, y, x)` and calls
+  `encode_image_chunk`, encoding the z-planes as one multi-component codestream;
+  it self-validates losslessly via `decode_image_chunk` (openjph-wasm worker).
 - The volumetric `mandelbulb` fixture is `t=2, c=1, z=8, 128×128` chunked at
-  `(1, 1, 1, 128, 128)` — one z-plane per chunk (`scripts/mandelbulb_fixtures.py`).
+  `(1, 1, 4, 128, 128)` — 4 z-planes per codestream (`scripts/mandelbulb_fixtures.py`).
 
-On the read side, `packages/zarrextra/src/codecs.ts` decodes one codestream per
-chunk and validates `decoded length === product(chunk_shape)`.
+On the read side, `packages/zarrextra/src/codecs.ts` decodes the codestream to a
+planar component-major buffer and validates `decoded length === product(chunk_shape)`,
+so a multi-component chunk maps straight onto `[..., z, y, x]`.
+
+`imagecodecs` is no longer on the HTJ2K path (encode and decode both go through
+the openjph-wasm worker — the same WASM as the JS reader); it remains only for
+the JPEG2000 fixture path.

--- a/python/spatialdata-codec-writer/scripts/fixture_writer.py
+++ b/python/spatialdata-codec-writer/scripts/fixture_writer.py
@@ -13,8 +13,8 @@ from spatialdata_codec_writer.codecs import (
     HTJ2K_ENCODER,
     CodecName,
     chunk_grid,
-    decode_image_plane,
-    encode_image_plane,
+    decode_image_chunk,
+    encode_image_chunk,
     is_htj2k_codec,
     package_version,
     sha256,
@@ -220,28 +220,36 @@ def _write_array_chunks(
 ) -> list[dict[str, Any]]:
     is_lossless = _is_lossless_encode(codec, encode_options)
     refs: list[dict[str, Any]] = []
+    # Each chunk's leading (t, c, z) dims become codestream components; the last
+    # two axes are the y/x plane. For z>1 chunks this is a multi-component codestream.
+    n_components = 1
+    for size in chunks[:-2]:
+        n_components *= int(size)
+    plane_h, plane_w = int(chunks[-2]), int(chunks[-1])
     for coords in chunk_grid(image.shape, chunks):
         chunk = _extract_chunk(image, chunks, coords)
-        encoded = encode_image_plane(
-            chunk.reshape(chunk.shape[-2], chunk.shape[-1]), codec, encode_options or {}
-        )
+        volume = chunk.reshape(n_components, plane_h, plane_w)
+        encoded = encode_image_chunk(volume, codec, encode_options or {})
         chunk_rel = f"{array_path}/c/" + "/".join(str(c) for c in coords)
         chunk_path = store_path / chunk_rel
         chunk_path.parent.mkdir(parents=True, exist_ok=True)
         chunk_path.write_bytes(encoded)
 
-        expected_plane = chunk.reshape(chunk.shape[-2], chunk.shape[-1])
         if len(refs) < 4:
-            decoded = decode_image_plane(encoded, codec).reshape(expected_plane.shape)
-            if is_lossless and not np.array_equal(decoded, expected_plane):
+            decoded = decode_image_chunk(
+                encoded, codec, components=n_components, height=plane_h, width=plane_w
+            )
+            if is_lossless and not np.array_equal(decoded, volume):
                 raise RuntimeError(f"Codec self-validation failed for chunk {coords}")
-            sample_plane = expected_plane if is_lossless else decoded
+            sample = volume if is_lossless else decoded
+            sample_plane = sample[0]
             refs.append(
                 {
                     "coords": list(coords),
                     "path": chunk_rel,
                     "encoded_sha256": sha256(encoded),
-                    "decoded_sha256": sha256(sample_plane.tobytes()),
+                    "decoded_sha256": sha256(sample.tobytes()),
+                    "components": n_components,
                     "samples": [
                         int(sample_plane[0, 0]),
                         int(sample_plane[0, min(1, sample_plane.shape[1] - 1)]),
@@ -255,8 +263,8 @@ def _write_array_chunks(
 def _validate_codec_chunks(chunks: tuple[int, int, int, int, int]) -> None:
     if len(chunks) != 5:
         raise ValueError("chunks must have shape [t, c, z, y, x]")
-    if chunks[:3] != (1, 1, 1):
-        raise ValueError("v1 codec fixtures require chunks beginning with (1, 1, 1)")
+    if chunks[:2] != (1, 1):
+        raise ValueError("codec fixtures require chunks beginning with (1, 1) for t and c")
 
 
 def _multiscale_levels(base: np.ndarray, multiscale: bool) -> list[np.ndarray]:

--- a/python/spatialdata-codec-writer/scripts/mandelbulb_fixtures.py
+++ b/python/spatialdata-codec-writer/scripts/mandelbulb_fixtures.py
@@ -11,7 +11,9 @@ MANDELBULB_FIXTURE_SIZE = 128
 MANDELBULB_FIXTURE_T = 2
 MANDELBULB_FIXTURE_C = 1
 MANDELBULB_FIXTURE_Z = 8
-MANDELBULB_FIXTURE_CHUNKS: tuple[int, int, int, int, int] = (1, 1, 1, 128, 128)
+# z>1 per chunk: each chunk is a 4-plane multi-component HTJ2K codestream, and z
+# (8) spans two chunks — exercising both multi-component and multi-z-chunk reads.
+MANDELBULB_FIXTURE_CHUNKS: tuple[int, int, int, int, int] = (1, 1, 4, 128, 128)
 MANDELBULB_FIXTURE_IMAGE_KEY = "mandelbulb"
 MANDELBULB_ENCODE_OPTIONS = {"reversible": True}
 

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/codecs.py
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/codecs.py
@@ -6,6 +6,13 @@ from importlib import metadata
 from pathlib import Path
 from typing import Any, Literal
 
+# `imagecodecs` is used only for the JPEG2000 (`imagecodecs_jpeg2k`) path. The
+# HTJ2K path goes through the vendored openjph-wasm worker (the same WASM the JS
+# reader uses), so it round-trips genuine multi-component (volumetric) data and
+# stays consistent encode-vs-decode. We deliberately do not maintain extra HTJ2K
+# backends here: native `imagecodecs` HTJ2K is build-fragile, and `itkwasm-htj2k`
+# (https://pypi.org/project/itkwasm-htj2k/) has been unmaintained for ~2 years.
+# If we ever drop the JPEG2000 fixture path, `imagecodecs` can be removed too.
 import imagecodecs
 import numpy as np
 
@@ -44,13 +51,15 @@ def sha256(data: bytes | bytearray) -> str:
 
 
 def decode_htj2k_plane(encoded: bytes | bytearray) -> np.ndarray:
-    """Decode an HTJ2K plane for validation (native imagecodecs when available)."""
-    htj2k = getattr(imagecodecs, "HTJ2K", None)
-    if htj2k is not None and getattr(htj2k, "available", False):
-        decoder = getattr(imagecodecs, "htj2k_decode", None)
-        if decoder is not None:
-            return decoder(encoded)
-    return imagecodecs.jpeg2k_decode(encoded)
+    """Decode an HTJ2K codestream via the vendored openjph-wasm worker.
+
+    Returns a 2D ``(y, x)`` array for single-component codestreams, otherwise a
+    ``(components, y, x)`` array.
+    """
+    from .htj2k_encode import decode_htj2k
+
+    array = decode_htj2k(encoded)
+    return array[0] if array.shape[0] == 1 else array
 
 
 def decode_image_plane(encoded: bytes | bytearray, codec: str) -> np.ndarray:
@@ -61,17 +70,21 @@ def decode_image_plane(encoded: bytes | bytearray, codec: str) -> np.ndarray:
     raise ValueError(f"Unsupported image codec: {codec}")
 
 
-def encode_htj2k_plane_with_options(
-    plane: np.ndarray, encode_options: dict[str, Any] | None = None
+def _htj2k_components(array: np.ndarray) -> int:
+    return int(np.prod(array.shape[:-2])) if array.ndim > 2 else 1
+
+
+def _encode_htj2k_with_options(
+    volume: np.ndarray, encode_options: dict[str, Any] | None = None
 ) -> bytes | bytearray:
-    from .htj2k_encode import encode_htj2k_plane, htj2k_encode_available, openjph_encode_options
+    from .htj2k_encode import encode_htj2k, htj2k_encode_available, openjph_encode_options
 
     if not htj2k_encode_available():
         raise RuntimeError(
             "HTJ2K encode is not available. Install spatialdata-codec-writer with Node.js on PATH."
         )
     reversible, quality = openjph_encode_options(encode_options or {})
-    return encode_htj2k_plane(plane, reversible=reversible, quality=quality)
+    return encode_htj2k(volume, reversible=reversible, quality=quality)
 
 
 def encode_image_plane(
@@ -81,7 +94,46 @@ def encode_image_plane(
     if codec == CODEC_JPEG2K:
         return imagecodecs.jpeg2k_encode(array, **encode_options)
     if codec == CODEC_HTJ2K_OPENJPH:
-        return encode_htj2k_plane_with_options(array, encode_options)
+        return _encode_htj2k_with_options(array, encode_options)
+    raise ValueError(f"Unsupported image codec: {codec}")
+
+
+def encode_image_chunk(
+    volume: np.ndarray, codec: str, encode_options: dict[str, Any]
+) -> bytes | bytearray:
+    """Encode a chunk of one or more planar components to a single codestream.
+
+    ``volume`` is ``(components, y, x)`` (or 2D for a single component). HTJ2K
+    encodes the planes as codestream components (e.g. z-planes of a volumetric
+    chunk); multi-component JPEG2K chunks are not produced by this writer.
+    """
+    array = np.ascontiguousarray(np.asarray(volume))
+    components = _htj2k_components(array)
+    if codec == CODEC_HTJ2K_OPENJPH:
+        return _encode_htj2k_with_options(array, encode_options)
+    if codec == CODEC_JPEG2K:
+        if components == 1:
+            plane = array.reshape(array.shape[-2], array.shape[-1])
+            return imagecodecs.jpeg2k_encode(plane, **encode_options)
+        raise NotImplementedError(
+            "Multi-component JPEG2K chunks are not supported; use HTJ2K (openjph)."
+        )
+    raise ValueError(f"Unsupported image codec: {codec}")
+
+
+def decode_image_chunk(
+    encoded: bytes | bytearray, codec: str, *, components: int, height: int, width: int
+) -> np.ndarray:
+    """Decode a chunk codestream to a ``(components, y, x)`` array."""
+    if is_htj2k_codec(codec):
+        from .htj2k_encode import decode_htj2k
+
+        return decode_htj2k(encoded).reshape(components, height, width)
+    if codec == CODEC_JPEG2K:
+        decoded = np.asarray(imagecodecs.jpeg2k_decode(encoded))
+        if decoded.ndim == 2:
+            return decoded.reshape(1, height, width)
+        return np.moveaxis(decoded, -1, 0).reshape(components, height, width)
     raise ValueError(f"Unsupported image codec: {codec}")
 
 

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/htj2k_encode.py
@@ -35,21 +35,44 @@ def openjph_encode_options(encode_options: dict[str, Any]) -> tuple[bool, float]
     return False, float(quality)
 
 
-def _plane_request_payload(
-    plane: np.ndarray, *, reversible: bool, quality: float
+def _encode_request_payload(
+    volume: np.ndarray, *, reversible: bool, quality: float
 ) -> dict[str, Any]:
-    array = np.ascontiguousarray(np.asarray(plane))
-    if array.ndim != 2:
-        raise ValueError(f"HTJ2K encode expects a 2D plane, got shape {array.shape}.")
-    height, width = (int(value) for value in array.shape)
+    """Build an encode request for a 2D plane or a 3D (components, y, x) volume.
+
+    The samples are sent planar / component-major (C-order of the array), which
+    is exactly the layout openjph-wasm expects for multi-component codestreams.
+    """
+    array = np.ascontiguousarray(np.asarray(volume))
+    if array.ndim == 2:
+        components, (height, width) = 1, (int(array.shape[0]), int(array.shape[1]))
+    elif array.ndim == 3:
+        components, height, width = (int(value) for value in array.shape)
+    else:
+        raise ValueError(
+            f"HTJ2K encode expects a 2D plane or 3D (components, y, x) volume, got shape {array.shape}."
+        )
     return {
         "width": width,
         "height": height,
+        "components": components,
         "dtype": array.dtype.name,
         "reversible": reversible,
         "quality": quality,
         "plane": base64.b64encode(array.tobytes(order="C")).decode("ascii"),
     }
+
+
+# Decode response header (see vendor/encode-plane.mjs): little-endian
+# u32 components, u32 height, u32 width, u8 bytesPerSample, u8 isSigned.
+_DECODE_HEADER = struct.Struct("<IIIBB")
+
+
+def _decode_response_to_array(resp: bytes) -> np.ndarray:
+    components, height, width, bytes_per_sample, is_signed = _DECODE_HEADER.unpack_from(resp, 0)
+    body = resp[_DECODE_HEADER.size :]
+    dtype = np.dtype(f"{'i' if is_signed else 'u'}{bytes_per_sample}")
+    return np.frombuffer(body, dtype=dtype).reshape(components, height, width)
 
 
 class OpenJphEncoderWorker:
@@ -99,29 +122,37 @@ class OpenJphEncoderWorker:
                         self._proc.kill()
             self._proc = None  # type: ignore[assignment]
 
-    def encode_plane(
-        self, plane: np.ndarray, *, reversible: bool = True, quality: float = 0.0
-    ) -> bytes:
+    def _request(self, payload: dict[str, Any]) -> bytes:
         with self._lock:
             if self._proc is None or self._proc.poll() is not None:
-                raise RuntimeError("HTJ2K encoder worker is not running.")
-            payload = json.dumps(
-                _plane_request_payload(plane, reversible=reversible, quality=quality)
-            ).encode("utf-8")
+                raise RuntimeError("HTJ2K worker is not running.")
+            body = json.dumps(payload).encode("utf-8")
             assert self._proc.stdin is not None
             assert self._proc.stdout is not None
-            self._proc.stdin.write(struct.pack(">I", len(payload)))
-            self._proc.stdin.write(payload)
+            self._proc.stdin.write(struct.pack(">I", len(body)))
+            self._proc.stdin.write(body)
             self._proc.stdin.flush()
 
             header = self._read_exact(self._proc.stdout, 5)
             status = header[0]
             length = struct.unpack(">I", header[1:5])[0]
-            body = self._read_exact(self._proc.stdout, length)
+            resp = self._read_exact(self._proc.stdout, length)
             if status != 0:
-                message = body.decode("utf-8", errors="replace")
-                raise RuntimeError(message or "HTJ2K encode failed.")
-            return bytes(body)
+                message = resp.decode("utf-8", errors="replace")
+                raise RuntimeError(message or "HTJ2K worker failed.")
+            return bytes(resp)
+
+    def encode(self, volume: np.ndarray, *, reversible: bool = True, quality: float = 0.0) -> bytes:
+        return self._request(
+            _encode_request_payload(volume, reversible=reversible, quality=quality)
+        )
+
+    def decode(self, codestream: bytes | bytearray) -> np.ndarray:
+        payload = {
+            "op": "decode",
+            "codestream": base64.b64encode(bytes(codestream)).decode("ascii"),
+        }
+        return _decode_response_to_array(self._request(payload))
 
     @staticmethod
     def _read_exact(stream: Any, length: int) -> bytes:
@@ -145,13 +176,17 @@ class EncoderPool:
         self._next = 0
         self._lock = threading.Lock()
 
-    def encode_plane(
-        self, plane: np.ndarray, *, reversible: bool = True, quality: float = 0.0
-    ) -> bytes:
+    def _next_worker(self) -> OpenJphEncoderWorker:
         with self._lock:
             worker = self._workers[self._next]
             self._next = (self._next + 1) % len(self._workers)
-        return worker.encode_plane(plane, reversible=reversible, quality=quality)
+        return worker
+
+    def encode(self, volume: np.ndarray, *, reversible: bool = True, quality: float = 0.0) -> bytes:
+        return self._next_worker().encode(volume, reversible=reversible, quality=quality)
+
+    def decode(self, codestream: bytes | bytearray) -> np.ndarray:
+        return self._next_worker().decode(codestream)
 
     def close(self) -> None:
         for worker in self._workers:
@@ -208,6 +243,16 @@ def htj2k_encode_available() -> bool:
     return True
 
 
+def encode_htj2k(
+    volume: np.ndarray,
+    *,
+    reversible: bool = True,
+    quality: float = 0.0,
+) -> bytes:
+    """Encode a 2D plane or 3D (components, y, x) volume to an HTJ2K codestream."""
+    return get_encoder_pool().encode(volume, reversible=reversible, quality=quality)
+
+
 def encode_htj2k_plane(
     plane: np.ndarray,
     *,
@@ -215,4 +260,9 @@ def encode_htj2k_plane(
     quality: float = 0.0,
 ) -> bytes:
     """Encode one 2D plane through the vendored OpenJPH WASM worker pool."""
-    return get_encoder_pool().encode_plane(plane, reversible=reversible, quality=quality)
+    return encode_htj2k(plane, reversible=reversible, quality=quality)
+
+
+def decode_htj2k(codestream: bytes | bytearray) -> np.ndarray:
+    """Decode an HTJ2K codestream to a (components, y, x) array via openjph-wasm."""
+    return get_encoder_pool().decode(codestream)

--- a/python/spatialdata-codec-writer/src/spatialdata_codec_writer/vendor/encode-plane.mjs
+++ b/python/spatialdata-codec-writer/src/spatialdata_codec_writer/vendor/encode-plane.mjs
@@ -1,20 +1,28 @@
 #!/usr/bin/env node
+import { dirname, join } from 'node:path';
 /**
- * Encode one 2D image plane to HTJ2K via vendored openjph-wasm.
+ * Encode/decode HTJ2K chunks via vendored openjph-wasm.
  *
- * One-shot mode (default):
- *   stdin: JSON { width, height, dtype, reversible?, quality?, plane: base64 }
+ * A chunk is one or more planar, component-major planes (e.g. z-planes of a
+ * volumetric chunk) encoded as a single multi-component codestream.
+ *
+ * One-shot mode (default): encode only.
+ *   stdin: JSON { width, height, components?, dtype, reversible?, quality?, plane: base64 }
  *   stdout: raw HTJ2K bytes
  *
  * Worker mode (--worker):
  *   Repeated length-prefixed requests on stdin; length-prefixed responses on stdout.
  *   Request:  [u32 BE length][JSON utf8]
+ *     encode (default): { width, height, components?, dtype, reversible?, quality?, plane: base64 }
+ *     decode:           { op: "decode", codestream: base64 }
  *   Response: [u8 status][u32 BE length][payload]
- *     status 0 = HTJ2K bytes
+ *     status 0 = payload (encode: HTJ2K bytes; decode: 14-byte header + planar samples)
  *     status 1 = UTF-8 error message
+ *
+ *   Decode header (little-endian): u32 components, u32 height, u32 width,
+ *     u8 bytesPerSample, u8 isSigned — followed by the raw component-major samples.
  */
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { dirname, join } from 'node:path';
 
 const vendorDir = dirname(fileURLToPath(import.meta.url));
 const openjphIndex = join(vendorDir, 'openjph', 'index.mjs');
@@ -43,31 +51,53 @@ function planeArrayForDtype(dtype, bytes) {
   }
 }
 
-async function loadEncoder() {
+async function loadRuntime() {
   const mod = await import(pathToFileURL(openjphIndex).href);
-  if (typeof mod.encode !== 'function') {
-    throw new Error('Vendored openjph-wasm does not expose encode().');
+  if (typeof mod.encode !== 'function' || typeof mod.decode !== 'function') {
+    throw new Error('Vendored openjph-wasm does not expose encode()/decode().');
   }
   return mod;
 }
 
-async function encodePlane(runtime, request) {
+async function encodeChunk(runtime, request) {
   const { width, height, dtype } = request;
+  const components = request.components ?? 1;
   const reversible = request.reversible ?? true;
   const quality = request.quality ?? 0;
   const planeBytes = Buffer.from(request.plane, 'base64');
-  const plane = planeArrayForDtype(dtype, planeBytes);
-  const expectedValues = width * height;
-  if (plane.length !== expectedValues) {
-    throw new Error(`Plane has ${plane.length} samples, expected ${expectedValues}.`);
+  const data = planeArrayForDtype(dtype, planeBytes);
+  const expectedValues = width * height * components;
+  if (data.length !== expectedValues) {
+    throw new Error(`Chunk has ${data.length} samples, expected ${expectedValues}.`);
   }
 
   // bitDepth / isSigned are inferred from the typed array by openjph-wasm.
-  const input = { data: plane, width, height, components: 1, reversible };
+  const input = { data, width, height, components, reversible };
   if (!reversible) {
     input.quality = quality;
   }
   return await runtime.encode(input);
+}
+
+async function decodeChunk(runtime, request) {
+  const codestream = Buffer.from(request.codestream, 'base64');
+  const result = await runtime.decode(new Uint8Array(codestream));
+  const samples = result.data;
+  const bytesPerSample = samples.BYTES_PER_ELEMENT;
+  const header = Buffer.alloc(14);
+  header.writeUInt32LE(result.components, 0);
+  header.writeUInt32LE(result.height, 4);
+  header.writeUInt32LE(result.width, 8);
+  header.writeUInt8(bytesPerSample, 12);
+  header.writeUInt8(result.isSigned ? 1 : 0, 13);
+  const body = Buffer.from(samples.buffer, samples.byteOffset, samples.byteLength);
+  return Buffer.concat([header, body]);
+}
+
+async function handleRequest(runtime, request) {
+  return request.op === 'decode'
+    ? await decodeChunk(runtime, request)
+    : await encodeChunk(runtime, request);
 }
 
 function writeResponse(status, payload) {
@@ -99,8 +129,8 @@ async function* readLengthPrefixedJson(stream) {
 async function runWorker(runtime) {
   for await (const request of readLengthPrefixedJson(process.stdin)) {
     try {
-      const encoded = await encodePlane(runtime, request);
-      writeResponse(0, Buffer.from(encoded));
+      const payload = await handleRequest(runtime, request);
+      writeResponse(0, Buffer.from(payload));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       writeResponse(1, Buffer.from(message, 'utf8'));
@@ -110,12 +140,12 @@ async function runWorker(runtime) {
 
 async function runOnce(runtime) {
   const request = JSON.parse((await readStdin()).toString('utf8'));
-  const encoded = await encodePlane(runtime, request);
+  const encoded = await encodeChunk(runtime, request);
   process.stdout.write(Buffer.from(encoded));
 }
 
 async function main() {
-  const runtime = await loadEncoder();
+  const runtime = await loadRuntime();
   if (workerMode) {
     await runWorker(runtime);
     return;

--- a/python/spatialdata-codec-writer/tests/test_htj2k_encode.py
+++ b/python/spatialdata-codec-writer/tests/test_htj2k_encode.py
@@ -28,10 +28,35 @@ def test_encoder_pool_round_trip() -> None:
     pool = EncoderPool(workers=2)
     try:
         plane = np.arange(16, dtype=np.uint16).reshape(4, 4)
-        encoded_a = pool.encode_plane(plane, reversible=True, quality=0.0)
-        encoded_b = pool.encode_plane(plane, reversible=True, quality=0.0)
+        encoded_a = pool.encode(plane, reversible=True, quality=0.0)
+        encoded_b = pool.encode(plane, reversible=True, quality=0.0)
         assert len(encoded_a) > 0
         assert len(encoded_b) > 0
+    finally:
+        pool.close()
+        shutdown_encoder_pool()
+
+
+@pytest.mark.skipif(
+    not htj2k_encode_available(),
+    reason="No HTJ2K encoder is available in this environment.",
+)
+def test_multi_component_round_trip() -> None:
+    """A z>1 chunk encodes to one multi-component codestream and round-trips losslessly."""
+    shutdown_encoder_pool()
+    pool = EncoderPool(workers=1)
+    try:
+        components, height, width = 4, 8, 8
+        volume = (
+            np.arange(components * height * width, dtype=np.uint16).reshape(
+                components, height, width
+            )
+            % 4096
+        )
+        encoded = pool.encode(volume, reversible=True, quality=0.0)
+        decoded = pool.decode(encoded)
+        assert decoded.shape == (components, height, width)
+        assert np.array_equal(decoded, volume)
     finally:
         pool.close()
         shutdown_encoder_pool()

--- a/python/spatialdata-codec-writer/tests/test_writer.py
+++ b/python/spatialdata-codec-writer/tests/test_writer.py
@@ -88,11 +88,13 @@ def test_write_mandelbulb_fixture(tmp_path: Path) -> None:
     assert list(fixture.manifest["chunks"]) == list(MANDELBULB_FIXTURE_CHUNKS)
 
     first_chunk = fixture.manifest["chunks_checked"][0]
+    assert first_chunk["components"] == 4
     encoded = (fixture.store_path / first_chunk["path"]).read_bytes()
     decoded = decode_htj2k_plane(encoded)
 
-    assert decoded.shape == (128, 128)
-    assert int(decoded[0, 0]) == first_chunk["samples"][0]
+    # z>1 chunk: one multi-component codestream (4 z-planes) -> (components, y, x).
+    assert decoded.shape == (4, 128, 128)
+    assert int(decoded[0, 0, 0]) == first_chunk["samples"][0]
 
 
 def test_image_to_tczyx_uses_named_dimensions() -> None:


### PR DESCRIPTION
## What

Encodes a chunk's **z-planes as components of a single HTJ2K codestream**, and switches the volumetric `mandelbulb` test fixture to `z > 1` chunks (`(1, 1, 4, 128, 128)`). The HTJ2K path — encode **and** decode — now runs entirely through the vendored **openjph-wasm** worker (the same WASM the JS reader uses); `imagecodecs` is no longer on the HTJ2K path.

## Why

The earlier swap to `openjph-wasm` ([#65](https://github.com/Taylor-CCB-Group/SpatialData.js/pull/65)) unblocked genuine multi-component round-trips (the previous cornerstone build dropped components — see `multi-component-codec-findings.md`). This is the "volumetric next" follow-up: actually use multi-component chunks so the fixture exercises volumetric decode.

Per guidance, the HTJ2K path uses the same WASM in Python as in JS. We deliberately avoid native `imagecodecs` HTJ2K (build-fragile) and `itkwasm-htj2k` (unmaintained ~2y); a note records this.

## Changes

- **`vendor/encode-plane.mjs`**: `encode` accepts `components` + a planar, component-major buffer; new `decode` op returns a self-describing header + planar samples, so the writer self-validates with the same decoder as the reader.
- **`htj2k_encode.py`**: payload handles a 2D plane or `(components, y, x)` volume; adds `encode_htj2k()`/`decode_htj2k()` and pool/worker `encode()`/`decode()`.
- **`codecs.py`**: HTJ2K encode+decode via openjph-wasm (no `imagecodecs`); adds `encode_image_chunk`/`decode_image_chunk`. `imagecodecs` retained only for the JPEG2000 fixture path.
- **`fixture_writer.py`**: each chunk → one multi-component codestream, self-validated losslessly via decode; `_validate_codec_chunks` now requires only a `(1, 1)` t/c prefix (z may be > 1).
- **`mandelbulb_fixtures.py`**: chunks → `(1, 1, 4, 128, 128)`.
- **tests/docs**: multi-component round-trip test; mandelbulb assertions updated to `(4, 128, 128)`; README/design/findings updated to "implemented".

## How the layout maps

`openjph-wasm` uses planar, component-major buffers (`data[(c*h + y)*w + x]`), which is exactly C-order `(z, y, x)`. So a chunk reshaped to `(components, y, x)` encodes directly, and the decoder's buffer maps straight onto the Zarr chunk's `[..., z, y, x]`. The TS reader needed **no changes** — `decoded.length === product(chunk_shape)` already holds.

## Validation

- Worker round-trip: C=1, C=4 lossless.
- Python `pnpm test:codec-writer`: **39 passed, 1 skipped** (incl. multi-component round-trip + mandelbulb z>1 self-validation).
- TS `codecFixtures` integration: **5/5** — JS reader decodes the z>1 mandelbulb across distinct t/z selections.

## Notes

- **Stacked on [#65](https://github.com/Taylor-CCB-Group/SpatialData.js/pull/65)** (base `claude/lucid-agnesi-29badc`); it depends on the openjph-wasm swap. GitHub will retarget to `main` when #65 merges.
- The fixture stores are generated, not committed.