### PR TITLE
Fix multiscale labels stretching when zoomed out past the coarsest level

### DIFF
--- a/.changeset/cull-out-of-bounds-label-tiles.md
+++ b/.changeset/cull-out-of-bounds-label-tiles.md
@@ -1,0 +1,9 @@
+---
+"@spatialdata/layers": patch
+---
+
+Fix multiscale labels rendering with an obviously wrong (vertically stretched, mis-placed) transformation when zoomed out past the coarsest resolution level.
+
+The `MultiscaleLabelsTileLayer` was configured with `minZoom: -20`, so deck.gl kept subdividing the tile grid below the deepest available resolution level. Past that level `getTileData` clamps to the deepest loader and returns the same data, but the tile bbox keeps doubling — so the bounds formula stretched that fixed data across an ever-larger world rect, far beyond the image extent. `minZoom` is now capped at `-(loader.length - 1)`, matching Viv's `MultiscaleImageLayer`, so the coarsest real tiles stay correctly placed at any zoom-out.
+
+Also adds the bbox-culling guards Viv's `renderSubLayers` applies (skip tiles with negative bbox edges or zero-sized data) for defense in depth. This is the underlying cause that #44 only masked by making sublayer ids unique.

--- a/packages/layers/src/LabelsLayer.ts
+++ b/packages/layers/src/LabelsLayer.ts
@@ -237,7 +237,15 @@ function renderSubBitmaskLayers(props: any) {
   } = props.tile;
   const { data, id, loader, maxZoom, minZoom, zoomOffset } = props;
 
-  if (!data) {
+  // Cull tiles that fall outside the image extent. deck.gl's TileLayer emits
+  // tiles with negative bbox edges at some zoom levels (notably zoomed-out /
+  // overview levels for non-power-of-2 images); feeding those negative edges
+  // into the bounds formula below produces a grossly mis-placed/stretched
+  // raster. Mirrors Viv's own renderSubLayers guard.
+  if ([left, bottom, right, top].some((v) => v < 0) || !data) {
+    return null;
+  }
+  if (data.width === 0 || data.height === 0) {
     return null;
   }
 
@@ -327,6 +335,13 @@ export class LabelsLayer extends CompositeLayer<LabelsLayerProps> {
       const { height, width } = getImageSize(baseLoader);
       const tileSize = baseLoader.tileSize;
       const zoomOffset = Math.round(Math.log2(modelMatrix ? modelMatrix.getScale()[0] : 1));
+      // Cap the coarsest tile zoom at the deepest available resolution level
+      // (matches Viv's MultiscaleImageLayer). Without this, deck.gl keeps
+      // subdividing past the last real level when zoomed out: getTileData
+      // clamps to the deepest loader and returns the same data, but the tile
+      // bbox keeps doubling, so the bounds formula stretches that data far
+      // beyond the image extent — the "wrong transformation" at low zoom.
+      const minZoom = Math.round(-(loader.length - 1));
 
       return new MultiscaleLabelsTileLayer(
         this.getSubLayerProps({
@@ -343,7 +358,7 @@ export class LabelsLayer extends CompositeLayer<LabelsLayerProps> {
           tileSize,
           extent: [0, 0, width, height],
           zoomOffset,
-          minZoom: MIN_LABELS_DISPLAY_ZOOM,
+          minZoom,
           maxZoom: 0,
           refinementStrategy: 'best-available',
           onTileError: baseLoader.onTileError,

--- a/packages/layers/tests/labelsLayer.spec.ts
+++ b/packages/layers/tests/labelsLayer.spec.ts
@@ -168,6 +168,84 @@ describe('LabelsLayer prop flow', () => {
     expect(bitmaskLayer.props.customExtensionProp).toBe('forwarded');
   });
 
+  it('caps minZoom at the deepest resolution level so zoom-out does not stretch labels', () => {
+    // deck.gl keeps subdividing past the coarsest real level when minZoom is
+    // too negative; getTileData then returns the same clamped data while the
+    // tile bbox doubles, stretching labels far beyond the image extent. Capping
+    // minZoom at -(levels - 1) (matching Viv) is what prevents that.
+    const twoLevel = renderLabelsLayer({ loader: makeLabelsLoader().loader });
+    expect(twoLevel.props.minZoom).toBe(-1);
+    expect(twoLevel.props.maxZoom).toBe(0);
+
+    const makeScale = () => ({
+      shape: [512, 512],
+      tileSize: 256,
+      getTile: vi.fn(async () => ({ data: new Float32Array([0, 1, 2, 0]), width: 2, height: 2 })),
+    });
+    const fourLevel = renderLabelsLayer({
+      loader: [makeScale(), makeScale(), makeScale(), makeScale()],
+    });
+    expect(fourLevel.props.minZoom).toBe(-3);
+  });
+
+  it('culls tiles whose bbox falls outside the image extent', () => {
+    const { loader } = makeLabelsLoader();
+    const tileLayer = renderLabelsLayer({ loader });
+    const data = {
+      data: [new Float32Array([0, 1, 2, 0])],
+      width: 2,
+      height: 2,
+    };
+
+    // A tile that extends past the left/top edge of the image carries negative
+    // bbox edges; rendering it produces the wrong-transformation glitch, so it
+    // must be culled rather than drawn with garbage bounds.
+    const outOfBounds = tileLayer.props.renderSubLayers({
+      ...tileLayer.props,
+      id: 'labels:mask-viewport-labels',
+      data,
+      tile: {
+        bbox: { left: -256, top: -256, right: 256, bottom: 256 },
+        index: { x: -1, y: -1, z: 0 },
+        zoom: 0,
+      },
+    });
+
+    expect(outOfBounds).toBeNull();
+
+    // A tile fully inside the extent still renders.
+    const inBounds = tileLayer.props.renderSubLayers({
+      ...tileLayer.props,
+      id: 'labels:mask-viewport-labels',
+      data,
+      tile: {
+        bbox: { left: 0, top: 0, right: 256, bottom: 256 },
+        index: { x: 0, y: 0, z: 0 },
+        zoom: 0,
+      },
+    });
+
+    expect(inBounds).toBeTruthy();
+  });
+
+  it('culls tiles with zero-sized data', () => {
+    const { loader } = makeLabelsLoader();
+    const tileLayer = renderLabelsLayer({ loader });
+
+    const empty = tileLayer.props.renderSubLayers({
+      ...tileLayer.props,
+      id: 'labels:mask-viewport-labels',
+      data: { data: [new Float32Array([])], width: 0, height: 0 },
+      tile: {
+        bbox: { left: 0, top: 0, right: 256, bottom: 256 },
+        index: { x: 0, y: 0, z: 0 },
+        zoom: 0,
+      },
+    });
+
+    expect(empty).toBeNull();
+  });
+
   it('keeps labels bitmask sublayer ids distinct across tile resolutions', () => {
     const { loader } = makeLabelsLoader();
     const tileLayer = renderLabelsLayer({ loader });


### PR DESCRIPTION
## What

Multiscale labels rendered with an obviously wrong, vertically-stretched, mis-placed transformation once you zoomed out past the deepest resolution level of the pyramid. This is the recurrence of the "labels switch to a wrong transformation at certain zoom levels" bug that [#44](https://github.com/Taylor-CCB-Group/SpatialData.js/pull/44) was thought to fix.

## Why it happened

`MultiscaleLabelsTileLayer` was configured with `minZoom: -20`. deck.gl therefore kept subdividing the tile grid below the coarsest level that actually exists (e.g. a 4-level pyramid only has tiles down to z = −3):

- `getTileData` clamps `resolution` to the deepest loader and returns the **same** data (a full `tileSize` tile).
- But the tile **bbox keeps doubling** as z goes more negative (bottom = 4096 → 8192 → 16384 …).
- Because the data fills a full tile, the "partial-edge" clamp in the bounds formula doesn't fire, so `bounds.bottom = bbox.bottom` — the inflated value. That fixed strip of label data gets stretched across a world rect far taller than the image.

This only triggers below a certain zoom, which is exactly the reported symptom. #44 (unique sublayer ids) only masked a separate stale-texture artifact.

## Fix

- Cap `minZoom` at `Math.round(-(loader.length - 1))`, matching Viv's `MultiscaleImageLayer`. deck.gl then stops subdividing past the coarsest real level and keeps those tiles correctly placed at any zoom-out.
- Add the bbox-culling guards Viv's `renderSubLayers` applies (skip tiles with negative bbox edges or zero-sized data) as defense in depth.

## Diagnosis notes

Confirmed in the running demo by instrumenting `renderSubBitmaskLayers` and reading the actual per-tile bounds + model-matrix world rects: at z = −3 the two tiles tile world-y 0 → 14950 → 19264 exactly (correct), while at z < −3 the same data inflated to world-y far beyond the image height — the stretch. The fix was verified visually against the `1113PMDC1_human_01` sample (H&E + `cell_labels`).

## Testing

- New unit tests assert `minZoom === -(levels - 1)` for 2- and 4-level loaders, plus culling of out-of-extent / zero-sized tiles.
- `pnpm --filter @spatialdata/layers test` → 46 passing; `build` (vite + `tsc --noEmit`) clean.

## Reviewer notes

- `MIN_LABELS_DISPLAY_ZOOM` is retained — still used by the single-scale path.
- Unrelated observation: `@spatialdata/layers` has no `dev` (`vite build --watch`) script, unlike `core`/`react`/`zarrextra`. The demo works because it aliases the package to source, but consumers reading the built `dist` won't see layer edits during `pnpm dev` without a manual build. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multiscale label rendering at very low zoom levels so labels stay aligned instead of stretching or shifting.
  * Improved tile filtering to skip out-of-bounds or empty tiles, reducing visual artifacts and unexpected rendering issues.

* **Tests**
  * Added coverage for low-zoom label behavior, out-of-bounds tile handling, and empty tile data cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->