### PR TITLE
Add `dev` watch script to @spatialdata/layers and @spatialdata/avivatorish

### DIFF
--- a/packages/avivatorish/package.json
+++ b/packages/avivatorish/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "vite build && tsc --noEmit",
+    "dev": "vite build --watch",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "vite build && tsc --noEmit",
+    "dev": "vite build --watch",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## What

Add `"dev": "vite build --watch"` to `@spatialdata/layers` and `@spatialdata/avivatorish`.

## Why

`pnpm dev` runs `pnpm -r --parallel dev`, which **silently skips** any package without a `dev` script. `layers` and `avivatorish` were the only buildable packages missing one (core/react/zarrextra all have `vite build --watch`), so their `dist/` was never watch-built. A consumer reading the built output therefore had to run a manual `pnpm --filter @spatialdata/layers build` to pick up edits.

This restores the "everything watches" behaviour so `pnpm dev` keeps every package's `dist/` fresh.

## Notes for reviewers

- **The demo was never broken by this.** Both the demo server ([`vite.config.demo.ts`](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/packages/vis/vite.config.demo.ts)) and the vis watch build ([`vite.config.ts`](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/packages/vis/vite.config.ts)) alias `@spatialdata/*` → `src/index.ts`, so they already read these packages from **source**. The fix matters for anything resolving the packages through their published `dist` entry, and for plain consistency.
- `vite build --watch` (library build → `dist/`) is the right tool here, not `vite dev` (which serves an app in-memory and writes nothing to disk). These are libraries with no app entry; only `build --watch` produces the `dist/` consumers read.
- No changeset: this is a dev-only script with zero impact on published runtime output.
- Verified both packages build cleanly (`dist/index.js` + `.d.ts`) under Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)