### PR TITLE
Auto-select the sole coordinate system

### DIFF
--- a/.changeset/default-coordinate-system-selection.md
+++ b/.changeset/default-coordinate-system-selection.md
@@ -1,0 +1,5 @@
+---
+"@spatialdata/vis": patch
+---
+
+Auto-select the coordinate system when a SpatialData object has exactly one. Previously the picker started unselected (showing "Select a coordinate system") even when there was only one choice, and a separate effect would eagerly pick the first of several. Now selection defaults only in the unambiguous single-coordinate-system case; multi-system datasets still require an explicit choice.

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -458,15 +458,15 @@ function SpatialCanvasInner({
   ]);
 
   useEffect(() => {
-    if (coordinateSystems.length > 0 && !coordinateSystem) {
-      actions.setCoordinateSystem(coordinateSystems[0]);
-    }
-  }, [coordinateSystems, coordinateSystem, actions]);
-
-  useEffect(() => {
     actions.reset();
-    if (coordinateSystem && coordinateSystems.includes(coordinateSystem)) {
-      actions.setCoordinateSystem(coordinateSystem);
+    const nextCoordinateSystem =
+      coordinateSystem && coordinateSystems.includes(coordinateSystem)
+        ? coordinateSystem
+        : coordinateSystems.length === 1
+          ? coordinateSystems[0]
+          : null;
+    if (nextCoordinateSystem) {
+      actions.setCoordinateSystem(nextCoordinateSystem);
     }
   }, [coordinateSystem, coordinateSystems, actions]);
 


### PR DESCRIPTION
Harvested from the larger points-loading branch as an isolated, low-risk change.

When a SpatialData object exposes exactly one coordinate system, select it by default instead of leaving the picker on "Select a coordinate system". Multi-system datasets still require an explicit choice (the previous behaviour eagerly picked the first of several, which this also removes).

- Single file: `packages/vis/src/SpatialCanvas/index.tsx`
- Patch changeset for `@spatialdata/vis` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Coordinate system selection now behaves more predictably when loading spatial data.
  * If only one coordinate system is available, it is selected automatically.
  * When multiple coordinate systems are available, the picker no longer preselects one by default.
  * Existing selections are preserved when still valid after a refresh or reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->