### PR TITLE
Add changeset for openjph-wasm switch (PR #65); fix dev.mjs import paths

### DIFF
--- a/.changeset/switch-openjph-wasm.md
+++ b/.changeset/switch-openjph-wasm.md
@@ -1,0 +1,8 @@
+---
+"zarrextra": minor
+"@spatialdata/vis": patch
+---
+
+Switch HTJ2K codec from `@cornerstonejs/codec-openjph` to `openjph-wasm`, which correctly round-trips multi-component (volumetric) HTJ2K data. The cornerstone build silently dropped components 2..N on decode; `openjph-wasm` handles arbitrary component counts losslessly.
+
+Also adds true z>1 multi-component chunk support: z-planes are now encoded as components of a single codestream rather than one plane per chunk. Exports `Htj2kPlane` from the package index.

--- a/packages/vis/scripts/dev.mjs
+++ b/packages/vis/scripts/dev.mjs
@@ -4,8 +4,8 @@ import {
   isPortInUse,
   listProcesses,
   portListeners,
-} from '../../scripts/dev-process-utils.mjs';
-import { FIXTURE_SERVER_PORT } from '../../scripts/fixture-server-port.mjs';
+} from '../../../scripts/dev-process-utils.mjs';
+import { FIXTURE_SERVER_PORT } from '../../../scripts/fixture-server-port.mjs';
 
 const DEMO_PORT = 5173;
 const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';


### PR DESCRIPTION
## What

- Adds the missing changeset for [PR #65](https://github.com/Taylor-CCB-Group/SpatialData.js/pull/65) which switched the HTJ2K codec from `@cornerstonejs/codec-openjph` to `openjph-wasm` and added z>1 multi-component chunk support.
- Fixes incorrect relative import paths in `packages/vis/scripts/dev.mjs` (paths had one `../` too few, breaking the dev server script).

## Changeset summary

| Package | Bump | Reason |
|---------|------|--------|
| `zarrextra` | minor | New `Htj2kPlane` export; behavioral change — z-planes now encoded as multi-component codestreams |
| `@spatialdata/vis` | patch | Dependency swap only (`openjph-wasm` replaces cornerstone codec) |

## Reviewer notes

The changeset was simply forgotten before merging #65 — no code changes beyond the import path fix. The bump levels can be adjusted if you disagree with minor vs patch for zarrextra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HTJ2K handling for volumetric data, preserving all components during lossless round-tripping.
  * Enhanced chunking for multi-component z>1 data to better encode z-planes within a single codestream.
  * Exposed `Htj2kPlane` for broader package use.

* **Bug Fixes**
  * Resolved silent loss of extra components during HTJ2K decoding, improving data fidelity.

* **Chores**
  * Updated package release version intents for related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->