### PR TITLE
Add spatialdata-experimental-writer Python package

### DIFF
--- a/python/spatialdata-experimental-writer/README.md
+++ b/python/spatialdata-experimental-writer/README.md
@@ -1,0 +1,16 @@
+# spatialdata-experimental-writer
+
+Experimental vector optimization writers for browser-oriented SpatialData
+rendering.
+
+The initial writer targets Vitessce-compatible Morton-sorted Points Parquet:
+
+- `x`, `y`, optional `z` coordinates are preserved.
+- `morton_code_2d` is added using 16 bits per axis.
+- the first 2-4 rows are sentinel/extreme rows with `morton_code_2d == 0`;
+  readers can infer the full point bounding box from these rows.
+- string/categorical columns are placed at the right side of the table.
+- row-group size is controlled when writing Parquet.
+
+The package also includes a small multiscale Parquet writer hook that stores
+Padua-style `spatialdata_multiscale` JSON metadata in the Parquet schema.

--- a/python/spatialdata-experimental-writer/README.md
+++ b/python/spatialdata-experimental-writer/README.md
@@ -31,6 +31,40 @@ cd python/spatialdata-experimental-writer
 uv sync
 ```
 
+For the interactive TUI:
+
+```bash
+uv sync --group tui
+```
+
+## Interactive TUI
+
+```bash
+uv run spatialdata-experimental-writer tui
+uv run spatialdata-experimental-writer tui ~/data/xenium_rep1_io.zarr
+```
+
+The TUI wraps all writer commands:
+
+1. Pick a command from the home menu.
+2. Enter paths and options on guided forms (Zarr store path is pre-filled when
+   passed on the command line).
+3. Confirm before any in-place overwrite of canonical `points/<key>/points.parquet`.
+4. Watch run output, then review post-write verification checks.
+
+Morton verification checks after Morton writes:
+
+| Check | Meaning |
+|-------|---------|
+| `column_present` | `morton_code_2d` column exists |
+| `sentinel_prefix` | First 2–4 rows have `morton_code_2d == 0` |
+| `sentinel_bbox` | Sentinel rows encode full dataset x/y bounds |
+| `morton_monotonic` | Morton codes non-decreasing after sentinels |
+| `row_group_sentinels` | Row group 0 contains only sentinel rows |
+| `no_uint_intermediates` | No persisted `*_uint` staging columns |
+
+Multiscale and index-permutation runs show schema/manifest checks instead.
+
 ## Commands
 
 ```bash

--- a/python/spatialdata-experimental-writer/README.md
+++ b/python/spatialdata-experimental-writer/README.md
@@ -7,10 +7,92 @@ The initial writer targets Vitessce-compatible Morton-sorted Points Parquet:
 
 - `x`, `y`, optional `z` coordinates are preserved.
 - `morton_code_2d` is added using 16 bits per axis.
-- the first 2-4 rows are sentinel/extreme rows with `morton_code_2d == 0`;
+- the first 2–4 rows are sentinel/extreme rows with `morton_code_2d == 0`;
   readers can infer the full point bounding box from these rows.
+- `{feature_key}_codes` (for example `feature_name_codes`) are added when
+  `feature_key` is set in element attrs.
 - string/categorical columns are placed at the right side of the table.
 - row-group size is controlled when writing Parquet.
+- intermediate Morton uint columns are not persisted in the output Parquet.
 
-The package also includes a small multiscale Parquet writer hook that stores
-Padua-style `spatialdata_multiscale` JSON metadata in the Parquet schema.
+Morton v1 belongs on the **canonical** element path
+`points/<key>/points.parquet`. Use `--experimental` only for layouts that
+standard readers cannot consume (see
+[ADR 0002](../../docs/adr/0002-spatially-aware-vector-loading.md)).
+
+Feature / gene filtering in the browser is documented in ADR 0002; pass integer
+`featureCodes` through `@spatialdata/core` `loadPointsInBounds()` and
+`PointsLayerConfig.featureCodes` in `@spatialdata/vis`.
+
+## Install
+
+```bash
+cd python/spatialdata-experimental-writer
+uv sync
+```
+
+## Commands
+
+```bash
+# List Points elements in a store
+uv run spatialdata-experimental-writer list-points ~/data/xenium.zarr
+
+# Morton-sort transcripts in-place on canonical points/<key>/points.parquet
+uv run spatialdata-experimental-writer morton-points-from-zarr \
+  ~/data/xenium.zarr --points-key transcripts
+
+# Optional: write to points.experimental/ instead of canonical path
+uv run spatialdata-experimental-writer morton-points-from-zarr \
+  ~/data/xenium.zarr --points-key transcripts --experimental
+
+# Build a derivative store with transcript index sort permutations
+uv run spatialdata-experimental-writer write-index-permutations \
+  ~/data/xenium_rep1_io.zarr \
+  ~/data/xenium_rep1_index-permutations.zarr
+
+# Morton-sort a CSV or Parquet file
+uv run spatialdata-experimental-writer morton-points input.csv output.parquet \
+  --feature-key feature_name
+```
+
+## Xenium workflow
+
+Standard sandbox datasets are listed in the
+[spatialdata datasets docs](https://spatialdata.scverse.org/en/stable/tutorials/notebooks/datasets/README.html):
+
+| Dataset | URL |
+|---------|-----|
+| `xenium_rep1_io.zarr` | `https://s3.embl.de/spatialdata/spatialdata-sandbox/xenium_rep1_io.zarr/` |
+| `xenium_rep2_io.zarr` | `https://s3.embl.de/spatialdata/spatialdata-sandbox/xenium_rep2_io.zarr/` |
+| `visium_associated_xenium_io.zarr` | `https://s3.embl.de/spatialdata/spatialdata-sandbox/visium_associated_xenium_io.zarr/` |
+
+After downloading a store locally:
+
+```bash
+uv run spatialdata-experimental-writer morton-points-from-zarr \
+  ~/data/spatialdata/sdata_inputs/xenium_rep1_io.zarr \
+  --points-key transcripts
+```
+
+This replaces `points/transcripts/points.parquet` in place (single-file output;
+multipart source directories are replaced). Open the store in `@spatialdata/vis`
+with `experimentalOptimizations="auto"` to use TileLayer row-group reads.
+
+For sort-strategy benchmarks on a **copy** of the store:
+
+```bash
+uv run spatialdata-experimental-writer write-index-permutations \
+  ~/data/spatialdata/sdata_inputs/xenium_rep1_io.zarr \
+  ~/data/spatialdata/sdata_inputs/xenium_rep1_index-permutations.zarr \
+  --max-rows 500000
+
+uv run python scripts/benchmark_points_index.py \
+  ~/data/spatialdata/sdata_inputs/xenium_rep1_index-permutations.zarr
+```
+
+## Multiscale hook
+
+The package also includes a Padua-style multiscale Parquet writer that stores
+`spatialdata_multiscale` JSON metadata in the Parquet schema. That layout is
+non-standard for morton-points v1 and belongs under `points.experimental/` if
+persisted.

--- a/python/spatialdata-experimental-writer/pyproject.toml
+++ b/python/spatialdata-experimental-writer/pyproject.toml
@@ -32,3 +32,6 @@ testpaths = ["tests"]
 dev = [
     "pytest>=8.0",
 ]
+tui = [
+    "textual>=1.0",
+]

--- a/python/spatialdata-experimental-writer/pyproject.toml
+++ b/python/spatialdata-experimental-writer/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "spatialdata-experimental-writer"
+version = "0.1.0"
+description = "Experimental SpatialData vector optimization writers"
+requires-python = ">=3.12"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "SpatialData.js contributors" }]
+dependencies = [
+    "numpy>=2.0",
+    "pandas>=2.2",
+    "pyarrow>=18",
+]
+
+[project.scripts]
+spatialdata-experimental-writer = "spatialdata_experimental_writer.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.uv]
+package = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]

--- a/python/spatialdata-experimental-writer/scripts/benchmark_points_index.py
+++ b/python/spatialdata-experimental-writer/scripts/benchmark_points_index.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Benchmark points index permutations using index-manifest.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+
+def _load_bounds(manifest: dict, scenario_id: str | None) -> dict[str, float]:
+    scenarios = manifest.get("benchmark_scenarios") or []
+    if scenario_id:
+        for scenario in scenarios:
+            if scenario.get("id") == scenario_id:
+                return scenario["bounds"]
+        raise SystemExit(f"Unknown scenario id: {scenario_id}")
+    if scenarios:
+        return scenarios[0]["bounds"]
+    raise SystemExit("Manifest has no benchmark_scenarios")
+
+
+def _feature_codes(manifest: dict, scenario_id: str | None) -> list[int] | None:
+    scenarios = manifest.get("benchmark_scenarios") or []
+    if not scenario_id:
+        return None
+    for scenario in scenarios:
+        if scenario.get("id") == scenario_id:
+            codes = scenario.get("feature_codes")
+            return list(codes) if codes is not None else None
+    return None
+
+
+def _parquet_path(store: Path, element_path: str) -> Path:
+    return store / element_path / "points.parquet"
+
+
+def _read_rows_in_bounds(
+    parquet_path: Path,
+    bounds: dict[str, float],
+    feature_codes: list[int] | None,
+    feature_key: str | None,
+) -> tuple[int, int]:
+    if parquet_path.is_dir():
+        parts = sorted(parquet_path.glob("part.*.parquet"))
+        if not parts:
+            raise FileNotFoundError(f"No parquet parts under {parquet_path}")
+        frames = [pd.read_parquet(part) for part in parts]
+        df = pd.concat(frames, ignore_index=True)
+        bytes_read = sum(part.stat().st_size for part in parts)
+    else:
+        bytes_read = parquet_path.stat().st_size
+        df = pd.read_parquet(parquet_path)
+
+    mask = (
+        (df["x"] >= bounds["minX"])
+        & (df["x"] <= bounds["maxX"])
+        & (df["y"] >= bounds["minY"])
+        & (df["y"] <= bounds["maxY"])
+    )
+    if feature_codes is not None:
+        code_column = f"{feature_key}_codes" if feature_key else "feature_name_codes"
+        if code_column not in df.columns:
+            raise KeyError(f"Missing feature code column {code_column!r}")
+        mask &= df[code_column].isin(feature_codes)
+    return int(mask.sum()), int(bytes_read)
+
+
+def _estimate_row_group_bytes(parquet_path: Path, bounds: dict[str, float]) -> int | None:
+    if not parquet_path.is_file():
+        return None
+    if "morton_code_2d" not in pq.ParquetFile(parquet_path).schema_arrow.names:
+        return None
+    # Upper bound only: full file size when row-group APIs are unavailable in this script.
+    return parquet_path.stat().st_size
+
+
+def benchmark_store(
+    store: Path,
+    *,
+    scenario_id: str | None,
+    conditions: list[str] | None,
+) -> list[dict]:
+    manifest_path = store / "index-manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing index-manifest.json under {store}")
+    manifest = json.loads(manifest_path.read_text())
+    bounds = _load_bounds(manifest, scenario_id)
+    feature_codes = _feature_codes(manifest, scenario_id)
+    feature_key = manifest.get("feature_key")
+    selected = conditions or [entry["id"] for entry in manifest.get("conditions", [])]
+
+    results: list[dict] = []
+    for condition in manifest.get("conditions", []):
+        condition_id = condition["id"]
+        if condition_id not in selected:
+            continue
+        element_path = condition["element_path"]
+        parquet_path = _parquet_path(store, element_path)
+        started = time.perf_counter()
+        try:
+            rows, bytes_read = _read_rows_in_bounds(
+                parquet_path, bounds, feature_codes, feature_key
+            )
+            row_group_hint = _estimate_row_group_bytes(parquet_path, bounds)
+        except Exception as error:  # noqa: BLE001 - report per condition
+            results.append(
+                {
+                    "condition": condition_id,
+                    "element_path": element_path,
+                    "error": str(error),
+                }
+            )
+            continue
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        results.append(
+            {
+                "condition": condition_id,
+                "element_path": element_path,
+                "sort_order": condition.get("sort_order"),
+                "tiling_kind": condition.get("tiling_kind"),
+                "rows_in_bounds": rows,
+                "bytes_read_estimate": bytes_read,
+                "morton_row_group_bytes_upper_bound": row_group_hint,
+                "latency_ms": round(elapsed_ms, 2),
+                "bounds": bounds,
+                "feature_codes": feature_codes,
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark points index permutations from index-manifest.json"
+    )
+    parser.add_argument("store", type=Path, help="Derivative Zarr store path")
+    parser.add_argument("--scenario", metavar="ID", help="benchmark_scenarios id")
+    parser.add_argument(
+        "--conditions",
+        metavar="IDS",
+        help="Comma-separated condition ids (default: all in manifest)",
+    )
+    args = parser.parse_args()
+    condition_ids = args.conditions.split(",") if args.conditions else None
+    results = benchmark_store(args.store, scenario_id=args.scenario, conditions=condition_ids)
+    print(json.dumps({"store": str(args.store), "results": results}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/__init__.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/__init__.py
@@ -1,0 +1,17 @@
+from .points import (
+    MORTON_CODE_2D_COLUMN,
+    MORTON_CODE_EXTREME_VALUE_INDICATOR,
+    build_spatialdata_multiscale_metadata,
+    morton_sort_points,
+    write_morton_points_parquet,
+    write_multiscale_points_parquet,
+)
+
+__all__ = [
+    "MORTON_CODE_2D_COLUMN",
+    "MORTON_CODE_EXTREME_VALUE_INDICATOR",
+    "build_spatialdata_multiscale_metadata",
+    "morton_sort_points",
+    "write_morton_points_parquet",
+    "write_multiscale_points_parquet",
+]

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Callable
+from typing import Any
 
+from .errors import WriterCommandError
 from .runners import (
     run_list_points,
     run_morton_points,
@@ -44,17 +47,24 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
-def _print_json(payload: dict) -> None:
+def _print_json(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
 
 
+def _run_command(command: Callable[[], dict[str, Any]]) -> None:
+    try:
+        _print_json(command())
+    except WriterCommandError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
 def _list_points(args: argparse.Namespace) -> None:
-    _print_json(run_list_points(args.zarr))
+    _run_command(lambda: run_list_points(args.zarr))
 
 
 def _morton_points(args: argparse.Namespace) -> None:
-    _print_json(
-        run_morton_points(
+    _run_command(
+        lambda: run_morton_points(
             args.input,
             args.output,
             feature_key=args.feature_key,
@@ -65,8 +75,8 @@ def _morton_points(args: argparse.Namespace) -> None:
 
 
 def _multiscale_points(args: argparse.Namespace) -> None:
-    _print_json(
-        run_multiscale_points(
+    _run_command(
+        lambda: run_multiscale_points(
             args.input,
             args.output,
             metadata_json=args.metadata_json,
@@ -77,8 +87,8 @@ def _multiscale_points(args: argparse.Namespace) -> None:
 
 
 def _morton_points_from_zarr(args: argparse.Namespace) -> None:
-    _print_json(
-        run_morton_points_from_zarr(
+    _run_command(
+        lambda: run_morton_points_from_zarr(
             args.zarr,
             points_key=args.points_key,
             experimental=args.experimental,
@@ -92,8 +102,8 @@ def _morton_points_from_zarr(args: argparse.Namespace) -> None:
 
 def _write_index_permutations(args: argparse.Namespace) -> None:
     condition_ids = args.conditions.split(",") if args.conditions else None
-    _print_json(
-        run_write_index_permutations(
+    _run_command(
+        lambda: run_write_index_permutations(
             args.source_zarr,
             args.dest_zarr,
             points_key=args.points_key,

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
 
 import pandas as pd
 
+from .index_permutations import DEFAULT_CONDITIONS, write_index_permutations
 from .points import (
     build_spatialdata_multiscale_metadata,
     write_morton_points_parquet,
     write_multiscale_points_parquet,
 )
 from .zarr import (
-    experimental_points_output_path,
     list_points_keys,
     points_parquet_path,
     read_points_dataframe,
@@ -24,9 +25,13 @@ examples:
   # List Points elements in a SpatialData Zarr store
   spatialdata-experimental-writer list-points ~/data/xenium.zarr
 
-  # Morton-sort transcripts from a Zarr store into points.experimental/
+  # Morton-sort transcripts in-place on the canonical points element
   spatialdata-experimental-writer morton-points-from-zarr \\
     ~/data/xenium.zarr --points-key transcripts
+
+  # Build a derivative store with transcript index permutations
+  spatialdata-experimental-writer write-index-permutations \\
+    ~/data/xenium_rep1_io.zarr ~/data/xenium_rep1_index-permutations.zarr
 
   # Morton-sort a CSV or single Parquet file
   spatialdata-experimental-writer morton-points input.csv output.parquet \\
@@ -139,11 +144,19 @@ def _morton_points_from_zarr(args: argparse.Namespace) -> None:
     attrs = read_points_element_attrs(zarr_path, points_key)
     feature_key = args.feature_key or attrs.get("feature_key")
     source_parquet = points_parquet_path(zarr_path, points_key)
-    output = Path(args.output) if args.output else experimental_points_output_path(
-        zarr_path, points_key
-    )
+    if args.output:
+        output = Path(args.output)
+    elif args.experimental:
+        output = zarr_path / "points.experimental" / points_key / "points.parquet"
+    else:
+        output = source_parquet
 
     df = read_points_dataframe(source_parquet)
+    if output.exists():
+        if output.is_dir():
+            shutil.rmtree(output)
+        else:
+            output.unlink()
     sorted_df = write_morton_points_parquet(
         df,
         output,
@@ -159,6 +172,7 @@ def _morton_points_from_zarr(args: argparse.Namespace) -> None:
                 "points_key": points_key,
                 "source": str(source_parquet),
                 "output": str(output),
+                "in_place": not args.experimental and args.output is None,
                 "feature_key": feature_key,
                 "rows": int(len(sorted_df)),
                 "row_group_size": args.row_group_size,
@@ -167,6 +181,29 @@ def _morton_points_from_zarr(args: argparse.Namespace) -> None:
             sort_keys=True,
         )
     )
+
+
+def _write_index_permutations(args: argparse.Namespace) -> None:
+    condition_ids = args.conditions.split(",") if args.conditions else None
+    selected = None
+    if condition_ids:
+        by_id = {condition.id: condition for condition in DEFAULT_CONDITIONS}
+        missing = [value for value in condition_ids if value not in by_id]
+        if missing:
+            raise SystemExit(f"Unknown conditions: {', '.join(missing)}")
+        selected = tuple(by_id[value] for value in condition_ids)
+
+    manifest = write_index_permutations(
+        args.source_zarr,
+        args.dest_zarr,
+        points_key=args.points_key,
+        max_rows=args.max_rows,
+        conditions=selected,
+        overwrite=args.overwrite,
+        row_group_size=args.row_group_size,
+        compression=args.compression,
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -198,13 +235,18 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Read points/<key>/points.parquet from a SpatialData Zarr store, "
             "add morton_code_2d sentinel rows, and write Vitessce-compatible Parquet. "
-            "Defaults to points.experimental/<key>/points.parquet inside the store."
+            "Defaults to in-place replacement of points/<key>/points.parquet."
         ),
     )
     morton_from_zarr.add_argument(
         "zarr",
         metavar="ZARR",
         help="Path to a SpatialData Zarr store",
+    )
+    morton_from_zarr.add_argument(
+        "--experimental",
+        action="store_true",
+        help="Write to points.experimental/<key>/points.parquet instead of canonical path",
     )
     morton_from_zarr.add_argument(
         "--points-key",
@@ -218,7 +260,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         metavar="PATH",
         help=(
-            "Output Parquet path (default: <zarr>/points.experimental/<key>/points.parquet)"
+            "Output Parquet path (default: in-place on points/<key>/points.parquet, "
+            "or points.experimental/<key>/points.parquet with --experimental)"
         ),
     )
     morton_from_zarr.add_argument(
@@ -316,6 +359,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Parquet compression codec (default: zstd)",
     )
     multiscale.set_defaults(func=_multiscale_points)
+
+    index_permutations = subparsers.add_parser(
+        "write-index-permutations",
+        help="write derivative Zarr with transcript index sort permutations",
+        description=(
+            "Copy a SpatialData Zarr store and add sibling points elements with "
+            "different transcript sort/index layouts plus index-manifest.json."
+        ),
+    )
+    index_permutations.add_argument("source_zarr", metavar="SOURCE_ZARR")
+    index_permutations.add_argument("dest_zarr", metavar="DEST_ZARR")
+    index_permutations.add_argument("--points-key", metavar="KEY")
+    index_permutations.add_argument("--max-rows", type=_positive_int, metavar="N")
+    index_permutations.add_argument(
+        "--conditions",
+        metavar="IDS",
+        help="Comma-separated condition ids (default: all)",
+    )
+    index_permutations.add_argument("--overwrite", action="store_true")
+    index_permutations.add_argument(
+        "--row-group-size",
+        type=_positive_int,
+        default=50_000,
+        metavar="N",
+    )
+    index_permutations.add_argument("--compression", default="zstd")
+    index_permutations.set_defaults(func=_write_index_permutations)
 
     return parser
 

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
@@ -93,7 +93,9 @@ def _morton_points_from_zarr(args: argparse.Namespace) -> None:
             points_key=args.points_key,
             experimental=args.experimental,
             output=args.output,
+            output_points_key=args.output_points_key,
             feature_key=args.feature_key,
+            overwrite=args.overwrite,
             row_group_size=args.row_group_size,
             compression=args.compression,
         )
@@ -183,6 +185,19 @@ def build_parser() -> argparse.ArgumentParser:
             "Output Parquet path (default: in-place on points/<key>/points.parquet, "
             "or points.experimental/<key>/points.parquet with --experimental)"
         ),
+    )
+    morton_from_zarr.add_argument(
+        "--output-points-key",
+        metavar="KEY",
+        help=(
+            "Output Points element name under points/ (for example transcripts_morton). "
+            "Cannot be combined with --output."
+        ),
+    )
+    morton_from_zarr.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting an existing explicit output path or output Points element.",
     )
     morton_from_zarr.add_argument(
         "--feature-key",

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
@@ -2,22 +2,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
-from pathlib import Path
 
-import pandas as pd
-
-from .index_permutations import DEFAULT_CONDITIONS, write_index_permutations
-from .points import (
-    build_spatialdata_multiscale_metadata,
-    write_morton_points_parquet,
-    write_multiscale_points_parquet,
-)
-from .zarr import (
-    list_points_keys,
-    points_parquet_path,
-    read_points_dataframe,
-    read_points_element_attrs,
+from .runners import (
+    run_list_points,
+    run_morton_points,
+    run_morton_points_from_zarr,
+    run_multiscale_points,
+    run_write_index_permutations,
 )
 
 _EPILOG = """\
@@ -39,6 +30,10 @@ examples:
 
   # Write multiscale Parquet with embedded spatialdata_multiscale metadata
   spatialdata-experimental-writer multiscale-points input.parquet output.parquet
+
+  # Interactive workflow TUI
+  uv sync --group tui
+  spatialdata-experimental-writer tui ~/data/xenium.zarr
 """
 
 
@@ -49,161 +44,76 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
-def _read_dataframe(path: str) -> pd.DataFrame:
-    input_path = Path(path)
-    if input_path.is_dir():
-        return read_points_dataframe(input_path)
-    suffix = input_path.suffix.lower()
-    if suffix == ".csv":
-        return pd.read_csv(input_path)
-    if suffix in {".parquet", ".pq"}:
-        return pd.read_parquet(input_path)
-    raise SystemExit(
-        f"Unsupported input: {path}\n"
-        "Expected a .csv file, .parquet file, or a directory of Parquet parts."
-    )
+def _print_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _list_points(args: argparse.Namespace) -> None:
+    _print_json(run_list_points(args.zarr))
 
 
 def _morton_points(args: argparse.Namespace) -> None:
-    df = _read_dataframe(args.input)
-    sorted_df = write_morton_points_parquet(
-        df,
-        args.output,
-        feature_key=args.feature_key,
-        row_group_size=args.row_group_size,
-        compression=args.compression,
-    )
-    print(
-        json.dumps(
-            {
-                "format": "morton-points",
-                "rows": int(len(sorted_df)),
-                "output": str(args.output),
-                "row_group_size": args.row_group_size,
-            },
-            indent=2,
-            sort_keys=True,
+    _print_json(
+        run_morton_points(
+            args.input,
+            args.output,
+            feature_key=args.feature_key,
+            row_group_size=args.row_group_size,
+            compression=args.compression,
         )
     )
 
 
 def _multiscale_points(args: argparse.Namespace) -> None:
-    df = _read_dataframe(args.input)
-    if args.metadata_json:
-        metadata = json.loads(Path(args.metadata_json).read_text())
-    else:
-        metadata = build_spatialdata_multiscale_metadata(df)
-    write_multiscale_points_parquet(
-        df,
-        args.output,
-        metadata=metadata,
-        row_group_size=args.row_group_size,
-        compression=args.compression,
-    )
-    print(
-        json.dumps(
-            {
-                "format": "spatialdata_multiscale_points",
-                "rows": int(len(df)),
-                "output": str(args.output),
-                "row_group_size": args.row_group_size,
-            },
-            indent=2,
-            sort_keys=True,
+    _print_json(
+        run_multiscale_points(
+            args.input,
+            args.output,
+            metadata_json=args.metadata_json,
+            row_group_size=args.row_group_size,
+            compression=args.compression,
         )
     )
-
-
-def _list_points(args: argparse.Namespace) -> None:
-    keys = list_points_keys(args.zarr)
-    if not keys:
-        raise SystemExit(f"No Points elements found under {Path(args.zarr) / 'points'}")
-    print(json.dumps({"zarr": str(args.zarr), "points_keys": keys}, indent=2, sort_keys=True))
 
 
 def _morton_points_from_zarr(args: argparse.Namespace) -> None:
-    zarr_path = Path(args.zarr)
-    keys = list_points_keys(zarr_path)
-    if not keys:
-        raise SystemExit(f"No Points elements found under {zarr_path / 'points'}")
-
-    points_key = args.points_key
-    if points_key is None:
-        if len(keys) == 1:
-            points_key = keys[0]
-        else:
-            raise SystemExit(
-                "Multiple Points elements found; pass --points-key.\n"
-                f"Available keys: {', '.join(keys)}"
-            )
-    if points_key not in keys:
-        raise SystemExit(
-            f"Unknown Points element {points_key!r}.\nAvailable keys: {', '.join(keys)}"
-        )
-
-    attrs = read_points_element_attrs(zarr_path, points_key)
-    feature_key = args.feature_key or attrs.get("feature_key")
-    source_parquet = points_parquet_path(zarr_path, points_key)
-    if args.output:
-        output = Path(args.output)
-    elif args.experimental:
-        output = zarr_path / "points.experimental" / points_key / "points.parquet"
-    else:
-        output = source_parquet
-
-    df = read_points_dataframe(source_parquet)
-    if output.exists():
-        if output.is_dir():
-            shutil.rmtree(output)
-        else:
-            output.unlink()
-    sorted_df = write_morton_points_parquet(
-        df,
-        output,
-        feature_key=feature_key,
-        row_group_size=args.row_group_size,
-        compression=args.compression,
-    )
-    print(
-        json.dumps(
-            {
-                "format": "morton-points",
-                "zarr": str(zarr_path),
-                "points_key": points_key,
-                "source": str(source_parquet),
-                "output": str(output),
-                "in_place": not args.experimental and args.output is None,
-                "feature_key": feature_key,
-                "rows": int(len(sorted_df)),
-                "row_group_size": args.row_group_size,
-            },
-            indent=2,
-            sort_keys=True,
+    _print_json(
+        run_morton_points_from_zarr(
+            args.zarr,
+            points_key=args.points_key,
+            experimental=args.experimental,
+            output=args.output,
+            feature_key=args.feature_key,
+            row_group_size=args.row_group_size,
+            compression=args.compression,
         )
     )
 
 
 def _write_index_permutations(args: argparse.Namespace) -> None:
     condition_ids = args.conditions.split(",") if args.conditions else None
-    selected = None
-    if condition_ids:
-        by_id = {condition.id: condition for condition in DEFAULT_CONDITIONS}
-        missing = [value for value in condition_ids if value not in by_id]
-        if missing:
-            raise SystemExit(f"Unknown conditions: {', '.join(missing)}")
-        selected = tuple(by_id[value] for value in condition_ids)
-
-    manifest = write_index_permutations(
-        args.source_zarr,
-        args.dest_zarr,
-        points_key=args.points_key,
-        max_rows=args.max_rows,
-        conditions=selected,
-        overwrite=args.overwrite,
-        row_group_size=args.row_group_size,
-        compression=args.compression,
+    _print_json(
+        run_write_index_permutations(
+            args.source_zarr,
+            args.dest_zarr,
+            points_key=args.points_key,
+            max_rows=args.max_rows,
+            condition_ids=condition_ids,
+            overwrite=args.overwrite,
+            row_group_size=args.row_group_size,
+            compression=args.compression,
+        )
     )
-    print(json.dumps(manifest, indent=2, sort_keys=True))
+
+
+def _tui(args: argparse.Namespace) -> None:
+    try:
+        from .tui.app import run_tui
+    except ImportError as exc:
+        raise SystemExit(
+            "TUI dependencies are not installed. Run: uv sync --group tui"
+        ) from exc
+    run_tui(initial_zarr=args.zarr)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -386,6 +296,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     index_permutations.add_argument("--compression", default="zstd")
     index_permutations.set_defaults(func=_write_index_permutations)
+
+    tui = subparsers.add_parser(
+        "tui",
+        help="interactive terminal workflow for writer commands",
+        description="Launch a Textual workflow UI for SpatialData experimental writer commands.",
+    )
+    tui.add_argument(
+        "zarr",
+        nargs="?",
+        metavar="ZARR",
+        help="Optional SpatialData Zarr store path (skips initial store picker)",
+    )
+    tui.set_defaults(func=_tui)
 
     return parser
 

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/cli.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from .points import (
+    build_spatialdata_multiscale_metadata,
+    write_morton_points_parquet,
+    write_multiscale_points_parquet,
+)
+from .zarr import (
+    experimental_points_output_path,
+    list_points_keys,
+    points_parquet_path,
+    read_points_dataframe,
+    read_points_element_attrs,
+)
+
+_EPILOG = """\
+examples:
+  # List Points elements in a SpatialData Zarr store
+  spatialdata-experimental-writer list-points ~/data/xenium.zarr
+
+  # Morton-sort transcripts from a Zarr store into points.experimental/
+  spatialdata-experimental-writer morton-points-from-zarr \\
+    ~/data/xenium.zarr --points-key transcripts
+
+  # Morton-sort a CSV or single Parquet file
+  spatialdata-experimental-writer morton-points input.csv output.parquet \\
+    --feature-key feature_name
+
+  # Write multiscale Parquet with embedded spatialdata_multiscale metadata
+  spatialdata-experimental-writer multiscale-points input.parquet output.parquet
+"""
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _read_dataframe(path: str) -> pd.DataFrame:
+    input_path = Path(path)
+    if input_path.is_dir():
+        return read_points_dataframe(input_path)
+    suffix = input_path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(input_path)
+    if suffix in {".parquet", ".pq"}:
+        return pd.read_parquet(input_path)
+    raise SystemExit(
+        f"Unsupported input: {path}\n"
+        "Expected a .csv file, .parquet file, or a directory of Parquet parts."
+    )
+
+
+def _morton_points(args: argparse.Namespace) -> None:
+    df = _read_dataframe(args.input)
+    sorted_df = write_morton_points_parquet(
+        df,
+        args.output,
+        feature_key=args.feature_key,
+        row_group_size=args.row_group_size,
+        compression=args.compression,
+    )
+    print(
+        json.dumps(
+            {
+                "format": "morton-points",
+                "rows": int(len(sorted_df)),
+                "output": str(args.output),
+                "row_group_size": args.row_group_size,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _multiscale_points(args: argparse.Namespace) -> None:
+    df = _read_dataframe(args.input)
+    if args.metadata_json:
+        metadata = json.loads(Path(args.metadata_json).read_text())
+    else:
+        metadata = build_spatialdata_multiscale_metadata(df)
+    write_multiscale_points_parquet(
+        df,
+        args.output,
+        metadata=metadata,
+        row_group_size=args.row_group_size,
+        compression=args.compression,
+    )
+    print(
+        json.dumps(
+            {
+                "format": "spatialdata_multiscale_points",
+                "rows": int(len(df)),
+                "output": str(args.output),
+                "row_group_size": args.row_group_size,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _list_points(args: argparse.Namespace) -> None:
+    keys = list_points_keys(args.zarr)
+    if not keys:
+        raise SystemExit(f"No Points elements found under {Path(args.zarr) / 'points'}")
+    print(json.dumps({"zarr": str(args.zarr), "points_keys": keys}, indent=2, sort_keys=True))
+
+
+def _morton_points_from_zarr(args: argparse.Namespace) -> None:
+    zarr_path = Path(args.zarr)
+    keys = list_points_keys(zarr_path)
+    if not keys:
+        raise SystemExit(f"No Points elements found under {zarr_path / 'points'}")
+
+    points_key = args.points_key
+    if points_key is None:
+        if len(keys) == 1:
+            points_key = keys[0]
+        else:
+            raise SystemExit(
+                "Multiple Points elements found; pass --points-key.\n"
+                f"Available keys: {', '.join(keys)}"
+            )
+    if points_key not in keys:
+        raise SystemExit(
+            f"Unknown Points element {points_key!r}.\nAvailable keys: {', '.join(keys)}"
+        )
+
+    attrs = read_points_element_attrs(zarr_path, points_key)
+    feature_key = args.feature_key or attrs.get("feature_key")
+    source_parquet = points_parquet_path(zarr_path, points_key)
+    output = Path(args.output) if args.output else experimental_points_output_path(
+        zarr_path, points_key
+    )
+
+    df = read_points_dataframe(source_parquet)
+    sorted_df = write_morton_points_parquet(
+        df,
+        output,
+        feature_key=feature_key,
+        row_group_size=args.row_group_size,
+        compression=args.compression,
+    )
+    print(
+        json.dumps(
+            {
+                "format": "morton-points",
+                "zarr": str(zarr_path),
+                "points_key": points_key,
+                "source": str(source_parquet),
+                "output": str(output),
+                "feature_key": feature_key,
+                "rows": int(len(sorted_df)),
+                "row_group_size": args.row_group_size,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Write browser-oriented SpatialData vector optimization artifacts "
+            "(Morton-sorted Points Parquet and multiscale metadata)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_EPILOG,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True, metavar="command")
+
+    list_points = subparsers.add_parser(
+        "list-points",
+        help="list Points element keys in a SpatialData Zarr store",
+        description="List Points element keys under <zarr>/points/.",
+    )
+    list_points.add_argument(
+        "zarr",
+        metavar="ZARR",
+        help="Path to a SpatialData Zarr store (directory containing points/)",
+    )
+    list_points.set_defaults(func=_list_points)
+
+    morton_from_zarr = subparsers.add_parser(
+        "morton-points-from-zarr",
+        help="Morton-sort a Points element from a SpatialData Zarr store",
+        description=(
+            "Read points/<key>/points.parquet from a SpatialData Zarr store, "
+            "add morton_code_2d sentinel rows, and write Vitessce-compatible Parquet. "
+            "Defaults to points.experimental/<key>/points.parquet inside the store."
+        ),
+    )
+    morton_from_zarr.add_argument(
+        "zarr",
+        metavar="ZARR",
+        help="Path to a SpatialData Zarr store",
+    )
+    morton_from_zarr.add_argument(
+        "--points-key",
+        metavar="KEY",
+        help=(
+            "Points element name under points/ (for example transcripts). "
+            "Required when the store has more than one Points element."
+        ),
+    )
+    morton_from_zarr.add_argument(
+        "--output",
+        metavar="PATH",
+        help=(
+            "Output Parquet path (default: <zarr>/points.experimental/<key>/points.parquet)"
+        ),
+    )
+    morton_from_zarr.add_argument(
+        "--feature-key",
+        metavar="COLUMN",
+        help=(
+            "Column used to derive <feature_key>_codes (default: spatialdata_attrs.feature_key "
+            "from the element zarr.json)"
+        ),
+    )
+    morton_from_zarr.add_argument(
+        "--row-group-size",
+        type=_positive_int,
+        default=50_000,
+        metavar="N",
+        help="Target row-group size after sentinel rows (default: 50000)",
+    )
+    morton_from_zarr.add_argument(
+        "--compression",
+        default="zstd",
+        help="Parquet compression codec (default: zstd)",
+    )
+    morton_from_zarr.set_defaults(func=_morton_points_from_zarr)
+
+    morton = subparsers.add_parser(
+        "morton-points",
+        help="Morton-sort points from CSV or Parquet",
+        description=(
+            "Sort x/y points by 2D Morton order, prepend sentinel bbox rows, "
+            "and write Vitessce-compatible Parquet."
+        ),
+    )
+    morton.add_argument(
+        "input",
+        metavar="INPUT",
+        help="Input .csv, .parquet file, or directory of Parquet parts",
+    )
+    morton.add_argument(
+        "output",
+        metavar="OUTPUT",
+        help="Output .parquet file",
+    )
+    morton.add_argument(
+        "--feature-key",
+        metavar="COLUMN",
+        help="Column used to derive <feature_key>_codes for categorical features",
+    )
+    morton.add_argument(
+        "--row-group-size",
+        type=_positive_int,
+        default=50_000,
+        metavar="N",
+        help="Target row-group size after sentinel rows (default: 50000)",
+    )
+    morton.add_argument(
+        "--compression",
+        default="zstd",
+        help="Parquet compression codec (default: zstd)",
+    )
+    morton.set_defaults(func=_morton_points)
+
+    multiscale = subparsers.add_parser(
+        "multiscale-points",
+        help="write multiscale Points Parquet with spatialdata_multiscale metadata",
+        description=(
+            "Write Points Parquet with Padua-style spatialdata_multiscale JSON "
+            "stored in the file schema metadata."
+        ),
+    )
+    multiscale.add_argument(
+        "input",
+        metavar="INPUT",
+        help="Input .csv, .parquet file, or directory of Parquet parts",
+    )
+    multiscale.add_argument(
+        "output",
+        metavar="OUTPUT",
+        help="Output .parquet file",
+    )
+    multiscale.add_argument(
+        "--metadata-json",
+        metavar="PATH",
+        help="Optional spatialdata_multiscale metadata JSON (default: inferred from input)",
+    )
+    multiscale.add_argument(
+        "--row-group-size",
+        type=_positive_int,
+        default=50_000,
+        metavar="N",
+        help="Target row-group size (default: 50000)",
+    )
+    multiscale.add_argument(
+        "--compression",
+        default="zstd",
+        help="Parquet compression codec (default: zstd)",
+    )
+    multiscale.set_defaults(func=_multiscale_points)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/errors.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/errors.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class WriterCommandError(RuntimeError):
+    """Expected user-facing failure from a writer command."""

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/index_permutations.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/index_permutations.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import pandas as pd
+
+from .points import MORTON_CODE_2D_COLUMN, write_morton_points_parquet
+from .zarr import (
+    list_points_keys,
+    points_parquet_path,
+    read_points_dataframe,
+    read_points_element_attrs,
+    register_points_elements_in_consolidated_metadata,
+)
+
+
+@dataclass(frozen=True)
+class IndexCondition:
+    id: str
+    element_suffix: str
+    sort_order: tuple[str, ...] | None
+    tiling_kind: str | None
+
+
+DEFAULT_CONDITIONS: tuple[IndexCondition, ...] = (
+    IndexCondition("canonical", "", None, None),
+    IndexCondition("morton", "_morton", (MORTON_CODE_2D_COLUMN,), "morton-points"),
+    IndexCondition(
+        "morton-then-feature",
+        "_morton_then_feature",
+        (MORTON_CODE_2D_COLUMN, "feature_name_codes"),
+        "morton-points",
+    ),
+    IndexCondition(
+        "feature-then-morton",
+        "_feature_then_morton",
+        ("feature_name_codes", MORTON_CODE_2D_COLUMN),
+        "experimental",
+    ),
+)
+
+
+def _resolve_feature_code_column(feature_key: str | None) -> str:
+    if feature_key:
+        return f"{feature_key}_codes"
+    return "feature_name_codes"
+
+
+def _condition_sort_order(
+    condition: IndexCondition, feature_key: str | None
+) -> list[str] | None:
+    if condition.sort_order is None:
+        return None
+    feature_code_column = _resolve_feature_code_column(feature_key)
+    return [
+        feature_code_column if column == "feature_name_codes" else column
+        for column in condition.sort_order
+    ]
+
+
+def _copy_store_shell(source: Path, dest: Path, *, overwrite: bool) -> None:
+    if dest.exists():
+        if not overwrite:
+            raise FileExistsError(f"Destination already exists: {dest}")
+        shutil.rmtree(dest)
+
+    def ignore_points(directory: str, names: list[str]) -> set[str]:
+        if Path(directory) == source:
+            return {"points"} if "points" in names else set()
+        return set()
+
+    shutil.copytree(source, dest, ignore=ignore_points)
+
+
+def _write_element_zarr_json(source_element_dir: Path, dest_element_dir: Path) -> None:
+    source_json = source_element_dir / "zarr.json"
+    dest_element_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_json, dest_element_dir / "zarr.json")
+
+
+def _copy_canonical_parquet(source_parquet: Path, dest_parquet: Path) -> None:
+    dest_parquet.parent.mkdir(parents=True, exist_ok=True)
+    if source_parquet.is_dir():
+        if dest_parquet.exists():
+            shutil.rmtree(dest_parquet)
+        shutil.copytree(source_parquet, dest_parquet)
+    else:
+        shutil.copy2(source_parquet, dest_parquet)
+
+
+def write_index_permutations(
+    source_zarr: str | Path,
+    dest_zarr: str | Path,
+    *,
+    points_key: str | None = None,
+    max_rows: int | None = None,
+    conditions: Sequence[IndexCondition] | None = None,
+    overwrite: bool = False,
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> dict[str, Any]:
+    source_path = Path(source_zarr)
+    dest_path = Path(dest_zarr)
+    keys = list_points_keys(source_path)
+    if not keys:
+        raise FileNotFoundError(f"No Points elements found under {source_path / 'points'}")
+
+    resolved_key = points_key or (keys[0] if len(keys) == 1 else None)
+    if resolved_key is None:
+        raise ValueError(
+            "Multiple Points elements found; pass points_key. "
+            f"Available keys: {', '.join(keys)}"
+        )
+    if resolved_key not in keys:
+        raise ValueError(f"Unknown points key {resolved_key!r}. Available: {', '.join(keys)}")
+
+    attrs = read_points_element_attrs(source_path, resolved_key)
+    feature_key = attrs.get("feature_key")
+    source_element_dir = source_path / "points" / resolved_key
+    source_parquet = points_parquet_path(source_path, resolved_key)
+
+    _copy_store_shell(source_path, dest_path, overwrite=overwrite)
+
+    df = read_points_dataframe(source_parquet)
+    if max_rows is not None and len(df) > max_rows:
+        df = df.sample(n=max_rows, random_state=0).reset_index(drop=True)
+
+    selected = tuple(conditions or DEFAULT_CONDITIONS)
+    manifest_conditions: list[dict[str, Any]] = []
+
+    for condition in selected:
+        element_key = (
+            resolved_key if condition.id == "canonical" else f"{resolved_key}{condition.element_suffix}"
+        )
+        element_dir = dest_path / "points" / element_key
+        output_parquet = element_dir / "points.parquet"
+        _write_element_zarr_json(source_element_dir, element_dir)
+
+        if condition.sort_order is None:
+            if max_rows is not None:
+                output_parquet.parent.mkdir(parents=True, exist_ok=True)
+                if output_parquet.exists():
+                    if output_parquet.is_dir():
+                        shutil.rmtree(output_parquet)
+                    else:
+                        output_parquet.unlink()
+                df.to_parquet(output_parquet, index=False)
+            else:
+                _copy_canonical_parquet(source_parquet, output_parquet)
+        else:
+            sort_order = _condition_sort_order(condition, feature_key)
+            write_morton_points_parquet(
+                df,
+                output_parquet,
+                feature_key=feature_key,
+                sort_order=sort_order,
+                row_group_size=row_group_size,
+                compression=compression,
+            )
+
+        manifest_conditions.append(
+            {
+                "id": condition.id,
+                "element_path": f"points/{element_key}",
+                "sort_order": list(condition.sort_order) if condition.sort_order else None,
+                "tiling_kind": condition.tiling_kind,
+            }
+        )
+
+    manifest = {
+        "version": "0.1",
+        "store_path": str(dest_path),
+        "source_store": str(source_path),
+        "source_element": f"points/{resolved_key}",
+        "feature_key": feature_key,
+        "n_points": int(len(df)),
+        "conditions": manifest_conditions,
+        "benchmark_scenarios": [
+            {
+                "id": "center-tile",
+                "bounds": {
+                    "minX": float(df["x"].quantile(0.25)),
+                    "maxX": float(df["x"].quantile(0.75)),
+                    "minY": float(df["y"].quantile(0.25)),
+                    "maxY": float(df["y"].quantile(0.75)),
+                },
+            }
+        ],
+    }
+    element_keys = [
+        (
+            resolved_key
+            if condition.id == "canonical"
+            else f"{resolved_key}{condition.element_suffix}"
+        )
+        for condition in selected
+    ]
+    register_points_elements_in_consolidated_metadata(
+        dest_path,
+        element_keys,
+        template_key=resolved_key,
+    )
+
+    manifest_path = dest_path / "index-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+MORTON_CODE_2D_COLUMN = "morton_code_2d"
+MORTON_CODE_EXTREME_VALUE_INDICATOR = np.uint32(0)
+MORTON_CODE_BITS_PER_AXIS = 16
+MORTON_CODE_VALUE_MAX = np.uint32((2**MORTON_CODE_BITS_PER_AXIS) - 1)
+
+
+def _norm_series_to_uint(series: pd.Series, v_min: float, v_max: float) -> pd.Series:
+    if v_max == v_min:
+        return pd.Series(np.zeros(len(series), dtype=np.uint32), index=series.index)
+    normalized = (series.astype("float64") - v_min) / (v_max - v_min)
+    clipped = normalized.clip(0.0, 1.0).fillna(0.0)
+    return (clipped * int(MORTON_CODE_VALUE_MAX)).astype(np.uint32)
+
+
+def _part1by1_16(values: np.ndarray) -> np.ndarray:
+    x = values.astype(np.uint32) & np.uint32(0x0000FFFF)
+    x = (x | np.left_shift(x, 8)) & np.uint32(0x00FF00FF)
+    x = (x | np.left_shift(x, 4)) & np.uint32(0x0F0F0F0F)
+    x = (x | np.left_shift(x, 2)) & np.uint32(0x33333333)
+    x = (x | np.left_shift(x, 1)) & np.uint32(0x55555555)
+    return x
+
+
+def morton_code_2d(x_uint: pd.Series, y_uint: pd.Series) -> np.ndarray:
+    xs = _part1by1_16(x_uint.to_numpy(np.uint32))
+    ys = _part1by1_16(y_uint.to_numpy(np.uint32))
+    return (np.left_shift(ys.astype(np.uint64), 1) | xs.astype(np.uint64)).astype(np.uint32)
+
+
+def _extreme_indices(df: pd.DataFrame) -> list[Any]:
+    extreme_values = [
+        ("x", df["x"].min()),
+        ("x", df["x"].max()),
+        ("y", df["y"].min()),
+        ("y", df["y"].max()),
+    ]
+    result: list[Any] = []
+    for column, value in extreme_values:
+        matches = df.index[df[column] == value]
+        if len(matches) == 0:
+            continue
+        index = matches[0]
+        if index not in result:
+            result.append(index)
+    return result
+
+
+def _append_feature_codes(df: pd.DataFrame, feature_key: str | None) -> pd.DataFrame:
+    if not feature_key or feature_key not in df.columns:
+        return df
+    code_column = f"{feature_key}_codes"
+    if code_column in df.columns:
+        return df
+    out = df.copy()
+    values = out[feature_key]
+    if isinstance(values.dtype, pd.CategoricalDtype):
+        out[code_column] = values.cat.codes.astype("int32")
+    else:
+        categories = pd.Categorical(values)
+        out[code_column] = categories.codes.astype("int32")
+    return out
+
+
+def _move_string_like_columns_right(df: pd.DataFrame) -> pd.DataFrame:
+    string_like: list[str] = []
+    other: list[str] = []
+    for column in df.columns:
+        dtype = df[column].dtype
+        if isinstance(dtype, pd.CategoricalDtype) or pd.api.types.is_string_dtype(dtype):
+            string_like.append(column)
+        else:
+            other.append(column)
+    return df[[*other, *string_like]]
+
+
+def morton_sort_points(df: pd.DataFrame, *, feature_key: str | None = None) -> pd.DataFrame:
+    missing = [column for column in ("x", "y") if column not in df.columns]
+    if missing:
+        raise ValueError("Points dataframe is missing required columns: " + ", ".join(missing))
+
+    out = _append_feature_codes(df.copy(), feature_key)
+    x_min = float(out["x"].min())
+    x_max = float(out["x"].max())
+    y_min = float(out["y"].min())
+    y_max = float(out["y"].max())
+    out["x_uint"] = _norm_series_to_uint(out["x"], x_min, x_max)
+    out["y_uint"] = _norm_series_to_uint(out["y"], y_min, y_max)
+    out[MORTON_CODE_2D_COLUMN] = morton_code_2d(out["x_uint"], out["y_uint"])
+
+    sentinel_indices = _extreme_indices(out)
+    sentinel = out.loc[sentinel_indices].copy().reset_index(drop=True)
+    sentinel[MORTON_CODE_2D_COLUMN] = MORTON_CODE_EXTREME_VALUE_INDICATOR
+
+    rest = out.drop(index=sentinel_indices)
+    sort_columns = [MORTON_CODE_2D_COLUMN]
+    if "z" in rest.columns and rest["z"].nunique(dropna=False) < 100:
+        sort_columns = ["z", MORTON_CODE_2D_COLUMN]
+    rest = rest.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
+
+    combined = pd.concat([sentinel, rest], ignore_index=True)
+    return _move_string_like_columns_right(combined)
+
+
+def _write_arrow_table_in_row_groups(
+    table: pa.Table,
+    output_path: Path,
+    *,
+    row_group_size: int,
+    metadata: dict[str, Any] | None = None,
+    compression: str = "zstd",
+) -> None:
+    if row_group_size <= 0:
+        raise ValueError("row_group_size must be positive")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    schema = table.schema
+    if metadata:
+        merged = dict(schema.metadata or {})
+        merged[b"spatialdata_multiscale"] = json.dumps(metadata).encode()
+        schema = schema.with_metadata(merged)
+
+    writer = pq.ParquetWriter(output_path, schema, compression=compression, write_statistics=True)
+    try:
+        sentinel_count = 0
+        if MORTON_CODE_2D_COLUMN in table.column_names:
+            morton_column = table.column(MORTON_CODE_2D_COLUMN).combine_chunks()
+            for i in range(min(4, table.num_rows)):
+                if morton_column[i].as_py() != 0:
+                    break
+                sentinel_count += 1
+        if sentinel_count:
+            writer.write_table(table.slice(0, sentinel_count), row_group_size=sentinel_count)
+        for start in range(sentinel_count, table.num_rows, row_group_size):
+            chunk = table.slice(start, min(row_group_size, table.num_rows - start))
+            writer.write_table(chunk, row_group_size=chunk.num_rows)
+    finally:
+        writer.close()
+
+
+def write_morton_points_parquet(
+    df: pd.DataFrame,
+    output_path: str | Path,
+    *,
+    feature_key: str | None = None,
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> pd.DataFrame:
+    sorted_df = morton_sort_points(df, feature_key=feature_key)
+    table = pa.Table.from_pandas(sorted_df, preserve_index=False)
+    _write_arrow_table_in_row_groups(
+        table,
+        Path(output_path),
+        row_group_size=row_group_size,
+        compression=compression,
+    )
+    return sorted_df
+
+
+def build_spatialdata_multiscale_metadata(
+    df: pd.DataFrame,
+    *,
+    axes: tuple[str, ...] = ("x", "y", "z"),
+    coordinate_space: str = "raw",
+    version: str = "1.0",
+    levels: list[dict[str, Any]] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    available_axes = [axis for axis in axes if axis in df.columns]
+    if not available_axes:
+        raise ValueError("No requested coordinate axes are present in the dataframe.")
+    return {
+        "version": version,
+        "format": "spatialdata_multiscale_points",
+        "axes": available_axes,
+        "bounding_box": {
+            "min": [float(df[axis].min()) for axis in available_axes],
+            "max": [float(df[axis].max()) for axis in available_axes],
+        },
+        "coordinate_space": coordinate_space,
+        "limit": limit,
+        "levels": levels or [],
+        "n_points_total": int(len(df)),
+    }
+
+
+def write_multiscale_points_parquet(
+    df: pd.DataFrame,
+    output_path: str | Path,
+    *,
+    metadata: dict[str, Any],
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> None:
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    if {"__spatial_index__", "__morton__"}.issubset(df.columns):
+        sort_keys = [("__spatial_index__", "ascending"), ("__morton__", "ascending")]
+        if "gene" in df.columns:
+            sort_keys.insert(0, ("gene", "ascending"))
+        table = table.take(pc.sort_indices(table, sort_keys=sort_keys))
+    _write_arrow_table_in_row_groups(
+        table,
+        Path(output_path),
+        row_group_size=row_group_size,
+        metadata=metadata,
+        compression=compression,
+    )

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
 import pandas as pd
@@ -85,7 +85,12 @@ def _move_string_like_columns_right(df: pd.DataFrame) -> pd.DataFrame:
     return df[[*other, *string_like]]
 
 
-def morton_sort_points(df: pd.DataFrame, *, feature_key: str | None = None) -> pd.DataFrame:
+def morton_sort_points(
+    df: pd.DataFrame,
+    *,
+    feature_key: str | None = None,
+    sort_order: Sequence[str] | None = None,
+) -> pd.DataFrame:
     missing = [column for column in ("x", "y") if column not in df.columns]
     if missing:
         raise ValueError("Points dataframe is missing required columns: " + ", ".join(missing))
@@ -95,18 +100,21 @@ def morton_sort_points(df: pd.DataFrame, *, feature_key: str | None = None) -> p
     x_max = float(out["x"].max())
     y_min = float(out["y"].min())
     y_max = float(out["y"].max())
-    out["x_uint"] = _norm_series_to_uint(out["x"], x_min, x_max)
-    out["y_uint"] = _norm_series_to_uint(out["y"], y_min, y_max)
-    out[MORTON_CODE_2D_COLUMN] = morton_code_2d(out["x_uint"], out["y_uint"])
+    x_uint = _norm_series_to_uint(out["x"], x_min, x_max)
+    y_uint = _norm_series_to_uint(out["y"], y_min, y_max)
+    out[MORTON_CODE_2D_COLUMN] = morton_code_2d(x_uint, y_uint)
 
     sentinel_indices = _extreme_indices(out)
     sentinel = out.loc[sentinel_indices].copy().reset_index(drop=True)
     sentinel[MORTON_CODE_2D_COLUMN] = MORTON_CODE_EXTREME_VALUE_INDICATOR
 
     rest = out.drop(index=sentinel_indices)
-    sort_columns = [MORTON_CODE_2D_COLUMN]
-    if "z" in rest.columns and rest["z"].nunique(dropna=False) < 100:
-        sort_columns = ["z", MORTON_CODE_2D_COLUMN]
+    if sort_order is None:
+        sort_columns: list[str] = [MORTON_CODE_2D_COLUMN]
+        if "z" in rest.columns and rest["z"].nunique(dropna=False) < 100:
+            sort_columns = ["z", MORTON_CODE_2D_COLUMN]
+    else:
+        sort_columns = list(sort_order)
     rest = rest.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
 
     combined = pd.concat([sentinel, rest], ignore_index=True)
@@ -153,11 +161,14 @@ def write_morton_points_parquet(
     output_path: str | Path,
     *,
     feature_key: str | None = None,
+    sort_order: Sequence[str] | None = None,
     row_group_size: int = 50_000,
     compression: str = "zstd",
 ) -> pd.DataFrame:
-    sorted_df = morton_sort_points(df, feature_key=feature_key)
-    table = pa.Table.from_pandas(sorted_df, preserve_index=False)
+    sorted_df = morton_sort_points(df, feature_key=feature_key, sort_order=sort_order)
+    indexed = sorted_df.copy()
+    indexed.index.name = "__index_level_0__"
+    table = pa.Table.from_pandas(indexed, preserve_index=True)
     _write_arrow_table_in_row_groups(
         table,
         Path(output_path),

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
@@ -14,6 +14,7 @@ MORTON_CODE_2D_COLUMN = "morton_code_2d"
 MORTON_CODE_EXTREME_VALUE_INDICATOR = np.uint32(0)
 MORTON_CODE_BITS_PER_AXIS = 16
 MORTON_CODE_VALUE_MAX = np.uint32((2**MORTON_CODE_BITS_PER_AXIS) - 1)
+MORTON_SENTINEL_COUNT_ATTR = "spatialdata_experimental_morton_sentinel_count"
 
 
 def _norm_series_to_uint(series: pd.Series, v_min: float, v_max: float) -> pd.Series:
@@ -118,7 +119,9 @@ def morton_sort_points(
     rest = rest.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
 
     combined = pd.concat([sentinel, rest], ignore_index=True)
-    return _move_string_like_columns_right(combined)
+    combined = _move_string_like_columns_right(combined)
+    combined.attrs[MORTON_SENTINEL_COUNT_ATTR] = len(sentinel)
+    return combined
 
 
 def _write_arrow_table_in_row_groups(
@@ -126,6 +129,7 @@ def _write_arrow_table_in_row_groups(
     output_path: Path,
     *,
     row_group_size: int,
+    sentinel_count: int | None = None,
     metadata: dict[str, Any] | None = None,
     compression: str = "zstd",
 ) -> None:
@@ -140,8 +144,9 @@ def _write_arrow_table_in_row_groups(
 
     writer = pq.ParquetWriter(output_path, schema, compression=compression, write_statistics=True)
     try:
-        sentinel_count = 0
-        if MORTON_CODE_2D_COLUMN in table.column_names:
+        if sentinel_count is None:
+            sentinel_count = 0
+        if sentinel_count == 0 and MORTON_CODE_2D_COLUMN in table.column_names:
             morton_column = table.column(MORTON_CODE_2D_COLUMN).combine_chunks()
             for i in range(min(4, table.num_rows)):
                 if morton_column[i].as_py() != 0:
@@ -169,10 +174,14 @@ def write_morton_points_parquet(
     indexed = sorted_df.copy()
     indexed.index.name = "__index_level_0__"
     table = pa.Table.from_pandas(indexed, preserve_index=True)
+    sentinel_count = sorted_df.attrs.get(MORTON_SENTINEL_COUNT_ATTR)
+    if not isinstance(sentinel_count, int):
+        sentinel_count = None
     _write_arrow_table_in_row_groups(
         table,
         Path(output_path),
         row_group_size=row_group_size,
+        sentinel_count=sentinel_count,
         compression=compression,
     )
     return sorted_df

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/points.py
@@ -40,21 +40,21 @@ def morton_code_2d(x_uint: pd.Series, y_uint: pd.Series) -> np.ndarray:
     return (np.left_shift(ys.astype(np.uint64), 1) | xs.astype(np.uint64)).astype(np.uint32)
 
 
-def _extreme_indices(df: pd.DataFrame) -> list[Any]:
+def _extreme_positions(df: pd.DataFrame) -> list[int]:
     extreme_values = [
         ("x", df["x"].min()),
         ("x", df["x"].max()),
         ("y", df["y"].min()),
         ("y", df["y"].max()),
     ]
-    result: list[Any] = []
+    result: list[int] = []
     for column, value in extreme_values:
-        matches = df.index[df[column] == value]
+        matches = np.flatnonzero((df[column] == value).to_numpy())
         if len(matches) == 0:
             continue
-        index = matches[0]
-        if index not in result:
-            result.append(index)
+        position = int(matches[0])
+        if position not in result:
+            result.append(position)
     return result
 
 
@@ -105,11 +105,13 @@ def morton_sort_points(
     y_uint = _norm_series_to_uint(out["y"], y_min, y_max)
     out[MORTON_CODE_2D_COLUMN] = morton_code_2d(x_uint, y_uint)
 
-    sentinel_indices = _extreme_indices(out)
-    sentinel = out.loc[sentinel_indices].copy().reset_index(drop=True)
+    sentinel_positions = _extreme_positions(out)
+    sentinel = out.iloc[sentinel_positions].copy().reset_index(drop=True)
     sentinel[MORTON_CODE_2D_COLUMN] = MORTON_CODE_EXTREME_VALUE_INDICATOR
 
-    rest = out.drop(index=sentinel_indices)
+    rest_mask = np.ones(len(out), dtype=bool)
+    rest_mask[sentinel_positions] = False
+    rest = out.iloc[rest_mask]
     if sort_order is None:
         sort_columns: list[str] = [MORTON_CODE_2D_COLUMN]
         if "z" in rest.columns and rest["z"].nunique(dropna=False) < 100:

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/runners.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/runners.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Sequence, TypeVar
 
 import pandas as pd
 
+from .errors import WriterCommandError
 from .index_permutations import DEFAULT_CONDITIONS, IndexCondition, write_index_permutations
 from .points import (
     build_spatialdata_multiscale_metadata,
@@ -20,6 +22,17 @@ from .zarr import (
     read_points_element_attrs,
 )
 
+_T = TypeVar("_T")
+
+
+def _as_command_error(action: Callable[[], _T]) -> _T:
+    try:
+        return action()
+    except WriterCommandError:
+        raise
+    except (FileNotFoundError, ValueError) as exc:
+        raise WriterCommandError(str(exc)) from exc
+
 
 def read_input_dataframe(path: str | Path) -> pd.DataFrame:
     input_path = Path(path)
@@ -30,7 +43,7 @@ def read_input_dataframe(path: str | Path) -> pd.DataFrame:
         return pd.read_csv(input_path)
     if suffix in {".parquet", ".pq"}:
         return pd.read_parquet(input_path)
-    raise ValueError(
+    raise WriterCommandError(
         f"Unsupported input: {path}\n"
         "Expected a .csv file, .parquet file, or a directory of Parquet parts."
     )
@@ -39,7 +52,7 @@ def read_input_dataframe(path: str | Path) -> pd.DataFrame:
 def run_list_points(zarr: str | Path) -> dict[str, Any]:
     keys = list_points_keys(zarr)
     if not keys:
-        raise FileNotFoundError(f"No Points elements found under {Path(zarr) / 'points'}")
+        raise WriterCommandError(f"No Points elements found under {Path(zarr) / 'points'}")
     return {"zarr": str(zarr), "points_keys": keys}
 
 
@@ -51,13 +64,15 @@ def run_morton_points(
     row_group_size: int = 50_000,
     compression: str = "zstd",
 ) -> dict[str, Any]:
-    df = read_input_dataframe(input_path)
-    sorted_df = write_morton_points_parquet(
-        df,
-        output_path,
-        feature_key=feature_key,
-        row_group_size=row_group_size,
-        compression=compression,
+    df = _as_command_error(lambda: read_input_dataframe(input_path))
+    sorted_df = _as_command_error(
+        lambda: write_morton_points_parquet(
+            df,
+            output_path,
+            feature_key=feature_key,
+            row_group_size=row_group_size,
+            compression=compression,
+        )
     )
     return {
         "format": "morton-points",
@@ -75,17 +90,19 @@ def run_multiscale_points(
     row_group_size: int = 50_000,
     compression: str = "zstd",
 ) -> dict[str, Any]:
-    df = read_input_dataframe(input_path)
+    df = _as_command_error(lambda: read_input_dataframe(input_path))
     if metadata_json:
-        metadata = json.loads(Path(metadata_json).read_text())
+        metadata = _as_command_error(lambda: json.loads(Path(metadata_json).read_text()))
     else:
-        metadata = build_spatialdata_multiscale_metadata(df)
-    write_multiscale_points_parquet(
-        df,
-        output_path,
-        metadata=metadata,
-        row_group_size=row_group_size,
-        compression=compression,
+        metadata = _as_command_error(lambda: build_spatialdata_multiscale_metadata(df))
+    _as_command_error(
+        lambda: write_multiscale_points_parquet(
+            df,
+            output_path,
+            metadata=metadata,
+            row_group_size=row_group_size,
+            compression=compression,
+        )
     )
     return {
         "format": "spatialdata_multiscale_points",
@@ -126,21 +143,23 @@ def run_morton_points_from_zarr(
     zarr_path = Path(zarr)
     keys = list_points_keys(zarr_path)
     if not keys:
-        raise FileNotFoundError(f"No Points elements found under {zarr_path / 'points'}")
+        raise WriterCommandError(f"No Points elements found under {zarr_path / 'points'}")
 
     resolved_key = points_key
     if resolved_key is None:
         if len(keys) == 1:
             resolved_key = keys[0]
         else:
-            raise ValueError(
+            raise WriterCommandError(
                 "Multiple Points elements found; pass points_key. "
                 f"Available keys: {', '.join(keys)}"
             )
     if resolved_key not in keys:
-        raise ValueError(f"Unknown Points element {resolved_key!r}. Available: {', '.join(keys)}")
+        raise WriterCommandError(
+            f"Unknown Points element {resolved_key!r}. Available: {', '.join(keys)}"
+        )
 
-    attrs = read_points_element_attrs(zarr_path, resolved_key)
+    attrs = _as_command_error(lambda: read_points_element_attrs(zarr_path, resolved_key))
     resolved_feature_key = feature_key or attrs.get("feature_key")
     source_parquet, resolved_output, in_place = resolve_morton_from_zarr_output(
         zarr_path,
@@ -149,18 +168,20 @@ def run_morton_points_from_zarr(
         experimental=experimental,
     )
 
-    df = read_points_dataframe(source_parquet)
+    df = _as_command_error(lambda: read_points_dataframe(source_parquet))
     if resolved_output.exists():
         if resolved_output.is_dir():
             shutil.rmtree(resolved_output)
         else:
             resolved_output.unlink()
-    sorted_df = write_morton_points_parquet(
-        df,
-        resolved_output,
-        feature_key=resolved_feature_key,
-        row_group_size=row_group_size,
-        compression=compression,
+    sorted_df = _as_command_error(
+        lambda: write_morton_points_parquet(
+            df,
+            resolved_output,
+            feature_key=resolved_feature_key,
+            row_group_size=row_group_size,
+            compression=compression,
+        )
     )
     return {
         "format": "morton-points",
@@ -191,16 +212,18 @@ def run_write_index_permutations(
         by_id = {condition.id: condition for condition in DEFAULT_CONDITIONS}
         missing = [value for value in condition_ids if value not in by_id]
         if missing:
-            raise ValueError(f"Unknown conditions: {', '.join(missing)}")
+            raise WriterCommandError(f"Unknown conditions: {', '.join(missing)}")
         selected = tuple(by_id[value] for value in condition_ids)
 
-    return write_index_permutations(
-        source_zarr,
-        dest_zarr,
-        points_key=points_key,
-        max_rows=max_rows,
-        conditions=selected,
-        overwrite=overwrite,
-        row_group_size=row_group_size,
-        compression=compression,
+    return _as_command_error(
+        lambda: write_index_permutations(
+            source_zarr,
+            dest_zarr,
+            points_key=points_key,
+            max_rows=max_rows,
+            conditions=selected,
+            overwrite=overwrite,
+            row_group_size=row_group_size,
+            compression=compression,
+        )
     )

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/runners.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/runners.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence, TypeVar
 
@@ -16,13 +17,26 @@ from .points import (
     write_multiscale_points_parquet,
 )
 from .zarr import (
+    copy_points_element_metadata,
+    experimental_points_output_path,
     list_points_keys,
     points_parquet_path,
     read_points_dataframe,
     read_points_element_attrs,
+    register_points_elements_in_consolidated_metadata,
+    validate_points_key,
 )
 
 _T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class MortonZarrOutput:
+    source_parquet: Path
+    output_parquet: Path
+    in_place: bool
+    output_points_key: str | None
+    collection: str
 
 
 def _as_command_error(action: Callable[[], _T]) -> _T:
@@ -117,17 +131,40 @@ def resolve_morton_from_zarr_output(
     points_key: str,
     *,
     output: str | Path | None = None,
+    output_points_key: str | None = None,
     experimental: bool = False,
-) -> tuple[Path, Path, bool]:
+) -> MortonZarrOutput:
+    if output is not None and output_points_key is not None:
+        raise WriterCommandError("Pass either output or output_points_key, not both.")
     source_parquet = points_parquet_path(zarr_path, points_key)
     if output:
         resolved_output = Path(output)
-    elif experimental:
-        resolved_output = zarr_path / "points.experimental" / points_key / "points.parquet"
-    else:
-        resolved_output = source_parquet
-    in_place = not experimental and output is None
-    return source_parquet, resolved_output, in_place
+        return MortonZarrOutput(
+            source_parquet=source_parquet,
+            output_parquet=resolved_output,
+            in_place=resolved_output == source_parquet,
+            output_points_key=None,
+            collection="path",
+        )
+    if experimental:
+        resolved_output_key = validate_points_key(output_points_key or points_key)
+        resolved_output = experimental_points_output_path(zarr_path, resolved_output_key)
+        return MortonZarrOutput(
+            source_parquet=source_parquet,
+            output_parquet=resolved_output,
+            in_place=False,
+            output_points_key=resolved_output_key,
+            collection="points.experimental",
+        )
+    resolved_output_key = validate_points_key(output_points_key or points_key)
+    resolved_output = points_parquet_path(zarr_path, resolved_output_key)
+    return MortonZarrOutput(
+        source_parquet=source_parquet,
+        output_parquet=resolved_output,
+        in_place=resolved_output == source_parquet,
+        output_points_key=resolved_output_key,
+        collection="points",
+    )
 
 
 def run_morton_points_from_zarr(
@@ -136,7 +173,9 @@ def run_morton_points_from_zarr(
     points_key: str | None = None,
     experimental: bool = False,
     output: str | Path | None = None,
+    output_points_key: str | None = None,
     feature_key: str | None = None,
+    overwrite: bool = False,
     row_group_size: int = 50_000,
     compression: str = "zstd",
 ) -> dict[str, Any]:
@@ -161,35 +200,82 @@ def run_morton_points_from_zarr(
 
     attrs = _as_command_error(lambda: read_points_element_attrs(zarr_path, resolved_key))
     resolved_feature_key = feature_key or attrs.get("feature_key")
-    source_parquet, resolved_output, in_place = resolve_morton_from_zarr_output(
+    output_spec = resolve_morton_from_zarr_output(
         zarr_path,
         resolved_key,
         output=output,
+        output_points_key=output_points_key,
         experimental=experimental,
     )
+    if (
+        output_spec.output_parquet.exists()
+        and not output_spec.in_place
+        and not overwrite
+    ):
+        raise WriterCommandError(
+            f"Output already exists: {output_spec.output_parquet}\n"
+            "Choose another element name/path or enable overwrite."
+        )
+    if (
+        output_spec.collection == "points"
+        and output_spec.output_points_key is not None
+        and output_spec.output_points_key != resolved_key
+    ):
+        target_element_dir = zarr_path / "points" / output_spec.output_points_key
+        if target_element_dir.exists() and not overwrite:
+            raise WriterCommandError(
+                f"Points element already exists: points/{output_spec.output_points_key}\n"
+                "Choose another element name or enable overwrite."
+            )
 
-    df = _as_command_error(lambda: read_points_dataframe(source_parquet))
-    if resolved_output.exists():
-        if resolved_output.is_dir():
-            shutil.rmtree(resolved_output)
+    df = _as_command_error(lambda: read_points_dataframe(output_spec.source_parquet))
+    if output_spec.output_parquet.exists():
+        if output_spec.output_parquet.is_dir():
+            shutil.rmtree(output_spec.output_parquet)
         else:
-            resolved_output.unlink()
+            output_spec.output_parquet.unlink()
+    if (
+        output_spec.collection == "points"
+        and output_spec.output_points_key is not None
+        and output_spec.output_points_key != resolved_key
+    ):
+        _as_command_error(
+            lambda: copy_points_element_metadata(
+                zarr_path,
+                source_key=resolved_key,
+                dest_key=output_spec.output_points_key,
+            )
+        )
     sorted_df = _as_command_error(
         lambda: write_morton_points_parquet(
             df,
-            resolved_output,
+            output_spec.output_parquet,
             feature_key=resolved_feature_key,
             row_group_size=row_group_size,
             compression=compression,
         )
     )
+    if (
+        output_spec.collection == "points"
+        and output_spec.output_points_key is not None
+        and output_spec.output_points_key != resolved_key
+    ):
+        _as_command_error(
+            lambda: register_points_elements_in_consolidated_metadata(
+                zarr_path,
+                [resolved_key, output_spec.output_points_key],
+                template_key=resolved_key,
+            )
+        )
     return {
         "format": "morton-points",
         "zarr": str(zarr_path),
         "points_key": resolved_key,
-        "source": str(source_parquet),
-        "output": str(resolved_output),
-        "in_place": in_place,
+        "output_points_key": output_spec.output_points_key,
+        "output_collection": output_spec.collection,
+        "source": str(output_spec.source_parquet),
+        "output": str(output_spec.output_parquet),
+        "in_place": output_spec.in_place,
         "feature_key": resolved_feature_key,
         "rows": int(len(sorted_df)),
         "row_group_size": row_group_size,

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/runners.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/runners.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Sequence
+
+import pandas as pd
+
+from .index_permutations import DEFAULT_CONDITIONS, IndexCondition, write_index_permutations
+from .points import (
+    build_spatialdata_multiscale_metadata,
+    write_morton_points_parquet,
+    write_multiscale_points_parquet,
+)
+from .zarr import (
+    list_points_keys,
+    points_parquet_path,
+    read_points_dataframe,
+    read_points_element_attrs,
+)
+
+
+def read_input_dataframe(path: str | Path) -> pd.DataFrame:
+    input_path = Path(path)
+    if input_path.is_dir():
+        return read_points_dataframe(input_path)
+    suffix = input_path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(input_path)
+    if suffix in {".parquet", ".pq"}:
+        return pd.read_parquet(input_path)
+    raise ValueError(
+        f"Unsupported input: {path}\n"
+        "Expected a .csv file, .parquet file, or a directory of Parquet parts."
+    )
+
+
+def run_list_points(zarr: str | Path) -> dict[str, Any]:
+    keys = list_points_keys(zarr)
+    if not keys:
+        raise FileNotFoundError(f"No Points elements found under {Path(zarr) / 'points'}")
+    return {"zarr": str(zarr), "points_keys": keys}
+
+
+def run_morton_points(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    feature_key: str | None = None,
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> dict[str, Any]:
+    df = read_input_dataframe(input_path)
+    sorted_df = write_morton_points_parquet(
+        df,
+        output_path,
+        feature_key=feature_key,
+        row_group_size=row_group_size,
+        compression=compression,
+    )
+    return {
+        "format": "morton-points",
+        "rows": int(len(sorted_df)),
+        "output": str(output_path),
+        "row_group_size": row_group_size,
+    }
+
+
+def run_multiscale_points(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    metadata_json: str | Path | None = None,
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> dict[str, Any]:
+    df = read_input_dataframe(input_path)
+    if metadata_json:
+        metadata = json.loads(Path(metadata_json).read_text())
+    else:
+        metadata = build_spatialdata_multiscale_metadata(df)
+    write_multiscale_points_parquet(
+        df,
+        output_path,
+        metadata=metadata,
+        row_group_size=row_group_size,
+        compression=compression,
+    )
+    return {
+        "format": "spatialdata_multiscale_points",
+        "rows": int(len(df)),
+        "output": str(output_path),
+        "row_group_size": row_group_size,
+    }
+
+
+def resolve_morton_from_zarr_output(
+    zarr_path: Path,
+    points_key: str,
+    *,
+    output: str | Path | None = None,
+    experimental: bool = False,
+) -> tuple[Path, Path, bool]:
+    source_parquet = points_parquet_path(zarr_path, points_key)
+    if output:
+        resolved_output = Path(output)
+    elif experimental:
+        resolved_output = zarr_path / "points.experimental" / points_key / "points.parquet"
+    else:
+        resolved_output = source_parquet
+    in_place = not experimental and output is None
+    return source_parquet, resolved_output, in_place
+
+
+def run_morton_points_from_zarr(
+    zarr: str | Path,
+    *,
+    points_key: str | None = None,
+    experimental: bool = False,
+    output: str | Path | None = None,
+    feature_key: str | None = None,
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> dict[str, Any]:
+    zarr_path = Path(zarr)
+    keys = list_points_keys(zarr_path)
+    if not keys:
+        raise FileNotFoundError(f"No Points elements found under {zarr_path / 'points'}")
+
+    resolved_key = points_key
+    if resolved_key is None:
+        if len(keys) == 1:
+            resolved_key = keys[0]
+        else:
+            raise ValueError(
+                "Multiple Points elements found; pass points_key. "
+                f"Available keys: {', '.join(keys)}"
+            )
+    if resolved_key not in keys:
+        raise ValueError(f"Unknown Points element {resolved_key!r}. Available: {', '.join(keys)}")
+
+    attrs = read_points_element_attrs(zarr_path, resolved_key)
+    resolved_feature_key = feature_key or attrs.get("feature_key")
+    source_parquet, resolved_output, in_place = resolve_morton_from_zarr_output(
+        zarr_path,
+        resolved_key,
+        output=output,
+        experimental=experimental,
+    )
+
+    df = read_points_dataframe(source_parquet)
+    if resolved_output.exists():
+        if resolved_output.is_dir():
+            shutil.rmtree(resolved_output)
+        else:
+            resolved_output.unlink()
+    sorted_df = write_morton_points_parquet(
+        df,
+        resolved_output,
+        feature_key=resolved_feature_key,
+        row_group_size=row_group_size,
+        compression=compression,
+    )
+    return {
+        "format": "morton-points",
+        "zarr": str(zarr_path),
+        "points_key": resolved_key,
+        "source": str(source_parquet),
+        "output": str(resolved_output),
+        "in_place": in_place,
+        "feature_key": resolved_feature_key,
+        "rows": int(len(sorted_df)),
+        "row_group_size": row_group_size,
+    }
+
+
+def run_write_index_permutations(
+    source_zarr: str | Path,
+    dest_zarr: str | Path,
+    *,
+    points_key: str | None = None,
+    max_rows: int | None = None,
+    condition_ids: Sequence[str] | None = None,
+    overwrite: bool = False,
+    row_group_size: int = 50_000,
+    compression: str = "zstd",
+) -> dict[str, Any]:
+    selected: tuple[IndexCondition, ...] | None = None
+    if condition_ids:
+        by_id = {condition.id: condition for condition in DEFAULT_CONDITIONS}
+        missing = [value for value in condition_ids if value not in by_id]
+        if missing:
+            raise ValueError(f"Unknown conditions: {', '.join(missing)}")
+        selected = tuple(by_id[value] for value in condition_ids)
+
+    return write_index_permutations(
+        source_zarr,
+        dest_zarr,
+        points_key=points_key,
+        max_rows=max_rows,
+        conditions=selected,
+        overwrite=overwrite,
+        row_group_size=row_group_size,
+        compression=compression,
+    )

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/app.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/app.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.app import App
+
+from .models import WriterContext
+
+if TYPE_CHECKING:
+    from .screens import HomeScreen
+
+
+class WriterApp(App[None]):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+
+    .screen-title {
+        width: 100%;
+        content-align: center middle;
+        padding: 1 0;
+        text-style: bold;
+    }
+
+    .section-label {
+        padding-top: 1;
+        text-style: bold;
+    }
+
+    #command-list {
+        width: 70;
+        height: auto;
+        max-height: 16;
+        border: solid $accent;
+        margin: 1 0;
+    }
+
+    #points-key-list {
+        width: 70;
+        height: auto;
+        max-height: 12;
+        border: solid $accent;
+        margin: 1 0;
+    }
+
+    VerticalScroll {
+        width: 80;
+        height: 1fr;
+        border: solid $primary;
+        padding: 1 2;
+    }
+
+    Input {
+        margin-bottom: 1;
+    }
+
+    #run-log {
+        width: 90;
+        height: 1fr;
+        border: solid $accent;
+        margin: 1 0;
+    }
+
+    #verify-table {
+        width: 100%;
+        height: auto;
+        max-height: 14;
+        margin: 1 0;
+    }
+
+    #confirm-message {
+        width: 80;
+        padding: 1 2;
+        border: solid $warning;
+        margin: 1 0;
+    }
+
+    Horizontal {
+        width: auto;
+        height: auto;
+        align: center middle;
+    }
+
+    Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def __init__(self, *, initial_zarr: str | None = None) -> None:
+        super().__init__()
+        self.context = WriterContext(zarr_path=initial_zarr)
+        self.home_screen: HomeScreen | None = None
+
+    def on_mount(self) -> None:
+        from .screens import HomeScreen
+
+        self.home_screen = HomeScreen()
+        self.install_screen(self.home_screen, "home")
+        self.push_screen("home")
+
+    def go_home(self) -> None:
+        if self.home_screen is None:
+            return
+        self.home_screen.pop_until_active()
+
+
+def run_tui(*, initial_zarr: str | None = None) -> None:
+    app = WriterApp(initial_zarr=initial_zarr)
+    app.run()

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/app.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/app.py
@@ -104,7 +104,7 @@ class WriterApp(App[None]):
     def go_home(self) -> None:
         if self.home_screen is None:
             return
-        self.home_screen.pop_until_active()
+        self.switch_screen("home")
 
 
 def run_tui(*, initial_zarr: str | None = None) -> None:

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/models.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/models.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+
+class CommandId(str, Enum):
+    LIST_POINTS = "list-points"
+    MORTON_FROM_ZARR = "morton-points-from-zarr"
+    MORTON_POINTS = "morton-points"
+    MULTISCALE_POINTS = "multiscale-points"
+    INDEX_PERMUTATIONS = "write-index-permutations"
+
+
+VerifyKind = Literal["none", "morton", "multiscale", "manifest"]
+
+
+@dataclass
+class TaskSpec:
+    command: CommandId
+    title: str
+    runner: Callable[[], dict[str, Any]]
+    verify_kind: VerifyKind = "none"
+    verify_paths: list[Path] = field(default_factory=list)
+    requires_confirm: bool = False
+    confirm_message: str = ""
+    log_lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WriterContext:
+    zarr_path: str | None = None
+    points_key: str | None = None

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from textual import getters, work
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.events import ScreenResume
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
@@ -59,8 +60,46 @@ class WriterScreen(Screen[None]):
     app = getters.app(WriterApp)
 
 
+class InputFormScreen(WriterScreen):
+    """Form screen with Enter-to-advance/submit and Escape-to-back."""
+
+    INPUT_ORDER: tuple[str, ...] = ()
+    PRIMARY_BUTTON_ID: str = "run"
+
+    BINDINGS = [
+        Binding("escape", "go_back", "Back"),
+    ]
+
+    def on_mount(self) -> None:
+        if self.INPUT_ORDER:
+            self.query_one(f"#{self.INPUT_ORDER[0]}", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        input_id = event.input.id
+        if input_id is None:
+            self._press_primary()
+            return
+        if not self.INPUT_ORDER or input_id not in self.INPUT_ORDER:
+            self._press_primary()
+            return
+        if input_id == self.INPUT_ORDER[-1]:
+            self._press_primary()
+            return
+        next_index = self.INPUT_ORDER.index(input_id) + 1
+        self.query_one(f"#{self.INPUT_ORDER[next_index]}", Input).focus()
+
+    def action_go_back(self) -> None:
+        self.app.pop_screen()
+
+    def _press_primary(self) -> None:
+        self.query_one(f"#{self.PRIMARY_BUTTON_ID}", Button).press()
+
+
 class HomeScreen(WriterScreen):
     BINDINGS = [("q", "quit", "Quit")]
+
+    def on_mount(self) -> None:
+        self.query_one("#command-list", ListView).focus()
 
     def on_screen_resume(self, event: ScreenResume) -> None:
         self.refresh()
@@ -126,7 +165,10 @@ class HomeScreen(WriterScreen):
         )
 
 
-class ZarrPathScreen(WriterScreen):
+class ZarrPathScreen(InputFormScreen):
+    INPUT_ORDER = ("zarr-path",)
+    PRIMARY_BUTTON_ID = "continue"
+
     def __init__(self, command: CommandId) -> None:
         super().__init__()
         self.command = command
@@ -142,8 +184,11 @@ class ZarrPathScreen(WriterScreen):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
-            self.app.pop_screen()
+            self.action_go_back()
             return
+        self._continue()
+
+    def _continue(self) -> None:
         path = self.query_one("#zarr-path", Input).value.strip()
         if not path:
             self.notify("Enter a Zarr store path.", severity="error")
@@ -175,6 +220,10 @@ class ZarrPathScreen(WriterScreen):
 
 
 class PointsKeyScreen(WriterScreen):
+    BINDINGS = [
+        Binding("escape", "go_back", "Back"),
+    ]
+
     def __init__(self, command: CommandId) -> None:
         super().__init__()
         self.command = command
@@ -202,11 +251,24 @@ class PointsKeyScreen(WriterScreen):
         if len(keys) == 1:
             self.app.context.points_key = keys[0]
             list_view.index = 0
+        list_view.focus()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        item_id = event.item.id or ""
+        if item_id.startswith("key-"):
+            self.app.context.points_key = item_id.removeprefix("key-")
+        self._continue()
+
+    def action_go_back(self) -> None:
+        self.app.pop_screen()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
-            self.app.pop_screen()
+            self.action_go_back()
             return
+        self._continue()
+
+    def _continue(self) -> None:
         list_view = self.query_one("#points-key-list", ListView)
         if list_view.index is None:
             self.notify("Select a Points element.", severity="error")
@@ -223,7 +285,9 @@ class PointsKeyScreen(WriterScreen):
             self.app.push_screen(IndexPermutationsScreen(from_zarr_context=True))
 
 
-class MortonFromZarrScreen(WriterScreen):
+class MortonFromZarrScreen(InputFormScreen):
+    INPUT_ORDER = ("feature-key", "row-group-size", "compression", "output-path")
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static("Morton-sort Points from Zarr", classes="screen-title")
@@ -254,11 +318,15 @@ class MortonFromZarrScreen(WriterScreen):
                 self.query_one("#feature-key", Input).value = str(feature_key)
         except OSError:
             pass
+        super().on_mount()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
-            self.app.pop_screen()
+            self.action_go_back()
             return
+        self._submit()
+
+    def _submit(self) -> None:
         zarr = self.app.context.zarr_path
         key = self.app.context.points_key
         if not zarr or not key:
@@ -315,7 +383,15 @@ class MortonFromZarrScreen(WriterScreen):
             self.app.push_screen(RunScreen(task_spec))
 
 
-class MortonFileScreen(WriterScreen):
+class MortonFileScreen(InputFormScreen):
+    INPUT_ORDER = (
+        "input-path",
+        "output-path",
+        "feature-key",
+        "row-group-size",
+        "compression",
+    )
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static("Morton-sort CSV/Parquet", classes="screen-title")
@@ -337,8 +413,11 @@ class MortonFileScreen(WriterScreen):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
-            self.app.pop_screen()
+            self.action_go_back()
             return
+        self._submit()
+
+    def _submit(self) -> None:
         input_path = self.query_one("#input-path", Input).value.strip()
         output_path = self.query_one("#output-path", Input).value.strip()
         if not input_path or not output_path:
@@ -376,7 +455,15 @@ class MortonFileScreen(WriterScreen):
         )
 
 
-class MultiscaleScreen(WriterScreen):
+class MultiscaleScreen(InputFormScreen):
+    INPUT_ORDER = (
+        "input-path",
+        "output-path",
+        "metadata-json",
+        "row-group-size",
+        "compression",
+    )
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static("Multiscale Points Parquet", classes="screen-title")
@@ -398,8 +485,11 @@ class MultiscaleScreen(WriterScreen):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
-            self.app.pop_screen()
+            self.action_go_back()
             return
+        self._submit()
+
+    def _submit(self) -> None:
         input_path = self.query_one("#input-path", Input).value.strip()
         output_path = self.query_one("#output-path", Input).value.strip()
         if not input_path or not output_path:
@@ -437,7 +527,16 @@ class MultiscaleScreen(WriterScreen):
         )
 
 
-class IndexPermutationsScreen(WriterScreen):
+class IndexPermutationsScreen(InputFormScreen):
+    INPUT_ORDER = (
+        "source-zarr",
+        "dest-zarr",
+        "points-key",
+        "max-rows",
+        "row-group-size",
+        "compression",
+    )
+
     def __init__(self, *, from_zarr_context: bool = False) -> None:
         super().__init__()
         self.from_zarr_context = from_zarr_context
@@ -473,11 +572,15 @@ class IndexPermutationsScreen(WriterScreen):
             self.query_one("#source-zarr", Input).value = self.app.context.zarr_path
         if self.from_zarr_context and self.app.context.points_key:
             self.query_one("#points-key", Input).value = self.app.context.points_key
+        super().on_mount()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
-            self.app.pop_screen()
+            self.action_go_back()
             return
+        self._submit()
+
+    def _submit(self) -> None:
         source = self.query_one("#source-zarr", Input).value.strip()
         dest = self.query_one("#dest-zarr", Input).value.strip()
         if not source or not dest:
@@ -538,6 +641,11 @@ class IndexPermutationsScreen(WriterScreen):
 
 
 class ConfirmScreen(WriterScreen):
+    BINDINGS = [
+        Binding("enter", "confirm", "Confirm overwrite"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
     def __init__(self, task_spec: TaskSpec) -> None:
         super().__init__()
         self.task_spec = task_spec
@@ -550,6 +658,15 @@ class ConfirmScreen(WriterScreen):
             yield Button("Confirm overwrite", variant="error", id="confirm")
             yield Button("Cancel", id="cancel")
         yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#confirm", Button).focus()
+
+    def action_confirm(self) -> None:
+        self.query_one("#confirm", Button).press()
+
+    def action_cancel(self) -> None:
+        self.query_one("#cancel", Button).press()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":
@@ -624,6 +741,11 @@ class RunScreen(WriterScreen):
 
 
 class VerifyReportScreen(WriterScreen):
+    BINDINGS = [
+        Binding("enter", "go_home", "Home"),
+        Binding("escape", "go_home", "Home"),
+    ]
+
     def __init__(
         self,
         *,
@@ -672,6 +794,12 @@ class VerifyReportScreen(WriterScreen):
             yield Button("Home", variant="primary", id="home")
             yield Button("Quit", id="quit")
         yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#home", Button).focus()
+
+    def action_go_home(self) -> None:
+        self.app.go_home()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "home":

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
@@ -25,6 +25,7 @@ from textual.widgets import (
     Static,
 )
 
+from ..errors import WriterCommandError
 from ..index_permutations import DEFAULT_CONDITIONS
 from ..runners import (
     resolve_morton_from_zarr_output,
@@ -649,6 +650,7 @@ class ConfirmScreen(WriterScreen):
     def __init__(self, task_spec: TaskSpec) -> None:
         super().__init__()
         self.task_spec = task_spec
+        self._handled = False
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -663,17 +665,30 @@ class ConfirmScreen(WriterScreen):
         self.query_one("#confirm", Button).focus()
 
     def action_confirm(self) -> None:
-        self.query_one("#confirm", Button).press()
+        self._confirm()
 
     def action_cancel(self) -> None:
-        self.query_one("#cancel", Button).press()
+        self._cancel()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
         if event.button.id == "cancel":
-            self.app.pop_screen()
+            self._cancel()
             return
+        self._confirm()
+
+    def _confirm(self) -> None:
+        if self._handled:
+            return
+        self._handled = True
         self.app.pop_screen()
         self.app.push_screen(RunScreen(self.task_spec))
+
+    def _cancel(self) -> None:
+        if self._handled:
+            return
+        self._handled = True
+        self.app.pop_screen()
 
 
 class RunScreen(WriterScreen):
@@ -705,6 +720,9 @@ class RunScreen(WriterScreen):
                 log.write, json.dumps(result, indent=2, sort_keys=True)
             )
             checks = self._verify()
+        except WriterCommandError as exc:
+            error = str(exc)
+            self.app.call_from_thread(log.write, error)
         except Exception as exc:
             error = "".join(traceback.format_exception_only(exc)).strip()
             self.app.call_from_thread(log.write, error)
@@ -759,6 +777,7 @@ class VerifyReportScreen(WriterScreen):
         self.result = result
         self.checks = checks
         self.error = error
+        self._handled = False
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -799,10 +818,23 @@ class VerifyReportScreen(WriterScreen):
         self.query_one("#home", Button).focus()
 
     def action_go_home(self) -> None:
-        self.app.go_home()
+        self._go_home()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
         if event.button.id == "home":
-            self.app.go_home()
+            self._go_home()
             return
+        self._exit()
+
+    def _go_home(self) -> None:
+        if self._handled:
+            return
+        self._handled = True
+        self.app.go_home()
+
+    def _exit(self) -> None:
+        if self._handled:
+            return
+        self._handled = True
         self.app.exit()

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
@@ -1,0 +1,680 @@
+from __future__ import annotations
+
+import json
+import traceback
+from pathlib import Path
+from typing import Any
+
+from textual import getters, work
+from textual.app import ComposeResult
+from textual.events import ScreenResume
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    Checkbox,
+    DataTable,
+    Footer,
+    Header,
+    Input,
+    Label,
+    ListItem,
+    ListView,
+    RichLog,
+    Static,
+)
+
+from ..index_permutations import DEFAULT_CONDITIONS
+from ..runners import (
+    resolve_morton_from_zarr_output,
+    run_list_points,
+    run_morton_points,
+    run_morton_points_from_zarr,
+    run_multiscale_points,
+    run_write_index_permutations,
+)
+from ..verify import (
+    VerifyCheck,
+    all_passed,
+    verify_index_permutations_manifest,
+    verify_morton_parquet,
+    verify_multiscale_parquet,
+)
+from ..zarr import list_points_keys, read_points_element_attrs
+from .app import WriterApp
+from .models import CommandId, TaskSpec
+
+
+def _positive_int(value: str, default: int) -> int:
+    stripped = value.strip()
+    if not stripped:
+        return default
+    parsed = int(stripped)
+    if parsed <= 0:
+        raise ValueError("value must be positive")
+    return parsed
+
+
+class WriterScreen(Screen[None]):
+    app = getters.app(WriterApp)
+
+
+class HomeScreen(WriterScreen):
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def on_screen_resume(self, event: ScreenResume) -> None:
+        self.refresh()
+        self.query_one("#command-list", ListView).focus()
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(
+            "SpatialData experimental writer — pick a command.",
+            id="home-title",
+        )
+        yield ListView(
+            ListItem(Label("List Points elements in a Zarr store"), id="cmd-list-points"),
+            ListItem(Label("Morton-sort Points from Zarr"), id="cmd-morton-from-zarr"),
+            ListItem(Label("Morton-sort CSV/Parquet file"), id="cmd-morton-points"),
+            ListItem(Label("Write multiscale Points Parquet"), id="cmd-multiscale-points"),
+            ListItem(
+                Label("Write index permutations derivative store"),
+                id="cmd-index-permutations",
+            ),
+            id="command-list",
+        )
+        yield Footer()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        item_id = event.item.id or ""
+        if item_id == "cmd-list-points":
+            self._start_zarr_command(CommandId.LIST_POINTS)
+        elif item_id == "cmd-morton-from-zarr":
+            self._start_zarr_command(CommandId.MORTON_FROM_ZARR)
+        elif item_id == "cmd-morton-points":
+            self.app.push_screen(MortonFileScreen())
+        elif item_id == "cmd-multiscale-points":
+            self.app.push_screen(MultiscaleScreen())
+        elif item_id == "cmd-index-permutations":
+            self.app.push_screen(IndexPermutationsScreen())
+
+    def _start_zarr_command(self, command: CommandId) -> None:
+        if command == CommandId.LIST_POINTS:
+            if self.app.context.zarr_path:
+                self._run_list_points(self.app.context.zarr_path)
+            else:
+                self.app.push_screen(ZarrPathScreen(command))
+            return
+        if self.app.context.zarr_path:
+            self.app.push_screen(PointsKeyScreen(command))
+        else:
+            self.app.push_screen(ZarrPathScreen(command))
+
+    def _run_list_points(self, zarr: str) -> None:
+        def runner() -> dict[str, Any]:
+            return run_list_points(zarr)
+
+        self.app.push_screen(
+            RunScreen(
+                TaskSpec(
+                    command=CommandId.LIST_POINTS,
+                    title="List Points",
+                    runner=runner,
+                    verify_kind="none",
+                )
+            )
+        )
+
+
+class ZarrPathScreen(WriterScreen):
+    def __init__(self, command: CommandId) -> None:
+        super().__init__()
+        self.command = command
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("SpatialData Zarr store path", classes="screen-title")
+        yield Input(placeholder="/path/to/store.zarr", id="zarr-path")
+        with Horizontal():
+            yield Button("Continue", variant="primary", id="continue")
+            yield Button("Back", id="back")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()
+            return
+        path = self.query_one("#zarr-path", Input).value.strip()
+        if not path:
+            self.notify("Enter a Zarr store path.", severity="error")
+            return
+        resolved = Path(path)
+        if not resolved.is_dir():
+            self.notify(f"Not a directory: {path}", severity="error")
+            return
+        self.app.context.zarr_path = str(resolved)
+        if self.command == CommandId.LIST_POINTS:
+            self._run_list_points(path)
+            return
+        self.app.push_screen(PointsKeyScreen(self.command))
+
+    def _run_list_points(self, zarr: str) -> None:
+        def runner() -> dict[str, Any]:
+            return run_list_points(zarr)
+
+        self.app.push_screen(
+            RunScreen(
+                TaskSpec(
+                    command=CommandId.LIST_POINTS,
+                    title="List Points",
+                    runner=runner,
+                    verify_kind="none",
+                )
+            )
+        )
+
+
+class PointsKeyScreen(WriterScreen):
+    def __init__(self, command: CommandId) -> None:
+        super().__init__()
+        self.command = command
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Select Points element", classes="screen-title")
+        yield ListView(id="points-key-list")
+        with Horizontal():
+            yield Button("Continue", variant="primary", id="continue")
+            yield Button("Back", id="back")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        zarr = self.app.context.zarr_path
+        list_view = self.query_one("#points-key-list", ListView)
+        if not zarr:
+            return
+        keys = list_points_keys(zarr)
+        if not keys:
+            list_view.mount(Static("No Points elements found."))
+            return
+        for key in keys:
+            list_view.mount(ListItem(Label(key), id=f"key-{key}"))
+        if len(keys) == 1:
+            self.app.context.points_key = keys[0]
+            list_view.index = 0
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()
+            return
+        list_view = self.query_one("#points-key-list", ListView)
+        if list_view.index is None:
+            self.notify("Select a Points element.", severity="error")
+            return
+        item = list_view.children[list_view.index]
+        item_id = item.id or ""
+        if not item_id.startswith("key-"):
+            self.notify("Select a Points element.", severity="error")
+            return
+        self.app.context.points_key = item_id.removeprefix("key-")
+        if self.command == CommandId.MORTON_FROM_ZARR:
+            self.app.push_screen(MortonFromZarrScreen())
+        elif self.command == CommandId.INDEX_PERMUTATIONS:
+            self.app.push_screen(IndexPermutationsScreen(from_zarr_context=True))
+
+
+class MortonFromZarrScreen(WriterScreen):
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Morton-sort Points from Zarr", classes="screen-title")
+        with VerticalScroll():
+            yield Label("Feature key column (optional)")
+            yield Input(placeholder="feature_name", id="feature-key")
+            yield Label("Row group size")
+            yield Input(value="50000", id="row-group-size")
+            yield Label("Compression")
+            yield Input(value="zstd", id="compression")
+            yield Label("Custom output path (optional)")
+            yield Input(placeholder="leave empty for default", id="output-path")
+            yield Checkbox("Write to points.experimental/", id="experimental")
+        with Horizontal():
+            yield Button("Run", variant="primary", id="run")
+            yield Button("Back", id="back")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        zarr = self.app.context.zarr_path
+        key = self.app.context.points_key
+        if not zarr or not key:
+            return
+        try:
+            attrs = read_points_element_attrs(zarr, key)
+            feature_key = attrs.get("feature_key")
+            if feature_key:
+                self.query_one("#feature-key", Input).value = str(feature_key)
+        except OSError:
+            pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()
+            return
+        zarr = self.app.context.zarr_path
+        key = self.app.context.points_key
+        if not zarr or not key:
+            self.notify("Missing Zarr context.", severity="error")
+            return
+
+        feature_key = self.query_one("#feature-key", Input).value.strip() or None
+        output_text = self.query_one("#output-path", Input).value.strip() or None
+        experimental = self.query_one("#experimental", Checkbox).value
+        try:
+            row_group_size = _positive_int(
+                self.query_one("#row-group-size", Input).value, 50_000
+            )
+        except ValueError as exc:
+            self.notify(str(exc), severity="error")
+            return
+        compression = self.query_one("#compression", Input).value.strip() or "zstd"
+
+        _, resolved_output, in_place = resolve_morton_from_zarr_output(
+            Path(zarr),
+            key,
+            output=output_text,
+            experimental=experimental,
+        )
+
+        def runner() -> dict[str, Any]:
+            return run_morton_points_from_zarr(
+                zarr,
+                points_key=key,
+                experimental=experimental,
+                output=output_text,
+                feature_key=feature_key,
+                row_group_size=row_group_size,
+                compression=compression,
+            )
+
+        task = TaskSpec(
+            command=CommandId.MORTON_FROM_ZARR,
+            title="Morton-sort from Zarr",
+            runner=runner,
+            verify_kind="morton",
+            verify_paths=[resolved_output],
+            requires_confirm=in_place,
+            confirm_message=(
+                f"In-place overwrite of canonical Parquet:\n{resolved_output}\n\nProceed?"
+            ),
+        )
+        self._launch_task(task)
+
+    def _launch_task(self, task_spec: TaskSpec) -> None:
+        if task_spec.requires_confirm:
+            self.app.push_screen(ConfirmScreen(task_spec))
+        else:
+            self.app.push_screen(RunScreen(task_spec))
+
+
+class MortonFileScreen(WriterScreen):
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Morton-sort CSV/Parquet", classes="screen-title")
+        with VerticalScroll():
+            yield Label("Input path")
+            yield Input(placeholder="input.csv or input.parquet", id="input-path")
+            yield Label("Output path")
+            yield Input(placeholder="output.parquet", id="output-path")
+            yield Label("Feature key column (optional)")
+            yield Input(placeholder="feature_name", id="feature-key")
+            yield Label("Row group size")
+            yield Input(value="50000", id="row-group-size")
+            yield Label("Compression")
+            yield Input(value="zstd", id="compression")
+        with Horizontal():
+            yield Button("Run", variant="primary", id="run")
+            yield Button("Back", id="back")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()
+            return
+        input_path = self.query_one("#input-path", Input).value.strip()
+        output_path = self.query_one("#output-path", Input).value.strip()
+        if not input_path or not output_path:
+            self.notify("Input and output paths are required.", severity="error")
+            return
+        feature_key = self.query_one("#feature-key", Input).value.strip() or None
+        try:
+            row_group_size = _positive_int(
+                self.query_one("#row-group-size", Input).value, 50_000
+            )
+        except ValueError as exc:
+            self.notify(str(exc), severity="error")
+            return
+        compression = self.query_one("#compression", Input).value.strip() or "zstd"
+
+        def runner() -> dict[str, Any]:
+            return run_morton_points(
+                input_path,
+                output_path,
+                feature_key=feature_key,
+                row_group_size=row_group_size,
+                compression=compression,
+            )
+
+        self.app.push_screen(
+            RunScreen(
+                TaskSpec(
+                    command=CommandId.MORTON_POINTS,
+                    title="Morton-sort file",
+                    runner=runner,
+                    verify_kind="morton",
+                    verify_paths=[Path(output_path)],
+                )
+            )
+        )
+
+
+class MultiscaleScreen(WriterScreen):
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Multiscale Points Parquet", classes="screen-title")
+        with VerticalScroll():
+            yield Label("Input path")
+            yield Input(placeholder="input.parquet", id="input-path")
+            yield Label("Output path")
+            yield Input(placeholder="output.parquet", id="output-path")
+            yield Label("Metadata JSON path (optional)")
+            yield Input(placeholder="metadata.json", id="metadata-json")
+            yield Label("Row group size")
+            yield Input(value="50000", id="row-group-size")
+            yield Label("Compression")
+            yield Input(value="zstd", id="compression")
+        with Horizontal():
+            yield Button("Run", variant="primary", id="run")
+            yield Button("Back", id="back")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()
+            return
+        input_path = self.query_one("#input-path", Input).value.strip()
+        output_path = self.query_one("#output-path", Input).value.strip()
+        if not input_path or not output_path:
+            self.notify("Input and output paths are required.", severity="error")
+            return
+        metadata_json = self.query_one("#metadata-json", Input).value.strip() or None
+        try:
+            row_group_size = _positive_int(
+                self.query_one("#row-group-size", Input).value, 50_000
+            )
+        except ValueError as exc:
+            self.notify(str(exc), severity="error")
+            return
+        compression = self.query_one("#compression", Input).value.strip() or "zstd"
+
+        def runner() -> dict[str, Any]:
+            return run_multiscale_points(
+                input_path,
+                output_path,
+                metadata_json=metadata_json,
+                row_group_size=row_group_size,
+                compression=compression,
+            )
+
+        self.app.push_screen(
+            RunScreen(
+                TaskSpec(
+                    command=CommandId.MULTISCALE_POINTS,
+                    title="Multiscale Points",
+                    runner=runner,
+                    verify_kind="multiscale",
+                    verify_paths=[Path(output_path)],
+                )
+            )
+        )
+
+
+class IndexPermutationsScreen(WriterScreen):
+    def __init__(self, *, from_zarr_context: bool = False) -> None:
+        super().__init__()
+        self.from_zarr_context = from_zarr_context
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Write index permutations", classes="screen-title")
+        with VerticalScroll():
+            yield Label("Source Zarr")
+            yield Input(id="source-zarr")
+            yield Label("Destination Zarr")
+            yield Input(id="dest-zarr")
+            yield Label("Points key (optional if single element)")
+            yield Input(id="points-key")
+            yield Label("Max rows (optional)")
+            yield Input(id="max-rows")
+            yield Label("Row group size")
+            yield Input(value="50000", id="row-group-size")
+            yield Label("Compression")
+            yield Input(value="zstd", id="compression")
+            yield Checkbox("Overwrite destination if it exists", id="overwrite")
+            yield Static("Conditions (default: all)", classes="section-label")
+            with Vertical(id="conditions"):
+                for condition in DEFAULT_CONDITIONS:
+                    yield Checkbox(condition.id, value=True, id=f"cond-{condition.id}")
+        with Horizontal():
+            yield Button("Run", variant="primary", id="run")
+            yield Button("Back", id="back")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self.app.context.zarr_path:
+            self.query_one("#source-zarr", Input).value = self.app.context.zarr_path
+        if self.from_zarr_context and self.app.context.points_key:
+            self.query_one("#points-key", Input).value = self.app.context.points_key
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()
+            return
+        source = self.query_one("#source-zarr", Input).value.strip()
+        dest = self.query_one("#dest-zarr", Input).value.strip()
+        if not source or not dest:
+            self.notify("Source and destination Zarr paths are required.", severity="error")
+            return
+        points_key = self.query_one("#points-key", Input).value.strip() or None
+        max_rows_text = self.query_one("#max-rows", Input).value.strip()
+        max_rows = None
+        if max_rows_text:
+            try:
+                max_rows = _positive_int(max_rows_text, 0)
+            except ValueError as exc:
+                self.notify(str(exc), severity="error")
+                return
+        try:
+            row_group_size = _positive_int(
+                self.query_one("#row-group-size", Input).value, 50_000
+            )
+        except ValueError as exc:
+            self.notify(str(exc), severity="error")
+            return
+        compression = self.query_one("#compression", Input).value.strip() or "zstd"
+        overwrite = self.query_one("#overwrite", Checkbox).value
+        selected = [
+            condition.id
+            for condition in DEFAULT_CONDITIONS
+            if self.query_one(f"#cond-{condition.id}", Checkbox).value
+        ]
+        if not selected:
+            self.notify("Select at least one condition.", severity="error")
+            return
+        all_selected = len(selected) == len(DEFAULT_CONDITIONS)
+        condition_ids = None if all_selected else selected
+
+        def runner() -> dict[str, Any]:
+            return run_write_index_permutations(
+                source,
+                dest,
+                points_key=points_key,
+                max_rows=max_rows,
+                condition_ids=condition_ids,
+                overwrite=overwrite,
+                row_group_size=row_group_size,
+                compression=compression,
+            )
+
+        self.app.push_screen(
+            RunScreen(
+                TaskSpec(
+                    command=CommandId.INDEX_PERMUTATIONS,
+                    title="Index permutations",
+                    runner=runner,
+                    verify_kind="manifest",
+                    verify_paths=[Path(dest)],
+                )
+            )
+        )
+
+
+class ConfirmScreen(WriterScreen):
+    def __init__(self, task_spec: TaskSpec) -> None:
+        super().__init__()
+        self.task_spec = task_spec
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Confirm in-place write", classes="screen-title")
+        yield Static(self.task_spec.confirm_message, id="confirm-message")
+        with Horizontal():
+            yield Button("Confirm overwrite", variant="error", id="confirm")
+            yield Button("Cancel", id="cancel")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.app.pop_screen()
+            return
+        self.app.pop_screen()
+        self.app.push_screen(RunScreen(self.task_spec))
+
+
+class RunScreen(WriterScreen):
+    def __init__(self, task_spec: TaskSpec) -> None:
+        super().__init__()
+        self.task_spec = task_spec
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(self.task_spec.title, classes="screen-title")
+        yield RichLog(id="run-log", highlight=True, markup=False)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.run_task()
+
+    @work(thread=True)
+    def run_task(self) -> None:
+        log = self.query_one("#run-log", RichLog)
+        result: dict[str, Any] | None = None
+        error: str | None = None
+        checks: list[VerifyCheck] = []
+        try:
+            self.app.call_from_thread(
+                log.write, f"Running {self.task_spec.command.value}..."
+            )
+            result = self.task_spec.runner()
+            self.app.call_from_thread(
+                log.write, json.dumps(result, indent=2, sort_keys=True)
+            )
+            checks = self._verify()
+        except Exception as exc:
+            error = "".join(traceback.format_exception_only(exc)).strip()
+            self.app.call_from_thread(log.write, error)
+
+        self.app.call_from_thread(
+            self.app.push_screen,
+            VerifyReportScreen(
+                task_spec=self.task_spec,
+                result=result,
+                checks=checks,
+                error=error,
+            ),
+        )
+
+    def _verify(self) -> list[VerifyCheck]:
+        if self.task_spec.verify_kind == "none":
+            return []
+        if self.task_spec.verify_kind == "morton":
+            checks: list[VerifyCheck] = []
+            for path in self.task_spec.verify_paths:
+                checks.extend(verify_morton_parquet(path))
+            return checks
+        if self.task_spec.verify_kind == "multiscale":
+            checks = []
+            for path in self.task_spec.verify_paths:
+                checks.extend(verify_multiscale_parquet(path))
+            return checks
+        if self.task_spec.verify_kind == "manifest":
+            checks = []
+            for path in self.task_spec.verify_paths:
+                checks.extend(verify_index_permutations_manifest(path))
+            return checks
+        return []
+
+
+class VerifyReportScreen(WriterScreen):
+    def __init__(
+        self,
+        *,
+        task_spec: TaskSpec,
+        result: dict[str, Any] | None,
+        checks: list[VerifyCheck],
+        error: str | None,
+    ) -> None:
+        super().__init__()
+        self.task_spec = task_spec
+        self.result = result
+        self.checks = checks
+        self.error = error
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Run complete", classes="screen-title")
+        with VerticalScroll():
+            if self.error:
+                yield Static(f"Error: {self.error}", id="error-text")
+            elif self.result:
+                if self.task_spec.command == CommandId.LIST_POINTS:
+                    keys = self.result.get("points_keys", [])
+                    yield Static(f"Points keys: {', '.join(keys) or '(none)'}")
+                else:
+                    rows = self.result.get("rows")
+                    output = self.result.get("output")
+                    if rows is not None:
+                        yield Static(f"Rows: {rows}")
+                    if output:
+                        yield Static(f"Output: {output}")
+            if self.checks:
+                passed = all_passed(self.checks)
+                status = "All checks passed" if passed else "Some checks failed"
+                yield Static(f"Verification: {status}", id="verify-summary")
+                table = DataTable(id="verify-table")
+                table.add_columns("Check", "Status", "Detail")
+                for check in self.checks:
+                    table.add_row(
+                        check.id,
+                        "PASS" if check.passed else "FAIL",
+                        check.detail,
+                    )
+                yield table
+        with Horizontal():
+            yield Button("Home", variant="primary", id="home")
+            yield Button("Quit", id="quit")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "home":
+            self.app.go_home()
+            return
+        self.app.exit()

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/tui/screens.py
@@ -287,7 +287,7 @@ class PointsKeyScreen(WriterScreen):
 
 
 class MortonFromZarrScreen(InputFormScreen):
-    INPUT_ORDER = ("feature-key", "row-group-size", "compression", "output-path")
+    INPUT_ORDER = ("feature-key", "row-group-size", "compression", "output-element")
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -299,8 +299,8 @@ class MortonFromZarrScreen(InputFormScreen):
             yield Input(value="50000", id="row-group-size")
             yield Label("Compression")
             yield Input(value="zstd", id="compression")
-            yield Label("Custom output path (optional)")
-            yield Input(placeholder="leave empty for default", id="output-path")
+            yield Label("Output Points element name (optional)")
+            yield Input(placeholder="leave empty to overwrite selected element", id="output-element")
             yield Checkbox("Write to points.experimental/", id="experimental")
         with Horizontal():
             yield Button("Run", variant="primary", id="run")
@@ -335,7 +335,7 @@ class MortonFromZarrScreen(InputFormScreen):
             return
 
         feature_key = self.query_one("#feature-key", Input).value.strip() or None
-        output_text = self.query_one("#output-path", Input).value.strip() or None
+        output_key = self.query_one("#output-element", Input).value.strip() or None
         experimental = self.query_one("#experimental", Checkbox).value
         try:
             row_group_size = _positive_int(
@@ -346,34 +346,67 @@ class MortonFromZarrScreen(InputFormScreen):
             return
         compression = self.query_one("#compression", Input).value.strip() or "zstd"
 
-        _, resolved_output, in_place = resolve_morton_from_zarr_output(
-            Path(zarr),
-            key,
-            output=output_text,
-            experimental=experimental,
-        )
+        try:
+            output_spec = resolve_morton_from_zarr_output(
+                Path(zarr),
+                key,
+                output_points_key=output_key,
+                experimental=experimental,
+            )
+        except WriterCommandError as exc:
+            self.notify(str(exc), severity="error")
+            return
+
+        target_exists = output_spec.output_parquet.exists()
+        if (
+            output_spec.collection == "points"
+            and output_spec.output_points_key is not None
+        ):
+            target_exists = target_exists or (
+                Path(zarr) / "points" / output_spec.output_points_key
+            ).exists()
+        requires_confirm = output_spec.in_place or target_exists
 
         def runner() -> dict[str, Any]:
             return run_morton_points_from_zarr(
                 zarr,
                 points_key=key,
                 experimental=experimental,
-                output=output_text,
+                output_points_key=output_key,
                 feature_key=feature_key,
+                overwrite=requires_confirm,
                 row_group_size=row_group_size,
                 compression=compression,
             )
+
+        if output_spec.in_place:
+            confirm_message = (
+                f"Overwrite selected Points element:\npoints/{key}\n\n"
+                f"Parquet path:\n{output_spec.output_parquet}\n\nProceed?"
+            )
+        elif target_exists and output_spec.collection == "points":
+            confirm_message = (
+                f"Overwrite existing Points element:\n"
+                f"points/{output_spec.output_points_key}\n\n"
+                f"Parquet path:\n{output_spec.output_parquet}\n\nProceed?"
+            )
+        elif target_exists and output_spec.collection == "points.experimental":
+            confirm_message = (
+                f"Overwrite existing experimental Points artifact:\n"
+                f"points.experimental/{output_spec.output_points_key}\n\n"
+                f"Parquet path:\n{output_spec.output_parquet}\n\nProceed?"
+            )
+        else:
+            confirm_message = ""
 
         task = TaskSpec(
             command=CommandId.MORTON_FROM_ZARR,
             title="Morton-sort from Zarr",
             runner=runner,
             verify_kind="morton",
-            verify_paths=[resolved_output],
-            requires_confirm=in_place,
-            confirm_message=(
-                f"In-place overwrite of canonical Parquet:\n{resolved_output}\n\nProceed?"
-            ),
+            verify_paths=[output_spec.output_parquet],
+            requires_confirm=requires_confirm,
+            confirm_message=confirm_message,
         )
         self._launch_task(task)
 

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/verify.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/verify.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+from .points import MORTON_CODE_2D_COLUMN
+
+_UINT_INTERMEDIATE_SUFFIXES = ("_uint",)
+
+
+def _dataframe_column(df: pd.DataFrame, name: str) -> pd.Series:
+    column = df[name]
+    if isinstance(column, pd.DataFrame):
+        raise TypeError(f"expected column {name!r} to be a Series, got DataFrame")
+    return column
+
+
+def _series_extrema(series: pd.Series) -> tuple[float, float]:
+    return float(series.min()), float(series.max())
+
+
+@dataclass(frozen=True)
+class VerifyCheck:
+    id: str
+    passed: bool
+    detail: str
+
+
+def _check(id: str, passed: bool, detail: str) -> VerifyCheck:
+    return VerifyCheck(id=id, passed=passed, detail=detail)
+
+
+def _count_sentinel_prefix(morton_values: pd.Series) -> int:
+    count = 0
+    for value in morton_values.head(4):
+        if int(value) != 0:
+            break
+        count += 1
+    return count
+
+
+def verify_morton_parquet(path: str | Path) -> list[VerifyCheck]:
+    parquet_path = Path(path)
+    checks: list[VerifyCheck] = []
+
+    if not parquet_path.is_file():
+        return [_check("file_exists", False, f"Parquet file not found: {parquet_path}")]
+
+    checks.append(_check("file_exists", True, str(parquet_path)))
+
+    parquet = pq.ParquetFile(parquet_path)
+    columns = parquet.schema_arrow.names
+    checks.append(
+        _check(
+            "column_present",
+            MORTON_CODE_2D_COLUMN in columns,
+            f"expected column {MORTON_CODE_2D_COLUMN!r} in schema",
+        )
+    )
+
+    uint_columns = [
+        name
+        for name in columns
+        if any(name.endswith(suffix) for suffix in _UINT_INTERMEDIATE_SUFFIXES)
+    ]
+    checks.append(
+        _check(
+            "no_uint_intermediates",
+            not uint_columns,
+            "no uint staging columns"
+            if not uint_columns
+            else f"unexpected uint columns: {', '.join(uint_columns)}",
+        )
+    )
+
+    if MORTON_CODE_2D_COLUMN not in columns:
+        return checks
+
+    df = pd.read_parquet(parquet_path, columns=[MORTON_CODE_2D_COLUMN, "x", "y"])
+    morton_column = _dataframe_column(df, MORTON_CODE_2D_COLUMN)
+    x_column = _dataframe_column(df, "x")
+    y_column = _dataframe_column(df, "y")
+    sentinel_count = _count_sentinel_prefix(morton_column)
+    checks.append(
+        _check(
+            "sentinel_prefix",
+            2 <= sentinel_count <= 4,
+            f"sentinel prefix rows: {sentinel_count} (expected 2–4)",
+        )
+    )
+
+    if sentinel_count > 0:
+        sentinel_x = x_column.iloc[:sentinel_count]
+        sentinel_y = y_column.iloc[:sentinel_count]
+        sentinel_x_min, sentinel_x_max = _series_extrema(sentinel_x)
+        dataset_x_min, dataset_x_max = _series_extrema(x_column)
+        sentinel_y_min, sentinel_y_max = _series_extrema(sentinel_y)
+        dataset_y_min, dataset_y_max = _series_extrema(y_column)
+        bbox_match = (
+            sentinel_x_min == dataset_x_min
+            and sentinel_x_max == dataset_x_max
+            and sentinel_y_min == dataset_y_min
+            and sentinel_y_max == dataset_y_max
+        )
+        checks.append(
+            _check(
+                "sentinel_bbox",
+                bbox_match,
+                "sentinel rows encode full x/y bounds"
+                if bbox_match
+                else "sentinel x/y extrema do not match dataset bounds",
+            )
+        )
+
+    if sentinel_count < len(df):
+        tail = morton_column.iloc[sentinel_count:].astype("int64")
+        monotonic = bool((tail.diff().dropna() >= 0).all())
+        checks.append(
+            _check(
+                "morton_monotonic",
+                monotonic,
+                "morton_code_2d non-decreasing after sentinels"
+                if monotonic
+                else "morton_code_2d decreases after sentinel prefix",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "morton_monotonic",
+                True,
+                "all rows are sentinel prefix (small dataset)",
+            )
+        )
+
+    if parquet.num_row_groups > 0:
+        first_group_rows = parquet.metadata.row_group(0).num_rows
+        sentinel_only = first_group_rows <= 4 and first_group_rows == sentinel_count
+        checks.append(
+            _check(
+                "row_group_sentinels",
+                sentinel_only,
+                f"row group 0 has {first_group_rows} rows (sentinel count {sentinel_count})",
+            )
+        )
+    else:
+        checks.append(_check("row_group_sentinels", False, "parquet has no row groups"))
+
+    return checks
+
+
+def verify_multiscale_parquet(path: str | Path) -> list[VerifyCheck]:
+    parquet_path = Path(path)
+    checks: list[VerifyCheck] = []
+
+    if not parquet_path.is_file():
+        return [_check("file_exists", False, f"Parquet file not found: {parquet_path}")]
+
+    checks.append(_check("file_exists", True, str(parquet_path)))
+
+    schema_metadata = pq.ParquetFile(parquet_path).schema_arrow.metadata
+    if schema_metadata is None or b"spatialdata_multiscale" not in schema_metadata:
+        checks.append(
+            _check(
+                "multiscale_metadata",
+                False,
+                "missing spatialdata_multiscale schema metadata",
+            )
+        )
+        return checks
+
+    stored = json.loads(schema_metadata[b"spatialdata_multiscale"])
+    checks.append(
+        _check(
+            "multiscale_metadata",
+            stored.get("format") == "spatialdata_multiscale_points",
+            f"format={stored.get('format')!r}",
+        )
+    )
+
+    bbox = stored.get("bounding_box")
+    has_bbox = (
+        isinstance(bbox, dict)
+        and isinstance(bbox.get("min"), list)
+        and isinstance(bbox.get("max"), list)
+        and len(bbox.get("min", [])) > 0
+        and len(bbox.get("max", [])) > 0
+    )
+    checks.append(
+        _check(
+            "multiscale_bbox",
+            has_bbox,
+            "bounding_box min/max present"
+            if has_bbox
+            else "bounding_box missing or incomplete",
+        )
+    )
+    return checks
+
+
+def verify_index_permutations_manifest(dest_zarr: str | Path) -> list[VerifyCheck]:
+    dest_path = Path(dest_zarr)
+    manifest_path = dest_path / "index-manifest.json"
+    checks: list[VerifyCheck] = []
+
+    if not manifest_path.is_file():
+        return [
+            _check(
+                "manifest_exists",
+                False,
+                f"index-manifest.json not found under {dest_path}",
+            )
+        ]
+
+    checks.append(_check("manifest_exists", True, str(manifest_path)))
+    manifest: dict[str, Any] = json.loads(manifest_path.read_text())
+    conditions = manifest.get("conditions", [])
+    if not isinstance(conditions, list) or not conditions:
+        checks.append(_check("manifest_conditions", False, "no conditions in manifest"))
+        return checks
+
+    checks.append(
+        _check("manifest_conditions", True, f"{len(conditions)} condition(s) listed")
+    )
+
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            continue
+        condition_id = condition.get("id", "unknown")
+        element_path = condition.get("element_path")
+        if not isinstance(element_path, str):
+            checks.append(
+                _check(
+                    f"path_{condition_id}",
+                    False,
+                    "condition missing element_path",
+                )
+            )
+            continue
+
+        parquet_path = dest_path / element_path / "points.parquet"
+        if not parquet_path.is_file() and not parquet_path.is_dir():
+            checks.append(
+                _check(
+                    f"path_{condition_id}",
+                    False,
+                    f"missing output: {parquet_path}",
+                )
+            )
+            continue
+
+        checks.append(_check(f"path_{condition_id}", True, str(parquet_path)))
+
+        tiling_kind = condition.get("tiling_kind")
+        if tiling_kind == "morton-points" and parquet_path.is_file():
+            for morton_check in verify_morton_parquet(parquet_path):
+                checks.append(
+                    VerifyCheck(
+                        id=f"{condition_id}_{morton_check.id}",
+                        passed=morton_check.passed,
+                        detail=morton_check.detail,
+                    )
+                )
+
+    return checks
+
+
+def all_passed(checks: list[VerifyCheck]) -> bool:
+    return bool(checks) and all(check.passed for check in checks)

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/verify.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/verify.py
@@ -53,7 +53,14 @@ def verify_morton_parquet(path: str | Path) -> list[VerifyCheck]:
 
     checks.append(_check("file_exists", True, str(parquet_path)))
 
-    parquet = pq.ParquetFile(parquet_path)
+    try:
+        parquet = pq.ParquetFile(parquet_path)
+    except Exception as exc:
+        checks.append(
+            _check("parquet_readable", False, f"failed to read Parquet metadata: {exc}")
+        )
+        return checks
+
     columns = parquet.schema_arrow.names
     checks.append(
         _check(
@@ -61,6 +68,12 @@ def verify_morton_parquet(path: str | Path) -> list[VerifyCheck]:
             MORTON_CODE_2D_COLUMN in columns,
             f"expected column {MORTON_CODE_2D_COLUMN!r} in schema",
         )
+    )
+    checks.append(
+        _check("x_column_present", "x" in columns, "expected column 'x' in schema")
+    )
+    checks.append(
+        _check("y_column_present", "y" in columns, "expected column 'y' in schema")
     )
 
     uint_columns = [
@@ -78,10 +91,25 @@ def verify_morton_parquet(path: str | Path) -> list[VerifyCheck]:
         )
     )
 
-    if MORTON_CODE_2D_COLUMN not in columns:
+    if (
+        MORTON_CODE_2D_COLUMN not in columns
+        or "x" not in columns
+        or "y" not in columns
+    ):
         return checks
 
-    df = pd.read_parquet(parquet_path, columns=[MORTON_CODE_2D_COLUMN, "x", "y"])
+    try:
+        df = pd.read_parquet(parquet_path, columns=[MORTON_CODE_2D_COLUMN, "x", "y"])
+    except Exception as exc:
+        checks.append(
+            _check(
+                "required_columns_readable",
+                False,
+                f"failed to read required columns: {exc}",
+            )
+        )
+        return checks
+
     morton_column = _dataframe_column(df, MORTON_CODE_2D_COLUMN)
     x_column = _dataframe_column(df, "x")
     y_column = _dataframe_column(df, "y")

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/verify.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/verify.py
@@ -44,6 +44,21 @@ def _count_sentinel_prefix(morton_values: pd.Series) -> int:
     return count
 
 
+def _sentinel_count_from_row_group(
+    parquet: pq.ParquetFile,
+    morton_values: pd.Series,
+) -> int | None:
+    if parquet.num_row_groups == 0:
+        return None
+    first_group_rows = parquet.metadata.row_group(0).num_rows
+    if not 2 <= first_group_rows <= 4:
+        return None
+    first_values = morton_values.iloc[:first_group_rows]
+    if first_values.astype("int64").eq(0).all():
+        return int(first_group_rows)
+    return None
+
+
 def verify_morton_parquet(path: str | Path) -> list[VerifyCheck]:
     parquet_path = Path(path)
     checks: list[VerifyCheck] = []
@@ -113,7 +128,9 @@ def verify_morton_parquet(path: str | Path) -> list[VerifyCheck]:
     morton_column = _dataframe_column(df, MORTON_CODE_2D_COLUMN)
     x_column = _dataframe_column(df, "x")
     y_column = _dataframe_column(df, "y")
-    sentinel_count = _count_sentinel_prefix(morton_column)
+    sentinel_count = _sentinel_count_from_row_group(parquet, morton_column)
+    if sentinel_count is None:
+        sentinel_count = _count_sentinel_prefix(morton_column)
     checks.append(
         _check(
             "sentinel_prefix",

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/zarr.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/zarr.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pyarrow.dataset as ds
+
+
+def _points_root(zarr_path: Path) -> Path:
+    return zarr_path / "points"
+
+
+def list_points_keys(zarr_path: str | Path) -> list[str]:
+    root = _points_root(Path(zarr_path))
+    if not root.is_dir():
+        return []
+    return sorted(
+        child.name
+        for child in root.iterdir()
+        if child.is_dir() and (child / "zarr.json").is_file()
+    )
+
+
+def _read_zarr_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def read_points_element_attrs(zarr_path: str | Path, points_key: str) -> dict[str, Any]:
+    element_json = _points_root(Path(zarr_path)) / points_key / "zarr.json"
+    if not element_json.is_file():
+        raise FileNotFoundError(f"Points element not found: points/{points_key}")
+    attrs = _read_zarr_json(element_json).get("attributes", {})
+    spatialdata_attrs = attrs.get("spatialdata_attrs", {})
+    if not isinstance(spatialdata_attrs, dict):
+        spatialdata_attrs = {}
+    return {
+        "axes": attrs.get("axes", []),
+        "feature_key": spatialdata_attrs.get("feature_key"),
+        "instance_key": spatialdata_attrs.get("instance_key"),
+        "version": spatialdata_attrs.get("version"),
+    }
+
+
+def points_parquet_path(zarr_path: str | Path, points_key: str) -> Path:
+    return _points_root(Path(zarr_path)) / points_key / "points.parquet"
+
+
+def experimental_points_output_path(zarr_path: str | Path, points_key: str) -> Path:
+    return Path(zarr_path) / "points.experimental" / points_key / "points.parquet"
+
+
+def read_points_dataframe(parquet_path: str | Path) -> pd.DataFrame:
+    path = Path(parquet_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Points Parquet not found: {path}")
+    if path.is_dir():
+        table = ds.dataset(path, format="parquet").to_table()
+    else:
+        table = ds.dataset(path, format="parquet").to_table()
+    return table.to_pandas()

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/zarr.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/zarr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -10,6 +11,17 @@ import pyarrow.dataset as ds
 
 def _points_root(zarr_path: Path) -> Path:
     return zarr_path / "points"
+
+
+def validate_points_key(points_key: str) -> str:
+    key = points_key.strip()
+    if not key:
+        raise ValueError("Points element name cannot be empty.")
+    if Path(key).name != key or key in {".", ".."}:
+        raise ValueError(
+            "Points element name must be a single name under points/, not a path."
+        )
+    return key
 
 
 def list_points_keys(zarr_path: str | Path) -> list[str]:
@@ -44,11 +56,25 @@ def read_points_element_attrs(zarr_path: str | Path, points_key: str) -> dict[st
 
 
 def points_parquet_path(zarr_path: str | Path, points_key: str) -> Path:
-    return _points_root(Path(zarr_path)) / points_key / "points.parquet"
+    return _points_root(Path(zarr_path)) / validate_points_key(points_key) / "points.parquet"
 
 
 def experimental_points_output_path(zarr_path: str | Path, points_key: str) -> Path:
-    return Path(zarr_path) / "points.experimental" / points_key / "points.parquet"
+    return Path(zarr_path) / "points.experimental" / validate_points_key(points_key) / "points.parquet"
+
+
+def copy_points_element_metadata(
+    zarr_path: str | Path,
+    *,
+    source_key: str,
+    dest_key: str,
+) -> None:
+    source = _points_root(Path(zarr_path)) / validate_points_key(source_key) / "zarr.json"
+    dest = _points_root(Path(zarr_path)) / validate_points_key(dest_key) / "zarr.json"
+    if not source.is_file():
+        raise FileNotFoundError(f"Points element metadata not found: {source}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, dest)
 
 
 def _points_element_consolidated_entry(

--- a/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/zarr.py
+++ b/python/spatialdata-experimental-writer/src/spatialdata_experimental_writer/zarr.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import pandas as pd
 import pyarrow.dataset as ds
@@ -49,6 +49,68 @@ def points_parquet_path(zarr_path: str | Path, points_key: str) -> Path:
 
 def experimental_points_output_path(zarr_path: str | Path, points_key: str) -> Path:
     return Path(zarr_path) / "points.experimental" / points_key / "points.parquet"
+
+
+def _points_element_consolidated_entry(
+    zarr_path: Path,
+    points_key: str,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if metadata is not None:
+        entry = metadata.get(f"points/{points_key}")
+        if isinstance(entry, dict):
+            return json.loads(json.dumps(entry))
+    element_json = _points_root(zarr_path) / points_key / "zarr.json"
+    element_doc = _read_zarr_json(element_json)
+    return {
+        "attributes": element_doc.get("attributes", {}),
+        "node_type": element_doc.get("node_type", "group"),
+        "zarr_format": element_doc.get("zarr_format", 3),
+    }
+
+
+def read_store_consolidated_metadata(zarr_path: str | Path) -> dict[str, Any]:
+    root_json = Path(zarr_path) / "zarr.json"
+    if not root_json.is_file():
+        raise FileNotFoundError(f"Missing store metadata: {root_json}")
+    doc = _read_zarr_json(root_json)
+    consolidated = doc.get("consolidated_metadata")
+    if not isinstance(consolidated, dict):
+        raise ValueError(f"Store has no consolidated metadata: {root_json}")
+    metadata = consolidated.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError(f"Store consolidated metadata has no metadata map: {root_json}")
+    return metadata
+
+
+def register_points_elements_in_consolidated_metadata(
+    zarr_path: str | Path,
+    element_keys: Sequence[str],
+    *,
+    template_key: str,
+) -> None:
+    """Register sibling points elements in the store root consolidated metadata."""
+    store_path = Path(zarr_path)
+    root_json = store_path / "zarr.json"
+    doc = _read_zarr_json(root_json)
+    consolidated = doc.get("consolidated_metadata")
+    if not isinstance(consolidated, dict):
+        consolidated = {"kind": "inline", "metadata": {}}
+        doc["consolidated_metadata"] = consolidated
+    metadata = consolidated.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        consolidated["metadata"] = metadata
+
+    template_entry = _points_element_consolidated_entry(
+        store_path,
+        template_key,
+        metadata=metadata,
+    )
+    for key in element_keys:
+        metadata[f"points/{key}"] = json.loads(json.dumps(template_entry))
+    root_json.write_text(json.dumps(doc, indent=2) + "\n")
 
 
 def read_points_dataframe(parquet_path: str | Path) -> pd.DataFrame:

--- a/python/spatialdata-experimental-writer/tests/test_integration.py
+++ b/python/spatialdata-experimental-writer/tests/test_integration.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from spatialdata_experimental_writer.index_permutations import write_index_permutations
+from spatialdata_experimental_writer.points import MORTON_CODE_2D_COLUMN, write_morton_points_parquet
+from spatialdata_experimental_writer.zarr import list_points_keys
+
+
+def _write_points_element(
+    zarr_root: Path,
+    key: str,
+    *,
+    feature_key: str = "feature_name",
+    rows: int = 200,
+) -> None:
+    element_dir = zarr_root / "points" / key
+    parquet_path = element_dir / "points.parquet"
+    element_dir.mkdir(parents=True)
+    rng = pd.Series(range(rows))
+    table = pa.Table.from_pandas(
+        pd.DataFrame(
+            {
+                "x": (rng.astype("float64") % 100).tolist(),
+                "y": ((rng * 3).astype("float64") % 100).tolist(),
+                "feature_name": (["gene_a", "gene_b", "gene_c"] * rows)[:rows],
+            }
+        ),
+        preserve_index=False,
+    )
+    pq.write_table(table, parquet_path)
+    element_dir.joinpath("zarr.json").write_text(
+        json.dumps(
+            {
+                "attributes": {
+                    "encoding-type": "ngff:points",
+                    "axes": ["x", "y"],
+                    "spatialdata_attrs": {
+                        "feature_key": feature_key,
+                        "version": "0.2",
+                    },
+                },
+                "zarr_format": 3,
+                "node_type": "group",
+            }
+        )
+    )
+    zarr_root.joinpath("zarr.json").write_text(
+        json.dumps({"zarr_format": 3, "node_type": "group"})
+    )
+
+
+def test_morton_parquet_does_not_persist_uint_columns(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 5.0, 2.0, 8.0],
+            "y": [3.0, 4.0, 20.0, 0.0, 9.0],
+            "feature_name": ["b", "a", "b", "c", "a"],
+        }
+    )
+    output = tmp_path / "points.parquet"
+    write_morton_points_parquet(df, output, feature_key="feature_name", row_group_size=2)
+    columns = pq.ParquetFile(output).schema_arrow.names
+    assert "x_uint" not in columns
+    assert "y_uint" not in columns
+    assert MORTON_CODE_2D_COLUMN in columns
+    assert "feature_name_codes" in columns
+
+
+def test_morton_points_from_zarr_defaults_to_canonical_path(tmp_path: Path) -> None:
+    zarr_root = tmp_path / "store.zarr"
+    _write_points_element(zarr_root, "transcripts")
+    canonical = zarr_root / "points" / "transcripts" / "points.parquet"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "spatialdata_experimental_writer.cli",
+            "morton-points-from-zarr",
+            str(zarr_root),
+            "--points-key",
+            "transcripts",
+            "--row-group-size",
+            "50",
+        ],
+        check=True,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+    assert canonical.is_file()
+    columns = pq.ParquetFile(canonical).schema_arrow.names
+    assert MORTON_CODE_2D_COLUMN in columns
+    assert "feature_name_codes" in columns
+
+
+def test_write_index_permutations_writes_manifest(tmp_path: Path) -> None:
+    source = tmp_path / "source.zarr"
+    dest = tmp_path / "dest.zarr"
+    _write_points_element(source, "transcripts", rows=120)
+
+    manifest = write_index_permutations(
+        source,
+        dest,
+        points_key="transcripts",
+        row_group_size=40,
+        conditions=tuple(
+            condition
+            for condition in __import__(
+                "spatialdata_experimental_writer.index_permutations",
+                fromlist=["DEFAULT_CONDITIONS"],
+            ).DEFAULT_CONDITIONS
+            if condition.id in {"canonical", "morton"}
+        ),
+    )
+
+    assert (dest / "index-manifest.json").exists()
+    assert manifest["source_element"] == "points/transcripts"
+    assert (dest / "points" / "transcripts" / "points.parquet").exists()
+    assert (dest / "points" / "transcripts_morton" / "points.parquet").exists()
+    assert list_points_keys(dest) == ["transcripts", "transcripts_morton"]
+    consolidated = json.loads((dest / "zarr.json").read_text())["consolidated_metadata"][
+        "metadata"
+    ]
+    assert "points/transcripts_morton" in consolidated
+    morton_columns = pq.ParquetFile(
+        dest / "points" / "transcripts_morton" / "points.parquet"
+    ).schema_arrow.names
+    assert MORTON_CODE_2D_COLUMN in morton_columns

--- a/python/spatialdata-experimental-writer/tests/test_integration.py
+++ b/python/spatialdata-experimental-writer/tests/test_integration.py
@@ -10,7 +10,9 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from spatialdata_experimental_writer.index_permutations import write_index_permutations
+from spatialdata_experimental_writer.errors import WriterCommandError
 from spatialdata_experimental_writer.points import MORTON_CODE_2D_COLUMN, write_morton_points_parquet
+from spatialdata_experimental_writer.runners import run_morton_points_from_zarr
 from spatialdata_experimental_writer.zarr import list_points_keys
 
 
@@ -121,6 +123,80 @@ def test_cli_expected_error_has_no_traceback(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "No Points elements found" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_morton_points_from_zarr_output_points_key_writes_element(tmp_path: Path) -> None:
+    zarr_root = tmp_path / "store.zarr"
+    _write_points_element(zarr_root, "transcripts")
+
+    result = run_morton_points_from_zarr(
+        zarr_root,
+        points_key="transcripts",
+        output_points_key="transcripts_morton",
+        row_group_size=50,
+    )
+
+    output = zarr_root / "points" / "transcripts_morton" / "points.parquet"
+    assert result["output_points_key"] == "transcripts_morton"
+    assert result["output"] == str(output)
+    assert output.is_file()
+    assert (zarr_root / "points" / "transcripts_morton" / "zarr.json").is_file()
+    assert list_points_keys(zarr_root) == ["transcripts", "transcripts_morton"]
+    metadata = json.loads(zarr_root.joinpath("zarr.json").read_text())[
+        "consolidated_metadata"
+    ]["metadata"]
+    assert "points/transcripts_morton" in metadata
+
+
+def test_morton_points_from_zarr_output_points_key_can_be_experimental(
+    tmp_path: Path,
+) -> None:
+    zarr_root = tmp_path / "store.zarr"
+    _write_points_element(zarr_root, "transcripts")
+
+    result = run_morton_points_from_zarr(
+        zarr_root,
+        points_key="transcripts",
+        experimental=True,
+        output_points_key="transcripts_morton",
+        row_group_size=50,
+    )
+
+    output = zarr_root / "points.experimental" / "transcripts_morton" / "points.parquet"
+    assert result["output_collection"] == "points.experimental"
+    assert result["output_points_key"] == "transcripts_morton"
+    assert result["output"] == str(output)
+    assert output.is_file()
+    assert not (zarr_root / "points" / "transcripts_morton").exists()
+
+
+def test_morton_points_from_zarr_requires_overwrite_for_existing_output_element(
+    tmp_path: Path,
+) -> None:
+    zarr_root = tmp_path / "store.zarr"
+    _write_points_element(zarr_root, "transcripts")
+    _write_points_element(zarr_root, "transcripts_morton")
+
+    try:
+        run_morton_points_from_zarr(
+            zarr_root,
+            points_key="transcripts",
+            output_points_key="transcripts_morton",
+            row_group_size=50,
+        )
+    except WriterCommandError as exc:
+        assert "already exists" in str(exc)
+    else:
+        raise AssertionError("expected WriterCommandError")
+
+    run_morton_points_from_zarr(
+        zarr_root,
+        points_key="transcripts",
+        output_points_key="transcripts_morton",
+        overwrite=True,
+        row_group_size=50,
+    )
+    assert (zarr_root / "points" / "transcripts_morton" / "points.parquet").is_file()
 
 
 def test_write_index_permutations_writes_manifest(tmp_path: Path) -> None:

--- a/python/spatialdata-experimental-writer/tests/test_integration.py
+++ b/python/spatialdata-experimental-writer/tests/test_integration.py
@@ -101,6 +101,28 @@ def test_morton_points_from_zarr_defaults_to_canonical_path(tmp_path: Path) -> N
     assert "feature_name_codes" in columns
 
 
+def test_cli_expected_error_has_no_traceback(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.zarr"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "spatialdata_experimental_writer.cli",
+            "list-points",
+            str(missing),
+        ],
+        check=False,
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "No Points elements found" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_write_index_permutations_writes_manifest(tmp_path: Path) -> None:
     source = tmp_path / "source.zarr"
     dest = tmp_path / "dest.zarr"

--- a/python/spatialdata-experimental-writer/tests/test_points.py
+++ b/python/spatialdata-experimental-writer/tests/test_points.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+from spatialdata_experimental_writer import (
+    MORTON_CODE_2D_COLUMN,
+    build_spatialdata_multiscale_metadata,
+    morton_sort_points,
+    write_morton_points_parquet,
+    write_multiscale_points_parquet,
+)
+
+
+def test_morton_sort_points_adds_sentinel_rows_and_feature_codes() -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 5.0, 2.0],
+            "y": [3.0, 4.0, 20.0, 0.0],
+            "feature_name": ["b", "a", "b", "c"],
+        }
+    )
+
+    sorted_df = morton_sort_points(df, feature_key="feature_name")
+
+    assert MORTON_CODE_2D_COLUMN in sorted_df.columns
+    assert "feature_name_codes" in sorted_df.columns
+    assert sorted_df[MORTON_CODE_2D_COLUMN].iloc[:4].eq(0).all()
+    assert sorted_df.columns[-1] == "feature_name"
+
+
+def test_write_morton_points_parquet_uses_small_sentinel_row_group(tmp_path) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 5.0, 2.0, 8.0],
+            "y": [3.0, 4.0, 20.0, 0.0, 9.0],
+            "feature_name": ["b", "a", "b", "c", "a"],
+        }
+    )
+    output = tmp_path / "points.parquet"
+
+    write_morton_points_parquet(df, output, feature_key="feature_name", row_group_size=2)
+
+    parquet = pq.ParquetFile(output)
+    assert parquet.num_row_groups >= 2
+    assert parquet.metadata.row_group(0).num_rows <= 4
+
+
+def test_write_multiscale_points_parquet_stores_metadata(tmp_path) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0],
+            "y": [3.0, 4.0],
+            "__spatial_index__": [0, 1],
+            "__morton__": [0, 1],
+        }
+    )
+    output = tmp_path / "points.parquet"
+    metadata = build_spatialdata_multiscale_metadata(df, axes=("x", "y"))
+
+    write_multiscale_points_parquet(df, output, metadata=metadata, row_group_size=2)
+
+    schema_metadata = pq.ParquetFile(output).schema_arrow.metadata
+    assert schema_metadata is not None
+    stored = json.loads(schema_metadata[b"spatialdata_multiscale"])
+    assert stored["format"] == "spatialdata_multiscale_points"
+    assert stored["bounding_box"]["min"] == [0.0, 3.0]

--- a/python/spatialdata-experimental-writer/tests/test_points.py
+++ b/python/spatialdata-experimental-writer/tests/test_points.py
@@ -48,6 +48,30 @@ def test_write_morton_points_parquet_uses_small_sentinel_row_group(tmp_path) -> 
     assert parquet.metadata.row_group(0).num_rows <= 4
 
 
+def test_write_morton_points_parquet_keeps_quantized_zero_points_out_of_sentinel_row_group(
+    tmp_path,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 0.00001, 5.0, 2.0],
+            "y": [0.0, 20.0, 0.00001, 10.0, 7.0],
+            "feature_name": ["min", "max", "near_min", "mid", "other"],
+        }
+    )
+    output = tmp_path / "points.parquet"
+
+    sorted_df = write_morton_points_parquet(
+        df,
+        output,
+        feature_key="feature_name",
+        row_group_size=2,
+    )
+
+    assert sorted_df[MORTON_CODE_2D_COLUMN].iloc[:3].eq(0).all()
+    parquet = pq.ParquetFile(output)
+    assert parquet.metadata.row_group(0).num_rows == 2
+
+
 def test_write_multiscale_points_parquet_stores_metadata(tmp_path) -> None:
     df = pd.DataFrame(
         {

--- a/python/spatialdata-experimental-writer/tests/test_points.py
+++ b/python/spatialdata-experimental-writer/tests/test_points.py
@@ -31,6 +31,34 @@ def test_morton_sort_points_adds_sentinel_rows_and_feature_codes() -> None:
     assert sorted_df.columns[-1] == "feature_name"
 
 
+def test_morton_sort_points_uses_extreme_row_positions_not_duplicate_index_labels() -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 50.0, 100.0, 25.0, 75.0, 10.0],
+            "y": [50.0, 100.0, 25.0, 0.0, 75.0, 10.0],
+            "feature_name": ["x_min", "y_max", "x_max", "y_min", "other", "near_min"],
+        },
+        index=[7, 7, 8, 8, 9, 9],
+    )
+
+    sorted_df = morton_sort_points(df, feature_key="feature_name")
+
+    sentinel = sorted_df.iloc[:4]
+    assert sentinel[MORTON_CODE_2D_COLUMN].eq(0).all()
+    assert sentinel["x"].min() == 0.0
+    assert sentinel["x"].max() == 100.0
+    assert sentinel["y"].min() == 0.0
+    assert sentinel["y"].max() == 100.0
+    assert sorted_df["feature_name"].value_counts().to_dict() == {
+        "x_min": 1,
+        "y_max": 1,
+        "x_max": 1,
+        "y_min": 1,
+        "other": 1,
+        "near_min": 1,
+    }
+
+
 def test_write_morton_points_parquet_uses_small_sentinel_row_group(tmp_path) -> None:
     df = pd.DataFrame(
         {

--- a/python/spatialdata-experimental-writer/tests/test_verify.py
+++ b/python/spatialdata-experimental-writer/tests/test_verify.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from spatialdata_experimental_writer.index_permutations import write_index_permutations
+from spatialdata_experimental_writer.points import (
+    MORTON_CODE_2D_COLUMN,
+    build_spatialdata_multiscale_metadata,
+    write_morton_points_parquet,
+    write_multiscale_points_parquet,
+)
+from spatialdata_experimental_writer.verify import (
+    all_passed,
+    verify_index_permutations_manifest,
+    verify_morton_parquet,
+    verify_multiscale_parquet,
+)
+
+
+def test_verify_morton_parquet_passes_for_writer_output(tmp_path) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 5.0, 2.0, 8.0],
+            "y": [3.0, 4.0, 20.0, 0.0, 9.0],
+            "feature_name": ["b", "a", "b", "c", "a"],
+        }
+    )
+    output = tmp_path / "points.parquet"
+    write_morton_points_parquet(df, output, feature_key="feature_name", row_group_size=2)
+
+    checks = verify_morton_parquet(output)
+    assert all_passed(checks)
+
+
+def test_verify_morton_parquet_fails_for_unsorted_tail(tmp_path) -> None:
+    rows = 40
+    rng = pd.Series(range(rows))
+    df = pd.DataFrame(
+        {
+            "x": (rng.astype("float64") % 20).tolist(),
+            "y": ((rng * 3).astype("float64") % 20).tolist(),
+            "feature_name": (["a", "b", "c"] * rows)[:rows],
+        }
+    )
+    output = tmp_path / "points.parquet"
+    write_morton_points_parquet(df, output, feature_key="feature_name", row_group_size=8)
+
+    table = pq.read_table(output)
+    pdf = table.to_pandas()
+    sentinel_count = int((pdf[MORTON_CODE_2D_COLUMN].head(4) == 0).sum())
+    assert sentinel_count < len(pdf) - 1
+    later = sentinel_count + 1
+    pdf.at[pdf.index[later], MORTON_CODE_2D_COLUMN] = int(
+        pdf[MORTON_CODE_2D_COLUMN].iloc[sentinel_count]
+    ) - 1
+    pq.write_table(pa.Table.from_pandas(pdf, preserve_index=False), output)
+
+    checks = verify_morton_parquet(output)
+    monotonic = next(check for check in checks if check.id == "morton_monotonic")
+    assert not monotonic.passed
+
+
+def test_verify_multiscale_parquet(tmp_path) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0],
+            "y": [3.0, 4.0],
+            "__spatial_index__": [0, 1],
+            "__morton__": [0, 1],
+        }
+    )
+    output = tmp_path / "points.parquet"
+    metadata = build_spatialdata_multiscale_metadata(df, axes=("x", "y"))
+    write_multiscale_points_parquet(df, output, metadata=metadata, row_group_size=2)
+
+    checks = verify_multiscale_parquet(output)
+    assert all_passed(checks)
+
+
+def test_verify_index_permutations_manifest(tmp_path) -> None:
+    source = tmp_path / "source.zarr"
+    dest = tmp_path / "dest.zarr"
+    element_dir = source / "points" / "transcripts"
+    element_dir.mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 5.0, 2.0],
+            "y": [3.0, 4.0, 20.0, 0.0],
+            "feature_name": ["b", "a", "b", "c"],
+        }
+    )
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), element_dir / "points.parquet")
+    element_dir.joinpath("zarr.json").write_text(
+        json.dumps(
+            {
+                "attributes": {
+                    "encoding-type": "ngff:points",
+                    "axes": ["x", "y"],
+                    "spatialdata_attrs": {"feature_key": "feature_name", "version": "0.2"},
+                },
+                "zarr_format": 3,
+                "node_type": "group",
+            }
+        )
+    )
+    source.joinpath("zarr.json").write_text(
+        json.dumps({"zarr_format": 3, "node_type": "group"})
+    )
+
+    write_index_permutations(
+        source,
+        dest,
+        points_key="transcripts",
+        row_group_size=2,
+        conditions=tuple(
+            condition
+            for condition in __import__(
+                "spatialdata_experimental_writer.index_permutations",
+                fromlist=["DEFAULT_CONDITIONS"],
+            ).DEFAULT_CONDITIONS
+            if condition.id in {"canonical", "morton"}
+        ),
+    )
+
+    checks = verify_index_permutations_manifest(dest)
+    morton_checks = [check for check in checks if check.id.endswith("morton_monotonic")]
+    assert morton_checks
+    assert all(check.passed for check in morton_checks)

--- a/python/spatialdata-experimental-writer/tests/test_verify.py
+++ b/python/spatialdata-experimental-writer/tests/test_verify.py
@@ -36,6 +36,26 @@ def test_verify_morton_parquet_passes_for_writer_output(tmp_path) -> None:
     assert all_passed(checks)
 
 
+def test_verify_morton_parquet_uses_sentinel_row_group_boundary(tmp_path) -> None:
+    df = pd.DataFrame(
+        {
+            "x": [0.0, 10.0, 0.00001, 5.0, 2.0],
+            "y": [0.0, 20.0, 0.00001, 10.0, 7.0],
+            "feature_name": ["min", "max", "near_min", "mid", "other"],
+        }
+    )
+    output = tmp_path / "points.parquet"
+    write_morton_points_parquet(df, output, feature_key="feature_name", row_group_size=2)
+
+    checks = verify_morton_parquet(output)
+
+    assert all_passed(checks)
+    sentinel = next(check for check in checks if check.id == "sentinel_prefix")
+    row_group = next(check for check in checks if check.id == "row_group_sentinels")
+    assert "sentinel prefix rows: 2" in sentinel.detail
+    assert "row group 0 has 2 rows" in row_group.detail
+
+
 def test_verify_morton_parquet_fails_for_unsorted_tail(tmp_path) -> None:
     rows = 40
     rng = pd.Series(range(rows))

--- a/python/spatialdata-experimental-writer/tests/test_verify.py
+++ b/python/spatialdata-experimental-writer/tests/test_verify.py
@@ -64,6 +64,20 @@ def test_verify_morton_parquet_fails_for_unsorted_tail(tmp_path) -> None:
     assert not monotonic.passed
 
 
+def test_verify_morton_parquet_reports_missing_coordinate_columns(tmp_path) -> None:
+    output = tmp_path / "points.parquet"
+    table = pa.table({MORTON_CODE_2D_COLUMN: pa.array([0, 1], type=pa.uint64())})
+    pq.write_table(table, output)
+
+    checks = verify_morton_parquet(output)
+
+    x_check = next(check for check in checks if check.id == "x_column_present")
+    y_check = next(check for check in checks if check.id == "y_column_present")
+    assert not x_check.passed
+    assert not y_check.passed
+    assert not all_passed(checks)
+
+
 def test_verify_multiscale_parquet(tmp_path) -> None:
     df = pd.DataFrame(
         {

--- a/python/spatialdata-experimental-writer/tests/test_zarr.py
+++ b/python/spatialdata-experimental-writer/tests/test_zarr.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 from spatialdata_experimental_writer.zarr import (
     experimental_points_output_path,
@@ -14,6 +15,7 @@ from spatialdata_experimental_writer.zarr import (
     read_points_dataframe,
     read_points_element_attrs,
     register_points_elements_in_consolidated_metadata,
+    validate_points_key,
 )
 
 
@@ -103,3 +105,9 @@ def test_list_points_keys_and_read_element(tmp_path: Path) -> None:
     assert experimental_points_output_path(tmp_path, "transcripts") == (
         tmp_path / "points.experimental" / "transcripts" / "points.parquet"
     )
+
+
+def test_validate_points_key_rejects_paths() -> None:
+    assert validate_points_key(" transcripts_morton ") == "transcripts_morton"
+    with pytest.raises(ValueError, match="single name"):
+        validate_points_key("nested/transcripts_morton")

--- a/python/spatialdata-experimental-writer/tests/test_zarr.py
+++ b/python/spatialdata-experimental-writer/tests/test_zarr.py
@@ -13,6 +13,7 @@ from spatialdata_experimental_writer.zarr import (
     points_parquet_path,
     read_points_dataframe,
     read_points_element_attrs,
+    register_points_elements_in_consolidated_metadata,
 )
 
 
@@ -52,6 +53,44 @@ def _write_points_element(
             }
         )
     )
+
+
+def test_register_points_elements_in_consolidated_metadata(tmp_path: Path) -> None:
+    _write_points_element(tmp_path, "transcripts")
+    root_json = tmp_path / "zarr.json"
+    root_json.write_text(
+        json.dumps(
+            {
+                "zarr_format": 3,
+                "node_type": "group",
+                "consolidated_metadata": {
+                    "kind": "inline",
+                    "metadata": {
+                        "points/transcripts": {
+                            "attributes": {
+                                "encoding-type": "ngff:points",
+                                "axes": ["x", "y"],
+                                "spatialdata_attrs": {
+                                    "feature_key": "feature_name",
+                                    "version": "0.2",
+                                },
+                            },
+                            "node_type": "group",
+                            "zarr_format": 3,
+                        }
+                    },
+                },
+            }
+        )
+    )
+    register_points_elements_in_consolidated_metadata(
+        tmp_path,
+        ["transcripts", "transcripts_morton"],
+        template_key="transcripts",
+    )
+    metadata = json.loads(root_json.read_text())["consolidated_metadata"]["metadata"]
+    assert "points/transcripts_morton" in metadata
+    assert metadata["points/transcripts_morton"]["attributes"]["encoding-type"] == "ngff:points"
 
 
 def test_list_points_keys_and_read_element(tmp_path: Path) -> None:

--- a/python/spatialdata-experimental-writer/tests/test_zarr.py
+++ b/python/spatialdata-experimental-writer/tests/test_zarr.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from spatialdata_experimental_writer.zarr import (
+    experimental_points_output_path,
+    list_points_keys,
+    points_parquet_path,
+    read_points_dataframe,
+    read_points_element_attrs,
+)
+
+
+def _write_points_element(
+    zarr_root: Path,
+    key: str,
+    *,
+    feature_key: str = "feature_name",
+) -> None:
+    element_dir = zarr_root / "points" / key
+    parquet_dir = element_dir / "points.parquet"
+    parquet_dir.mkdir(parents=True)
+    table = pa.Table.from_pandas(
+        pd.DataFrame(
+            {
+                "x": [0.0, 1.0],
+                "y": [2.0, 3.0],
+                "feature_name": ["a", "b"],
+            }
+        ),
+        preserve_index=False,
+    )
+    pq.write_table(table, parquet_dir / "part.0.parquet")
+    element_dir.joinpath("zarr.json").write_text(
+        json.dumps(
+            {
+                "attributes": {
+                    "encoding-type": "ngff:points",
+                    "axes": ["x", "y"],
+                    "spatialdata_attrs": {
+                        "feature_key": feature_key,
+                        "version": "0.2",
+                    },
+                },
+                "zarr_format": 3,
+                "node_type": "group",
+            }
+        )
+    )
+
+
+def test_list_points_keys_and_read_element(tmp_path: Path) -> None:
+    _write_points_element(tmp_path, "transcripts")
+    assert list_points_keys(tmp_path) == ["transcripts"]
+    attrs = read_points_element_attrs(tmp_path, "transcripts")
+    assert attrs["feature_key"] == "feature_name"
+    df = read_points_dataframe(points_parquet_path(tmp_path, "transcripts"))
+    assert list(df.columns) == ["x", "y", "feature_name"]
+    assert experimental_points_output_path(tmp_path, "transcripts") == (
+        tmp_path / "points.experimental" / "transcripts" / "points.parquet"
+    )

--- a/python/spatialdata-experimental-writer/uv.lock
+++ b/python/spatialdata-experimental-writer/uv.lock
@@ -1,0 +1,283 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "spatialdata-experimental-writer"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.0" },
+    { name = "pandas", specifier = ">=2.2" },
+    { name = "pyarrow", specifier = ">=18" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]

--- a/python/spatialdata-experimental-writer/uv.lock
+++ b/python/spatialdata-experimental-writer/uv.lock
@@ -29,6 +29,56 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -151,6 +201,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -240,6 +299,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -262,6 +334,9 @@ dependencies = [
 dev = [
     { name = "pytest" },
 ]
+tui = [
+    { name = "textual" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -272,6 +347,33 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]
+tui = [{ name = "textual", specifier = ">=1.0" }]
+
+[[package]]
+name = "textual"
+version = "8.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
 
 [[package]]
 name = "tzdata"
@@ -280,4 +382,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]


### PR DESCRIPTION
Harvested from the larger points-loading branch as a self-contained slice. This package does not touch the TS render path and main never referenced it, so it applied as 8 clean cherry-picks off `main`.

New Python package `python/spatialdata-experimental-writer` (note that we will follow-up at some point by merging image codec writing into this, possibly with a different name, and publish to pypi):
- Morton (2D) point index writer for SpatialData Points Parquet, following current Vitessce practice (`morton_code_2d`, `{feature_key}_codes`, controlled row groups, sentinel bbox rows). See ADR 0002.
- CLI + a Textual TUI for driving writes and index options.
- `write-index-permutations` benchmark tooling for comparing sort strategies (spatial Morton vs. feature-primary vs. compound) on a derivative Zarr store.
- Tests for points sorting, zarr writes, and verification.

Notes:
- Not run in isolation here (needs a `uv` env); it was green on the source branch.
- Depends on / pairs with the ADRs in the companion docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)