### PR TITLE
Implement rotation/mapAxis/inverse; validate against RFC-5 conformance suite

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@spatialdata/vis", "dev:demo"],
       "port": 5173
+    },
+    {
+      "name": "docs",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "docs", "dev"],
+      "port": 3001
     }
   ]
 }

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -13,8 +13,8 @@ below is effectively the backlog of transform features still to implement. (A
 secondary, incidental use was ruling our transform *math* in/out while chasing a
 viv image-render bug — but that bug most likely lives in viv, not here.)
 
-This lives on the `transform-conformance` branch of SpatialData.js. It is a dev
-script (not shipped in any package).
+This is a dev script (not shipped in any package) — run it manually when
+touching `packages/core/src/transformations/`.
 
 ## What it wraps
 

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -16,6 +16,13 @@ below for the full breakdown and [Maturation backlog](#maturation-backlog-drivin
 for what's left. The same summary lives in the docs site at
 [`docs/docs/core/transformations.mdx`](../../docs/docs/core/transformations.mdx#supported-transformation-types).
 
+We validate this support against the
+[`ome-zarr-transformations-conformance`](https://github.com/clbarnes/ome_zarr_transformations_conformance)
+package (its `oztc` runner + bundled RFC-5 cases), pinned to
+[commit `6f93379`](https://github.com/clbarnes/ome_zarr_transformations_conformance/tree/6f933795aa61259c36914ff919f47d5f9255bd8d)
+in [`pyproject.toml`](./pyproject.toml) — this dingus is the only thing that
+runs it, and its output is what "supported" means above.
+
 ## Motivation
 
 The primary goal is to **mature the SpatialData.js transform implementation**:
@@ -98,7 +105,8 @@ node --experimental-strip-types dingus.ts \
 ## Baseline
 
 `baseline-results.tsv` records the latest run (conformance suite pinned at
-commit `6f93379`): **24 pass, 17 error, 0 fail**.
+[commit `6f93379`](https://github.com/clbarnes/ome_zarr_transformations_conformance/tree/6f933795aa61259c36914ff919f47d5f9255bd8d)):
+**24 pass, 17 error, 0 fail**.
 
 The key positive result is **0 `fail`**: every transform SpatialData.js actually
 implements produced numerically correct coordinates, including inverse affine,

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -1,0 +1,70 @@
+# SpatialData.js transform conformance dingus
+
+A "dingus" CLI implementing the contract from
+[clbarnes/ome_zarr_transformations_conformance](https://github.com/clbarnes/ome_zarr_transformations_conformance),
+used to validate SpatialData.js's coordinate-transform computation against the
+RFC-5 OME-Zarr transformations test cases.
+
+This lives on the `transform-conformance` branch of SpatialData.js. It is a dev
+script (not shipped in any package).
+
+## What it wraps
+
+`dingus.ts` imports `parseTransformEntry` from
+`packages/core/src/transformations/transformations.ts` and uses the resulting
+`BaseTransformation.toMatrix()` (a `@math.gl/core` `Matrix4`). That is the actual
+SpatialData.js transform computation. The dingus adds only glue:
+
+- reads `attributes.ome.scene` (coordinate systems + transformation edges) from
+  the case `zarr.json`;
+- builds a graph and BFS-finds a path SOURCE -> TARGET;
+- composes per-edge matrices, applying coordinates in name-based `x/y/z` space;
+- for **reverse** edges, inverts the 4x4 with `Matrix4.invert()` (a generic
+  matrix inverse; SpatialData.js core has no native transform inversion);
+- prints `{"coordinates": [...]}` (exit 0), or `{"message": "..."}` (exit 1) for
+  any unsupported feature or failure, per the contract.
+
+## RFC-5 support assessment (why many cases report `error`)
+
+SpatialData.js's `parseTransformEntry` implements **identity, scale, translation,
+affine, sequence** (with `input`/`output` coordinate-system refs and axis-name ->
+XYZ mapping). It does **not** implement: `rotation`, `mapAxis` (class is a stub),
+`byDimension`, `bijection`, `displacements`, or affine/rotation **by path**
+(parameters stored in an external zarr array). It also has no standalone
+`$.ome.scene` graph reader (its model is element -> coordinate-system via
+`element.getTransformation()` on multiscale `coordinateTransformations`).
+
+The dingus therefore reports those as unsupported (`error`) rather than guessing,
+which is the honest signal of current library coverage. Non-spatial axes (e.g.
+`i`, `v`) are also reported unsupported because the matrix path is XYZ-only.
+
+## Run
+
+Requires `pnpm install` at the SpatialData.js root (provides `@math.gl/core`) and
+Node >= 22 (type stripping). From the conformance repo:
+
+```bash
+./transformation_conformance.py ./cases -- \
+  /abs/path/to/SpatialData.js/dev_scripts/conformance-dingus/dingus.sh
+```
+
+Single case (for debugging):
+
+```bash
+node --experimental-strip-types dingus.ts \
+  /path/to/cases/affine.ome.zarr input output '[[-1,-1,-1],[0,0,0]]'
+```
+
+## Baseline
+
+`baseline-results.tsv` records the run captured when this dingus was written
+(conformance suite pinned at commit `6f93379`): **18 pass, 23 error, 0 fail**.
+
+The key positive result is **0 `fail`**: every transform SpatialData.js actually
+implements produced numerically correct coordinates, including inverse affine,
+composed sequences, and multi-edge paths. All 23 `error` rows are unsupported
+features (see assessment above), not wrong answers.
+
+To extend coverage, implement the missing transform types in
+`packages/core/src/transformations/transformations.ts` (and a native inverse),
+then re-run; failures would then surface real numerical bugs.

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -5,6 +5,17 @@ A "dingus" CLI implementing the contract from
 used to validate SpatialData.js's coordinate-transform computation against the
 RFC-5 OME-Zarr transformations test cases.
 
+## Current support (tl;dr)
+
+SpatialData.js implements RFC-5 `identity`, `scale`, `translation`, `affine`,
+`rotation`, `mapAxis`, and `sequence` (inline parameters, spatial axes only).
+**Not** implemented: `byDimension`, `bijection`, `displacements`, affine/rotation
+**by path** (parameters in an external zarr array), and non-spatial axes. Latest
+verified baseline: **24 pass, 17 error, 0 fail** — see [Baseline](#baseline)
+below for the full breakdown and [Maturation backlog](#maturation-backlog-driving-the-implementation)
+for what's left. The same summary lives in the docs site at
+[`docs/docs/core/transformations.mdx`](../../docs/docs/core/transformations.mdx#supported-transformation-types).
+
 ## Motivation
 
 The primary goal is to **mature the SpatialData.js transform implementation**:

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -94,6 +94,28 @@ implements produced numerically correct coordinates, including inverse affine,
 rotation, mapAxis, composed sequences, and multi-edge paths. All 17 `error` rows
 are unsupported features (see assessment above), not wrong answers.
 
+## Maintenance: validating a new conformance suite revision
+
+The suite revision is pinned in `pyproject.toml`
+(`ome-zarr-transformations-conformance @ git+...@<rev>`). Since this isn't run
+in CI, staleness only surfaces when someone bumps it by hand — do that
+periodically (e.g. when RFC-5 gains new cases/clarifications) as follows:
+
+1. Bump `<rev>` in `pyproject.toml` to the new commit/tag, then
+   `cd dev_scripts/conformance-dingus && uv lock` to update `uv.lock`.
+2. `./run-conformance.sh -v` and diff the output against
+   `baseline-results.tsv`. Three outcomes matter differently:
+   - **New/renamed `error` rows** — expected when the suite adds cases for
+     features we don't implement yet; just fold them into the backlog below.
+   - **Any `fail` row** (as opposed to `error`) — a real numerical bug: the
+     dingus ran a case we claim to support and got the wrong answer. Treat
+     this as a blocking regression, not a backlog item.
+   - **A previously-`pass` case flips to `error`/`fail`** — the suite changed
+     semantics or fixed a case; re-read the case's `zarr.json`/
+     `conformance.toml` to see what changed before assuming our code is wrong.
+3. Regenerate `baseline-results.tsv` from the new run and update the pass/
+   error/fail counts quoted in the Baseline section above.
+
 ## Maturation backlog (driving the implementation)
 
 Turning `error` rows into `pass` is the work this dingus exists to drive. In

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -20,27 +20,27 @@ script (not shipped in any package).
 
 `dingus.ts` imports `parseTransformEntry` from
 `packages/core/src/transformations/transformations.ts` and uses the resulting
-`BaseTransformation.toMatrix()` (a `@math.gl/core` `Matrix4`). That is the actual
-SpatialData.js transform computation. The dingus adds only glue:
+`BaseTransformation.toMatrix()`/`.inverse()` (`@math.gl/core` `Matrix4`). That is
+the actual SpatialData.js transform computation. The dingus adds only glue:
 
 - reads `attributes.ome.scene` (coordinate systems + transformation edges) from
   the case `zarr.json`;
 - builds a graph and BFS-finds a path SOURCE -> TARGET;
 - composes per-edge matrices, applying coordinates in name-based `x/y/z` space;
-- for **reverse** edges, inverts the 4x4 with `Matrix4.invert()` (a generic
-  matrix inverse; SpatialData.js core has no native transform inversion);
+- for **reverse** edges, calls `BaseTransformation.inverse()` (native to core);
 - prints `{"coordinates": [...]}` (exit 0), or `{"message": "..."}` (exit 1) for
   any unsupported feature or failure, per the contract.
 
 ## RFC-5 support assessment (why many cases report `error`)
 
 SpatialData.js's `parseTransformEntry` implements **identity, scale, translation,
-affine, sequence** (with `input`/`output` coordinate-system refs and axis-name ->
-XYZ mapping). It does **not** implement: `rotation`, `mapAxis` (class is a stub),
-`byDimension`, `bijection`, `displacements`, or affine/rotation **by path**
-(parameters stored in an external zarr array). It also has no standalone
-`$.ome.scene` graph reader (its model is element -> coordinate-system via
-`element.getTransformation()` on multiscale `coordinateTransformations`).
+affine, rotation, mapAxis, sequence** (with `input`/`output` coordinate-system
+refs and axis-name -> XYZ mapping), plus a native `BaseTransformation.inverse()`.
+It does **not** implement: `byDimension`, `bijection`, `displacements`, or
+affine/rotation **by path** (parameters stored in an external zarr array). It
+also has no standalone `$.ome.scene` graph reader (its model is element ->
+coordinate-system via `element.getTransformation()` on multiscale
+`coordinateTransformations`).
 
 The dingus therefore reports those as unsupported (`error`) rather than guessing,
 which is the honest signal of current library coverage. Non-spatial axes (e.g.
@@ -86,13 +86,13 @@ node --experimental-strip-types dingus.ts \
 
 ## Baseline
 
-`baseline-results.tsv` records the run captured when this dingus was written
-(conformance suite pinned at commit `6f93379`): **18 pass, 23 error, 0 fail**.
+`baseline-results.tsv` records the latest run (conformance suite pinned at
+commit `6f93379`): **24 pass, 17 error, 0 fail**.
 
 The key positive result is **0 `fail`**: every transform SpatialData.js actually
 implements produced numerically correct coordinates, including inverse affine,
-composed sequences, and multi-edge paths. All 23 `error` rows are unsupported
-features (see assessment above), not wrong answers.
+rotation, mapAxis, composed sequences, and multi-edge paths. All 17 `error` rows
+are unsupported features (see assessment above), not wrong answers.
 
 ## Maturation backlog (driving the implementation)
 
@@ -100,11 +100,12 @@ Turning `error` rows into `pass` is the work this dingus exists to drive. In
 roughly increasing effort, implement in
 `packages/core/src/transformations/transformations.ts`:
 
-1. **`rotation`** — 8 cases; a rotation matrix is a special affine, so this is
-   mostly a `parseTransformEntry` case + `toArray()` mapping.
-2. **`mapAxis`** — 2 cases; finish the existing stub (permute axes).
-3. **Native inverse** — add `BaseTransformation.inverse()` so reverse traversal
-   is library-native instead of the dingus's generic 4x4 invert.
+1. ~~**`rotation`** — 8 cases; a rotation matrix is a special affine, so this is
+   mostly a `parseTransformEntry` case + `toArray()` mapping.~~ Done: 4/8 now
+   pass (the other 4 are the "by path" form, see item 7).
+2. ~~**`mapAxis`** — 2 cases; finish the existing stub (permute axes).~~ Done.
+3. ~~**Native inverse** — add `BaseTransformation.inverse()` so reverse traversal
+   is library-native instead of the dingus's generic 4x4 invert.~~ Done.
 4. **`byDimension`** — 4 cases; per-axis sub-transforms.
 5. **`bijection`** — 2 cases; explicit forward/inverse pair.
 6. **`displacements`** — 1 case; deformation field (largest lift; needs array IO).

--- a/dev_scripts/conformance-dingus/README.md
+++ b/dev_scripts/conformance-dingus/README.md
@@ -5,6 +5,14 @@ A "dingus" CLI implementing the contract from
 used to validate SpatialData.js's coordinate-transform computation against the
 RFC-5 OME-Zarr transformations test cases.
 
+## Motivation
+
+The primary goal is to **mature the SpatialData.js transform implementation**:
+the conformance suite gives an objective, RFC-5-aligned target, and the baseline
+below is effectively the backlog of transform features still to implement. (A
+secondary, incidental use was ruling our transform *math* in/out while chasing a
+viv image-render bug — but that bug most likely lives in viv, not here.)
+
 This lives on the `transform-conformance` branch of SpatialData.js. It is a dev
 script (not shipped in any package).
 
@@ -40,15 +48,36 @@ which is the honest signal of current library coverage. Non-spatial axes (e.g.
 
 ## Run
 
-Requires `pnpm install` at the SpatialData.js root (provides `@math.gl/core`) and
-Node >= 22 (type stripping). From the conformance repo:
+Prerequisites: `pnpm install` at the SpatialData.js root (provides
+`@math.gl/core`) and Node >= 22 (type stripping).
+
+### Self-contained (recommended)
+
+The conformance runner (`oztc`) and its RFC-5 cases are a **pinned uv git
+dependency** declared in `pyproject.toml` here, so SpatialData.js can run
+conformance with no external checkout:
+
+```bash
+cd dev_scripts/conformance-dingus
+./run-conformance.sh            # uv sync + run all cases against the dingus
+./run-conformance.sh -v -p affine   # extra args forwarded to oztc
+```
+
+`run-conformance.sh` resolves the cases bundled into the installed package
+(site-packages/cases) and points `oztc` at them. Bump the rev in `pyproject.toml`
+to track a newer suite.
+
+### Against an external checkout
+
+If you have the suite checked out (e.g. as a sibling submodule), invoke its
+runner directly:
 
 ```bash
 ./transformation_conformance.py ./cases -- \
   /abs/path/to/SpatialData.js/dev_scripts/conformance-dingus/dingus.sh
 ```
 
-Single case (for debugging):
+### Single case (debugging)
 
 ```bash
 node --experimental-strip-types dingus.ts \
@@ -65,6 +94,24 @@ implements produced numerically correct coordinates, including inverse affine,
 composed sequences, and multi-edge paths. All 23 `error` rows are unsupported
 features (see assessment above), not wrong answers.
 
-To extend coverage, implement the missing transform types in
-`packages/core/src/transformations/transformations.ts` (and a native inverse),
-then re-run; failures would then surface real numerical bugs.
+## Maturation backlog (driving the implementation)
+
+Turning `error` rows into `pass` is the work this dingus exists to drive. In
+roughly increasing effort, implement in
+`packages/core/src/transformations/transformations.ts`:
+
+1. **`rotation`** — 8 cases; a rotation matrix is a special affine, so this is
+   mostly a `parseTransformEntry` case + `toArray()` mapping.
+2. **`mapAxis`** — 2 cases; finish the existing stub (permute axes).
+3. **Native inverse** — add `BaseTransformation.inverse()` so reverse traversal
+   is library-native instead of the dingus's generic 4x4 invert.
+4. **`byDimension`** — 4 cases; per-axis sub-transforms.
+5. **`bijection`** — 2 cases; explicit forward/inverse pair.
+6. **`displacements`** — 1 case; deformation field (largest lift; needs array IO).
+7. **Affine/rotation *by path*** — load parameters from the referenced zarr array.
+8. **Non-spatial / >3D axes** — generalise beyond the XYZ `Matrix4` fast path.
+
+A standalone `$.ome.scene` graph reader (with SOURCE→TARGET pathfinding +
+inversion) would let the library — not just this dingus — consume RFC-5 scenes
+directly. After each change, re-run the suite; any new `fail` (vs `error`)
+indicates a real numerical bug to fix.

--- a/dev_scripts/conformance-dingus/baseline-results.tsv
+++ b/dev_scripts/conformance-dingus/baseline-results.tsv
@@ -1,0 +1,42 @@
+case	status	message
+affine	pass
+affine_downProjection	pass
+affine_identity	pass
+affine_identity_inverse	pass
+affine_inverse	pass
+affine_inverse_path_float32	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+affine_inverse_path_float64	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+affine_path_float32	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+affine_path_float64	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+affine_upProjection	pass
+bijection_forward	error	transform type 'bijection' is not implemented by SpatialData.js
+bijection_inverse	error	transform type 'bijection' is not implemented by SpatialData.js
+byDimension	error	transform type 'byDimension' is not implemented by SpatialData.js
+byDimension_inverse	error	transform type 'byDimension' is not implemented by SpatialData.js
+byDimension_nonContiguous	error	transform type 'byDimension' is not implemented by SpatialData.js
+byDimension_nonContiguous_inverse	error	transform type 'byDimension' is not implemented by SpatialData.js
+coordinates_1d	error	coordinate system 'input' axis 'i' is not x/y/z (unsupported)
+coordinates_2d-3d	error	coordinate system 'input' axis 'v' is not x/y/z (unsupported)
+displacements_constant	error	transform type 'displacements' is not implemented by SpatialData.js
+identity	pass
+identity_inverse	pass
+mapAxis	error	transform type 'mapAxis' is not implemented by SpatialData.js
+mapAxis_inverse	error	transform type 'mapAxis' is not implemented by SpatialData.js
+rotation	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_identity	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_identity_inverse	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_inverse	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_inverse_path_float32	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_inverse_path_float64	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_path_float32	error	transform type 'rotation' is not implemented by SpatialData.js
+rotation_path_float64	error	transform type 'rotation' is not implemented by SpatialData.js
+scale	pass
+scale_inverse	pass
+sequence	pass
+sequence_inverse	pass
+simple_path	pass
+simple_path_inverse	pass
+translation	pass
+translation_inverse	pass
+unknown_source	pass	unknown source coordinate system 'not_input'
+unknown_target	pass	unknown target coordinate system 'not_output'

--- a/dev_scripts/conformance-dingus/baseline-results.tsv
+++ b/dev_scripts/conformance-dingus/baseline-results.tsv
@@ -20,16 +20,16 @@ coordinates_2d-3d	error	coordinate system 'input' axis 'v' is not x/y/z (unsuppo
 displacements_constant	error	transform type 'displacements' is not implemented by SpatialData.js
 identity	pass
 identity_inverse	pass
-mapAxis	error	transform type 'mapAxis' is not implemented by SpatialData.js
-mapAxis_inverse	error	transform type 'mapAxis' is not implemented by SpatialData.js
-rotation	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_identity	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_identity_inverse	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_inverse	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_inverse_path_float32	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_inverse_path_float64	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_path_float32	error	transform type 'rotation' is not implemented by SpatialData.js
-rotation_path_float64	error	transform type 'rotation' is not implemented by SpatialData.js
+mapAxis	pass
+mapAxis_inverse	pass
+rotation	pass
+rotation_identity	pass
+rotation_identity_inverse	pass
+rotation_inverse	pass
+rotation_inverse_path_float32	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+rotation_inverse_path_float64	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+rotation_path_float32	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
+rotation_path_float64	error	transform 'inputToOutput' stores parameters by path; external parameter arrays are not supported
 scale	pass
 scale_inverse	pass
 sequence	pass

--- a/dev_scripts/conformance-dingus/dingus.sh
+++ b/dev_scripts/conformance-dingus/dingus.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper so the ome_zarr_transformations_conformance runner can call the dingus.
+# Usage (from the conformance repo):
+#   ./transformation_conformance.py ./cases -- \
+#     /path/to/SpatialData.js/dev_scripts/conformance-dingus/dingus.sh
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node --experimental-strip-types "$DIR/dingus.ts" "$@"

--- a/dev_scripts/conformance-dingus/dingus.ts
+++ b/dev_scripts/conformance-dingus/dingus.ts
@@ -15,14 +15,13 @@
  *
  * What this wraps: the transform primitives in
  *   packages/core/src/transformations/transformations.ts
- * (`parseTransformEntry` -> `BaseTransformation.toMatrix()`), i.e. the actual
- * SpatialData.js transform computation. SpatialData.js implements
- * identity/scale/translation/affine/sequence; rotation/mapAxis/byDimension/
- * bijection/displacements are NOT implemented and are reported as unsupported.
+ * (`parseTransformEntry` -> `BaseTransformation.toMatrix()`/`.inverse()`), i.e.
+ * the actual SpatialData.js transform computation. SpatialData.js implements
+ * identity/scale/translation/affine/rotation/mapAxis/sequence; byDimension/
+ * bijection/displacements are NOT implemented and are reported as unsupported,
+ * as are "by path" parameter forms (external zarr array references).
  *
- * Reverse-edge traversal uses a generic math.gl 4x4 matrix inverse (a
- * dingus-level capability; SpatialData.js core has no native transform
- * inversion). This is documented so the conformance baseline is read correctly.
+ * Reverse-edge traversal uses `BaseTransformation.inverse()`, native to core.
  *
  * Run via Node type-stripping (Node >= 22):
  *   node --experimental-strip-types dev_scripts/conformance-dingus/dingus.ts \
@@ -42,7 +41,15 @@ import {
 
 // SpatialData.js parseTransformEntry recognises exactly these (others -> Identity
 // fallback). We treat anything else as explicitly unsupported.
-const SUPPORTED_TYPES = new Set(['identity', 'scale', 'translation', 'affine', 'sequence']);
+const SUPPORTED_TYPES = new Set([
+  'identity',
+  'scale',
+  'translation',
+  'affine',
+  'rotation',
+  'mapAxis',
+  'sequence',
+]);
 
 const AXIS_TO_XYZ: Record<string, 0 | 1 | 2> = { x: 0, y: 1, z: 2 };
 
@@ -201,15 +208,18 @@ function stepMatrix(
   const input: CoordinateSystemRef = { name: inCs.name, axes: inCs.axes as never };
   const output: CoordinateSystemRef = { name: outCs.name, axes: outCs.axes as never };
   const entry = { ...edge, input, output };
-  const matrix = parseTransformEntry(entry as never).toMatrix();
-  if (!reversed) return matrix;
+  const transformation = parseTransformEntry(entry as never);
+  if (!reversed) return transformation.toMatrix();
 
-  // Reverse traversal: invert the 4x4 (generic; not native to core).
-  const det = matrix.determinant();
-  if (!Number.isFinite(det) || Math.abs(det) < 1e-12) {
-    throw new DingusError(`transform '${edge.name ?? edge.type}' is not invertible (det=${det})`);
+  // Reverse traversal: use SpatialData.js's native inverse() rather than a
+  // dingus-level generic 4x4 invert.
+  try {
+    return transformation.inverse();
+  } catch (err) {
+    throw new DingusError(
+      `transform '${edge.name ?? edge.type}' is not invertible: ${String(err)}`
+    );
   }
-  return matrix.clone().invert();
 }
 
 function toXYZ(point: number[], indices: Array<0 | 1 | 2>): [number, number, number] {

--- a/dev_scripts/conformance-dingus/dingus.ts
+++ b/dev_scripts/conformance-dingus/dingus.ts
@@ -38,6 +38,7 @@ import {
   type CoordinateSystemRef,
   parseTransformEntry,
 } from '../../packages/core/src/transformations/transformations.ts';
+import type { Axis, CoordinateTransformation } from '../../packages/core/src/schemas/index.ts';
 
 // SpatialData.js parseTransformEntry recognises exactly these (others -> Identity
 // fallback). We treat anything else as explicitly unsupported.
@@ -53,22 +54,19 @@ const SUPPORTED_TYPES = new Set([
 
 const AXIS_TO_XYZ: Record<string, 0 | 1 | 2> = { x: 0, y: 1, z: 2 };
 
-interface Axis {
-  name: string;
-  type?: string;
-  unit?: string;
-}
 interface CoordinateSystem {
   name: string;
   axes: Axis[];
 }
-interface TransformEdge {
+// A single transformation entry per `parseTransformEntry`'s real contract, plus
+// the RFC-5 scene-edge fields (`name`, and always-present `input`/`output`)
+// that aren't part of the schema for transformations nested inside a sequence.
+type TransformEdge = CoordinateTransformation[number] & {
   name?: string;
-  type: string;
+  path?: string;
   input: { name: string };
   output: { name: string };
-  [k: string]: unknown;
-}
+};
 interface Scene {
   coordinateSystems: CoordinateSystem[];
   coordinateTransformations: TransformEdge[];
@@ -179,24 +177,18 @@ function stepMatrix(
         `external parameter arrays are not supported`
     );
   }
-  if (edge.type === 'affine' && !Array.isArray((edge as { affine?: unknown }).affine)) {
+  if (edge.type === 'affine' && !Array.isArray(edge.affine)) {
     throw new DingusError(`affine transform missing inline 'affine' matrix (unsupported form)`);
   }
-  if (edge.type === 'scale' && !Array.isArray((edge as { scale?: unknown }).scale)) {
+  if (edge.type === 'scale' && !Array.isArray(edge.scale)) {
     throw new DingusError(`scale transform missing inline 'scale' array (unsupported form)`);
   }
-  if (
-    edge.type === 'translation' &&
-    !Array.isArray((edge as { translation?: unknown }).translation)
-  ) {
+  if (edge.type === 'translation' && !Array.isArray(edge.translation)) {
     throw new DingusError(
       `translation transform missing inline 'translation' array (unsupported form)`
     );
   }
-  if (
-    edge.type === 'sequence' &&
-    !Array.isArray((edge as { transformations?: unknown }).transformations)
-  ) {
+  if (edge.type === 'sequence' && !Array.isArray(edge.transformations)) {
     throw new DingusError(`sequence transform missing inline 'transformations' (unsupported form)`);
   }
   const inCs = csByName.get(edge.input.name);
@@ -205,10 +197,10 @@ function stepMatrix(
     throw new DingusError(`edge references unknown coordinate system`);
   }
   // Inject axes so SpatialData.js maps values by axis name into XYZ.
-  const input: CoordinateSystemRef = { name: inCs.name, axes: inCs.axes as never };
-  const output: CoordinateSystemRef = { name: outCs.name, axes: outCs.axes as never };
+  const input: CoordinateSystemRef = { name: inCs.name, axes: inCs.axes };
+  const output: CoordinateSystemRef = { name: outCs.name, axes: outCs.axes };
   const entry = { ...edge, input, output };
-  const transformation = parseTransformEntry(entry as never);
+  const transformation = parseTransformEntry(entry);
   if (!reversed) return transformation.toMatrix();
 
   // Reverse traversal: use SpatialData.js's native inverse() rather than a

--- a/dev_scripts/conformance-dingus/dingus.ts
+++ b/dev_scripts/conformance-dingus/dingus.ts
@@ -1,0 +1,279 @@
+/**
+ * OME-Zarr transformations conformance "dingus" for SpatialData.js.
+ *
+ * Implements the CLI contract from
+ *   https://github.com/clbarnes/ome_zarr_transformations_conformance
+ * Last four positional args MUST be: PATH SOURCE TARGET COORDINATES
+ *   PATH         path to an OME-Zarr hierarchy (dir containing zarr.json) or a
+ *                zarr.json file directly
+ *   SOURCE       name of the source coordinate system
+ *   TARGET       name of the target coordinate system
+ *   COORDINATES  JSON array of D-length arrays (D = SOURCE axis count)
+ *
+ * On success prints a JSON Response {"coordinates": [...]} and exits 0.
+ * On any unsupported feature / failure prints {"message": "..."} and exits 1.
+ *
+ * What this wraps: the transform primitives in
+ *   packages/core/src/transformations/transformations.ts
+ * (`parseTransformEntry` -> `BaseTransformation.toMatrix()`), i.e. the actual
+ * SpatialData.js transform computation. SpatialData.js implements
+ * identity/scale/translation/affine/sequence; rotation/mapAxis/byDimension/
+ * bijection/displacements are NOT implemented and are reported as unsupported.
+ *
+ * Reverse-edge traversal uses a generic math.gl 4x4 matrix inverse (a
+ * dingus-level capability; SpatialData.js core has no native transform
+ * inversion). This is documented so the conformance baseline is read correctly.
+ *
+ * Run via Node type-stripping (Node >= 22):
+ *   node --experimental-strip-types dev_scripts/conformance-dingus/dingus.ts \
+ *     <PATH> <SOURCE> <TARGET> '<COORDS_JSON>'
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+// Type-only import: erased at runtime, so we never resolve @math.gl/core from
+// outside packages/core (pnpm isolates it there). The Matrix4 *instances* come
+// from parseTransformEntry(...).toMatrix(), and we only call instance methods.
+import type { Matrix4 } from '@math.gl/core';
+import {
+  type CoordinateSystemRef,
+  parseTransformEntry,
+} from '../../packages/core/src/transformations/transformations.ts';
+
+// SpatialData.js parseTransformEntry recognises exactly these (others -> Identity
+// fallback). We treat anything else as explicitly unsupported.
+const SUPPORTED_TYPES = new Set(['identity', 'scale', 'translation', 'affine', 'sequence']);
+
+const AXIS_TO_XYZ: Record<string, 0 | 1 | 2> = { x: 0, y: 1, z: 2 };
+
+interface Axis {
+  name: string;
+  type?: string;
+  unit?: string;
+}
+interface CoordinateSystem {
+  name: string;
+  axes: Axis[];
+}
+interface TransformEdge {
+  name?: string;
+  type: string;
+  input: { name: string };
+  output: { name: string };
+  [k: string]: unknown;
+}
+interface Scene {
+  coordinateSystems: CoordinateSystem[];
+  coordinateTransformations: TransformEdge[];
+}
+
+class DingusError extends Error {}
+
+function emitError(message: string): never {
+  process.stdout.write(JSON.stringify({ message }));
+  process.exit(1);
+}
+
+function readScene(path: string): Scene {
+  const jsonPath = path.endsWith('.json') ? path : join(path, 'zarr.json');
+  let doc: unknown;
+  try {
+    doc = JSON.parse(readFileSync(jsonPath, 'utf8'));
+  } catch (err) {
+    throw new DingusError(`could not read zarr.json at ${jsonPath}: ${String(err)}`);
+  }
+  const scene = (doc as { attributes?: { ome?: { scene?: Scene } } })?.attributes?.ome?.scene;
+  if (!scene || !Array.isArray(scene.coordinateSystems)) {
+    throw new DingusError(`no ome.scene with coordinateSystems at ${jsonPath}`);
+  }
+  return scene;
+}
+
+/** Build the spatial-axis -> XYZ index map for a coordinate system, validating. */
+function spatialAxisIndices(cs: CoordinateSystem): Array<0 | 1 | 2> {
+  const idx: Array<0 | 1 | 2> = [];
+  for (const axis of cs.axes) {
+    if (axis.type && axis.type !== 'space') {
+      throw new DingusError(
+        `coordinate system '${cs.name}' has non-spatial axis '${axis.name}' (unsupported)`
+      );
+    }
+    const dim = AXIS_TO_XYZ[axis.name.toLowerCase()];
+    if (dim === undefined) {
+      throw new DingusError(
+        `coordinate system '${cs.name}' axis '${axis.name}' is not x/y/z (unsupported)`
+      );
+    }
+    idx.push(dim);
+  }
+  return idx;
+}
+
+/** A directed step along the path: which edge, and whether traversed in reverse. */
+interface Step {
+  edge: TransformEdge;
+  reversed: boolean;
+}
+
+function findPath(scene: Scene, source: string, target: string): Step[] {
+  if (source === target) return [];
+  const adjacency = new Map<string, Array<{ to: string; step: Step }>>();
+  const add = (from: string, to: string, step: Step) => {
+    if (!adjacency.has(from)) adjacency.set(from, []);
+    adjacency.get(from)!.push({ to, step });
+  };
+  for (const edge of scene.coordinateTransformations) {
+    add(edge.input.name, edge.output.name, { edge, reversed: false });
+    add(edge.output.name, edge.input.name, { edge, reversed: true });
+  }
+
+  // BFS for a shortest edge path.
+  const queue: string[] = [source];
+  const cameFrom = new Map<string, { from: string; step: Step }>();
+  const seen = new Set<string>([source]);
+  while (queue.length) {
+    const node = queue.shift()!;
+    if (node === target) break;
+    for (const { to, step } of adjacency.get(node) ?? []) {
+      if (seen.has(to)) continue;
+      seen.add(to);
+      cameFrom.set(to, { from: node, step });
+      queue.push(to);
+    }
+  }
+  if (!seen.has(target)) {
+    throw new DingusError(`no transform path from '${source}' to '${target}'`);
+  }
+  const steps: Step[] = [];
+  let node = target;
+  while (node !== source) {
+    const prev = cameFrom.get(node)!;
+    steps.unshift(prev.step);
+    node = prev.from;
+  }
+  return steps;
+}
+
+function stepMatrix(
+  scene: Scene,
+  csByName: Map<string, CoordinateSystem>,
+  step: Step
+): Matrix4 {
+  const { edge, reversed } = step;
+  if (!SUPPORTED_TYPES.has(edge.type)) {
+    throw new DingusError(`transform type '${edge.type}' is not implemented by SpatialData.js`);
+  }
+  // Reject inline-parameter forms SpatialData.js cannot consume (notably the
+  // RFC-5 "by path" forms where the matrix/parameters live in an external zarr
+  // array referenced by `path`). SpatialData.js only reads inline parameters.
+  if ('path' in edge && edge.path !== undefined) {
+    throw new DingusError(
+      `transform '${edge.name ?? edge.type}' stores parameters by path; ` +
+        `external parameter arrays are not supported`
+    );
+  }
+  if (edge.type === 'affine' && !Array.isArray((edge as { affine?: unknown }).affine)) {
+    throw new DingusError(`affine transform missing inline 'affine' matrix (unsupported form)`);
+  }
+  if (edge.type === 'scale' && !Array.isArray((edge as { scale?: unknown }).scale)) {
+    throw new DingusError(`scale transform missing inline 'scale' array (unsupported form)`);
+  }
+  if (
+    edge.type === 'translation' &&
+    !Array.isArray((edge as { translation?: unknown }).translation)
+  ) {
+    throw new DingusError(
+      `translation transform missing inline 'translation' array (unsupported form)`
+    );
+  }
+  if (
+    edge.type === 'sequence' &&
+    !Array.isArray((edge as { transformations?: unknown }).transformations)
+  ) {
+    throw new DingusError(`sequence transform missing inline 'transformations' (unsupported form)`);
+  }
+  const inCs = csByName.get(edge.input.name);
+  const outCs = csByName.get(edge.output.name);
+  if (!inCs || !outCs) {
+    throw new DingusError(`edge references unknown coordinate system`);
+  }
+  // Inject axes so SpatialData.js maps values by axis name into XYZ.
+  const input: CoordinateSystemRef = { name: inCs.name, axes: inCs.axes as never };
+  const output: CoordinateSystemRef = { name: outCs.name, axes: outCs.axes as never };
+  const entry = { ...edge, input, output };
+  const matrix = parseTransformEntry(entry as never).toMatrix();
+  if (!reversed) return matrix;
+
+  // Reverse traversal: invert the 4x4 (generic; not native to core).
+  const det = matrix.determinant();
+  if (!Number.isFinite(det) || Math.abs(det) < 1e-12) {
+    throw new DingusError(`transform '${edge.name ?? edge.type}' is not invertible (det=${det})`);
+  }
+  return matrix.clone().invert();
+}
+
+function toXYZ(point: number[], indices: Array<0 | 1 | 2>): [number, number, number] {
+  const vec: [number, number, number] = [0, 0, 0];
+  if (point.length !== indices.length) {
+    throw new DingusError(
+      `coordinate has ${point.length} values but coordinate system has ${indices.length} axes`
+    );
+  }
+  for (let i = 0; i < indices.length; i++) vec[indices[i]] = point[i]!;
+  return vec;
+}
+
+function fromXYZ(vec: number[], indices: Array<0 | 1 | 2>): number[] {
+  return indices.map((dim) => vec[dim]!);
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  if (argv.length < 4) {
+    throw new DingusError('expected at least 4 positional args: PATH SOURCE TARGET COORDINATES');
+  }
+  const [path, source, target, coordsJson] = argv.slice(-4) as [string, string, string, string];
+
+  let coords: number[][];
+  try {
+    coords = JSON.parse(coordsJson);
+  } catch (err) {
+    throw new DingusError(`COORDINATES is not valid JSON: ${String(err)}`);
+  }
+
+  const scene = readScene(path);
+  const csByName = new Map(scene.coordinateSystems.map((cs) => [cs.name, cs]));
+  const sourceCs = csByName.get(source);
+  const targetCs = csByName.get(target);
+  if (!sourceCs) throw new DingusError(`unknown source coordinate system '${source}'`);
+  if (!targetCs) throw new DingusError(`unknown target coordinate system '${target}'`);
+
+  const sourceIdx = spatialAxisIndices(sourceCs);
+  const targetIdx = spatialAxisIndices(targetCs);
+
+  const steps = findPath(scene, source, target);
+  const matrices = steps.map((step) => stepMatrix(scene, csByName, step));
+
+  const out: number[][] = coords.map((point) => {
+    let vec = toXYZ(point, sourceIdx);
+    for (const m of matrices) {
+      vec = m.transformAsPoint(vec, [0, 0, 0]) as [number, number, number];
+    }
+    const result = fromXYZ(vec, targetIdx);
+    for (const v of result) {
+      if (!Number.isFinite(v)) {
+        throw new DingusError('non-finite coordinate produced');
+      }
+    }
+    return result;
+  });
+
+  process.stdout.write(JSON.stringify({ coordinates: out }));
+}
+
+try {
+  main();
+} catch (err) {
+  if (err instanceof DingusError) emitError(err.message);
+  emitError(`unexpected error: ${String(err)}`);
+}

--- a/dev_scripts/conformance-dingus/pyproject.toml
+++ b/dev_scripts/conformance-dingus/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "spatialdata-js-transform-conformance"
+version = "0.0.0"
+description = "Dev harness: run the OME-Zarr transformations conformance suite against the SpatialData.js dingus"
+requires-python = ">=3.11"
+dependencies = []
+
+# The conformance runner (`oztc`) and its RFC-5 test cases come from the upstream
+# suite as a pinned git dependency, so SpatialData.js can run conformance on its
+# own (no sibling checkout required). Bump the rev to update.
+[dependency-groups]
+dev = [
+    "ome-zarr-transformations-conformance @ git+https://github.com/clbarnes/ome_zarr_transformations_conformance.git@6f933795aa61259c36914ff919f47d5f9255bd8d",
+]
+
+[tool.uv]
+package = false

--- a/dev_scripts/conformance-dingus/run-conformance.sh
+++ b/dev_scripts/conformance-dingus/run-conformance.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run the OME-Zarr transformations conformance suite against the SpatialData.js
+# dingus, fully self-contained via uv (no sibling checkout needed).
+#
+# The conformance suite is a pinned git dependency (see pyproject.toml). Its
+# `cases/` are bundled into the installed package at site-packages/cases, so we
+# resolve that path and pass it explicitly (the suite's "builtin cases" lookup
+# does not work for its single-module install layout).
+#
+# Usage:
+#   ./run-conformance.sh                 # run all cases
+#   ./run-conformance.sh -v -p affine    # extra args are forwarded to oztc
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"
+
+uv sync --quiet
+CASES="$(uv run python -c 'import os,sysconfig;print(os.path.join(sysconfig.get_paths()["purelib"],"cases"))')"
+if [ ! -d "$CASES" ]; then
+  echo "conformance cases not found at $CASES" >&2
+  exit 1
+fi
+exec uv run oztc "$CASES" "$@" -- "$DIR/dingus.sh"

--- a/dev_scripts/conformance-dingus/uv.lock
+++ b/dev_scripts/conformance-dingus/uv.lock
@@ -1,0 +1,23 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "ome-zarr-transformations-conformance"
+version = "0.1.2"
+source = { git = "https://github.com/clbarnes/ome_zarr_transformations_conformance.git?rev=6f933795aa61259c36914ff919f47d5f9255bd8d#6f933795aa61259c36914ff919f47d5f9255bd8d" }
+
+[[package]]
+name = "spatialdata-js-transform-conformance"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "ome-zarr-transformations-conformance" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ome-zarr-transformations-conformance", git = "https://github.com/clbarnes/ome_zarr_transformations_conformance.git?rev=6f933795aa61259c36914ff919f47d5f9255bd8d" }]

--- a/docs/docs/core/internals.mdx
+++ b/docs/docs/core/internals.mdx
@@ -192,7 +192,15 @@ These classes represent parsed transformations internally. They're returned by e
 | `Translation` | `new Translation(translation[], input?, output?)` | Translation |
 | `Affine` | `new Affine(matrix[][], input?, output?)` | Full affine |
 | `Sequence` | `new Sequence(transforms[], input?, output?)` | Composed transforms |
-| `MapAxis` | `new MapAxis(...)` | Axis remapping (stub) |
+| `Rotation` | `new Rotation(matrix[][], input?, output?)` | Rotation matrix (square, no translation) |
+| `MapAxis` | `new MapAxis(mapAxis[], input?, output?)` | Axis remapping/permutation |
+
+Not yet implemented: `byDimension`, `bijection`, `displacements`, and affine/rotation
+"by path" (parameters stored in an external zarr array). See
+[Coordinate Transformations](./transformations#supported-transformation-types)
+for the current support summary, and
+`dev_scripts/conformance-dingus/` for the RFC-5 conformance harness that tracks
+this backlog.
 
 All classes extend `BaseTransformation` and provide:
 
@@ -203,6 +211,7 @@ abstract class BaseTransformation {
   
   abstract toArray(): number[];  // 16-element column-major
   toMatrix(): Matrix4;           // Matrix4 from @math.gl/core
+  inverse(): Matrix4;            // Inverted Matrix4; throws if singular
   abstract get type(): string;
 }
 ```

--- a/docs/docs/core/transformations.mdx
+++ b/docs/docs/core/transformations.mdx
@@ -6,6 +6,28 @@ sidebar_position: 3
 
 Coordinate transformations are fundamental to SpatialData, allowing different elements to be placed in shared coordinate systems. The `@spatialdata/core` package aims to provide a comprehensive implementation of transformation classes that can be represented in the standard.
 
+## Supported transformation types
+
+| RFC-5 type | Support |
+|------------|---------|
+| `identity` | ✅ |
+| `scale` | ✅ |
+| `translation` | ✅ |
+| `affine` | ✅ (inline parameters only, not "by path") |
+| `rotation` | ✅ (inline parameters only, not "by path") |
+| `mapAxis` | ✅ |
+| `sequence` | ✅ |
+| `byDimension` | ❌ Not implemented |
+| `bijection` | ❌ Not implemented |
+| `displacements` | ❌ Not implemented |
+| affine/rotation **by path** (params in an external zarr array) | ❌ Not implemented |
+| non-spatial axes (e.g. `c`, `t`) alongside spatial ones | ⚠️ Spatial axes only; the matrix path is XYZ-only |
+
+This is validated against the upstream
+[RFC-5 OME-Zarr transformations conformance suite](https://github.com/clbarnes/ome_zarr_transformations_conformance)
+via `dev_scripts/conformance-dingus/` — see that directory's README for how to
+run it and the current pass/error/fail baseline.
+
 :::info Read-Only API
 
 The current version of `@spatialdata/core` is focused on **reading** SpatialData stores. Stores are treated as immutable—you load elements and access their transformations, but you don't construct or modify them.
@@ -57,11 +79,12 @@ abstract class BaseTransformation {
   
   abstract toArray(): number[];           // 16-element column-major array
   toMatrix(): Matrix4;                    // Matrix4 from @math.gl/core
+  inverse(): Matrix4;                     // Inverted Matrix4; throws if singular
   abstract get type(): string;            // 'identity' | 'scale' | 'translation' | etc.
 }
 ```
 
-The following transformation types are supported:
+The transformation classes are:
 
 | Type | Description |
 |------|-------------|
@@ -69,8 +92,12 @@ The following transformation types are supported:
 | `Scale` | Uniform or non-uniform scaling |
 | `Translation` | Coordinate offset |
 | `Affine` | Full affine matrix (2×3, 3×3, or 4×4 formats) |
+| `Rotation` | Rotation matrix (square, no translation) |
+| `MapAxis` | Axis remapping/permutation |
 | `Sequence` | Composition of multiple transformations |
-| `MapAxis` | Axis remapping (stub implementation) |
+
+See [Supported transformation types](#supported-transformation-types) above
+for what's not yet implemented.
 
 ## Multiscale Image Transforms
 
@@ -145,8 +172,8 @@ const transformed = matrix.transform(point);
 // Compose with another matrix
 const combined = matrix.clone().multiplyRight(otherMatrix);
 
-// Get the inverse
-const inverse = matrix.clone().invert();
+// Get the inverse (throws if the transformation is singular/non-invertible)
+const inverse = transformResult.value.inverse();
 ```
 
 ## See Also

--- a/docs/docs/core/transformations.mdx
+++ b/docs/docs/core/transformations.mdx
@@ -23,10 +23,13 @@ Coordinate transformations are fundamental to SpatialData, allowing different el
 | affine/rotation **by path** (params in an external zarr array) | ❌ Not implemented |
 | non-spatial axes (e.g. `c`, `t`) alongside spatial ones | ⚠️ Spatial axes only; the matrix path is XYZ-only |
 
-This is validated against the upstream
-[RFC-5 OME-Zarr transformations conformance suite](https://github.com/clbarnes/ome_zarr_transformations_conformance)
-via `dev_scripts/conformance-dingus/` — see that directory's README for how to
-run it and the current pass/error/fail baseline.
+We validate this against the upstream
+[`ome-zarr-transformations-conformance`](https://github.com/clbarnes/ome_zarr_transformations_conformance)
+package (pinned to
+[commit `6f93379`](https://github.com/clbarnes/ome_zarr_transformations_conformance/tree/6f933795aa61259c36914ff919f47d5f9255bd8d)),
+run via `dev_scripts/conformance-dingus/` — see that directory's README for how
+to run it and the current pass/error/fail baseline. That conformance run is the
+source of truth for the table above.
 
 :::info Read-Only API
 

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -67,6 +67,20 @@ const affineTransformSchema = z.object({
   output: coordinateSystemRefSchema.optional(),
 });
 
+const rotationTransformSchema = z.object({
+  type: z.literal('rotation'),
+  rotation: z.array(z.array(z.number())).min(2),
+  input: coordinateSystemRefSchema.optional(),
+  output: coordinateSystemRefSchema.optional(),
+});
+
+const mapAxisTransformSchema = z.object({
+  type: z.literal('mapAxis'),
+  mapAxis: z.array(z.number().int().nonnegative()).min(1),
+  input: coordinateSystemRefSchema.optional(),
+  output: coordinateSystemRefSchema.optional(),
+});
+
 /**
  * Union of base transformation types
  */
@@ -74,7 +88,9 @@ type BaseTransformation =
   | z.infer<typeof scaleTransformSchema>
   | z.infer<typeof translationTransformSchema>
   | z.infer<typeof identityTransformSchema>
-  | z.infer<typeof affineTransformSchema>;
+  | z.infer<typeof affineTransformSchema>
+  | z.infer<typeof rotationTransformSchema>
+  | z.infer<typeof mapAxisTransformSchema>;
 
 /**
  * Full transformation type including sequence (recursive)
@@ -95,6 +111,8 @@ const transformationSchema: z.ZodType<Transformation> = z.lazy(() =>
     translationTransformSchema,
     identityTransformSchema,
     affineTransformSchema,
+    rotationTransformSchema,
+    mapAxisTransformSchema,
     z.object({
       type: z.literal('sequence'),
       transformations: z.array(transformationSchema).min(1),

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -69,14 +69,30 @@ const affineTransformSchema = z.object({
 
 const rotationTransformSchema = z.object({
   type: z.literal('rotation'),
-  rotation: z.array(z.array(z.number())).min(2),
+  rotation: z
+    .array(z.array(z.number()))
+    .min(2)
+    .refine(
+      (rotation) => rotation.every((row) => row.length === rotation.length),
+      'rotation must be a square matrix (row count must equal column count)'
+    ),
   input: coordinateSystemRefSchema.optional(),
   output: coordinateSystemRefSchema.optional(),
 });
 
 const mapAxisTransformSchema = z.object({
   type: z.literal('mapAxis'),
-  mapAxis: z.array(z.number().int().nonnegative()).min(1),
+  mapAxis: z
+    .array(z.number().int().nonnegative())
+    .min(1)
+    .refine(
+      (mapAxis) => mapAxis.every((sourceIndex) => sourceIndex < mapAxis.length),
+      'mapAxis values must each be a valid axis index (< mapAxis.length)'
+    )
+    .refine(
+      (mapAxis) => new Set(mapAxis).size === mapAxis.length,
+      'mapAxis values must be unique (a one-hot permutation)'
+    ),
   input: coordinateSystemRefSchema.optional(),
   output: coordinateSystemRefSchema.optional(),
 });

--- a/packages/core/src/transformations/transformations.ts
+++ b/packages/core/src/transformations/transformations.ts
@@ -249,6 +249,19 @@ export abstract class BaseTransformation {
     return new Matrix4(this.toArray());
   }
 
+  /**
+   * Get the inverse of this transformation as a Matrix4.
+   * Throws if the transformation's matrix is singular (not invertible).
+   */
+  inverse(): Matrix4 {
+    const matrix = this.toMatrix();
+    const det = matrix.determinant();
+    if (!Number.isFinite(det) || Math.abs(det) < 1e-12) {
+      throw new Error(`Transformation of type '${this.type}' is not invertible (det=${det})`);
+    }
+    return matrix.clone().invert();
+  }
+
   /** The transformation type name */
   abstract get type(): string;
 }
@@ -410,6 +423,49 @@ export class Affine extends BaseTransformation {
   }
 }
 
+export class Rotation extends BaseTransformation {
+  readonly rotation: number[][];
+
+  constructor(rotation: number[][], input?: CoordinateSystemRef, output?: CoordinateSystemRef) {
+    super(input, output);
+    this.rotation = rotation;
+  }
+
+  get type() {
+    return 'rotation' as const;
+  }
+
+  toArray(): number[] {
+    // A rotation is a square matrix with no translation component. Reuse Affine's
+    // axis-name-aware matrix construction by appending a zero translation column.
+    const affine = this.rotation.map((row) => [...row, 0]);
+    return new Affine(affine, this.input, this.output).toArray();
+  }
+}
+
+export class MapAxis extends BaseTransformation {
+  /** For each output axis (by position), the input axis position it takes its value from. */
+  readonly mapAxis: number[];
+
+  constructor(mapAxis: number[], input?: CoordinateSystemRef, output?: CoordinateSystemRef) {
+    super(input, output);
+    this.mapAxis = mapAxis;
+  }
+
+  get type() {
+    return 'mapAxis' as const;
+  }
+
+  toArray(): number[] {
+    // mapAxis is a permutation: express it as a one-hot square matrix and reuse
+    // Affine's axis-name-aware matrix construction, same as Rotation above.
+    const affine = this.mapAxis.map((sourceIndex) =>
+      this.mapAxis.map((_, col) => (col === sourceIndex ? 1 : 0)).concat(0)
+    );
+    return new Affine(affine, this.input, this.output).toArray();
+  }
+}
+
 export class Sequence extends BaseTransformation {
   readonly transformations: BaseTransformation[];
 
@@ -432,18 +488,6 @@ export class Sequence extends BaseTransformation {
 
   toMatrix(): Matrix4 {
     return composeMatricesInApplicationOrder(this.transformations.map((t) => t.toMatrix()));
-  }
-}
-
-// MapAxis is less common, stub for now
-export class MapAxis extends BaseTransformation {
-  get type() {
-    return 'mapAxis' as const;
-  }
-
-  toArray(): number[] {
-    // TODO: implement axis mapping
-    return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
   }
 }
 
@@ -479,6 +523,12 @@ export function parseTransformEntry(t: TransformEntry): BaseTransformation {
 
     case 'affine':
       return new Affine(t.affine, input, output);
+
+    case 'rotation':
+      return new Rotation(t.rotation, input, output);
+
+    case 'mapAxis':
+      return new MapAxis(t.mapAxis, input, output);
 
     case 'sequence': {
       const children = t.transformations.map((sub: TransformEntry) => parseTransformEntry(sub));

--- a/packages/core/tests/schemas.spec.ts
+++ b/packages/core/tests/schemas.spec.ts
@@ -169,6 +169,67 @@ describe('Schema Transformations', () => {
       expect(() => coordinateTransformationSchema.parse(transform)).not.toThrow();
     });
 
+    it('should validate rotation transformation', () => {
+      const transform = [
+        {
+          type: 'rotation',
+          rotation: [
+            [0, -1],
+            [1, 0],
+          ],
+        },
+      ];
+
+      expect(() => coordinateTransformationSchema.parse(transform)).not.toThrow();
+    });
+
+    it('should reject a non-square rotation matrix', () => {
+      const transform = [
+        {
+          type: 'rotation',
+          rotation: [
+            [0, -1, 0],
+            [1, 0, 0],
+          ],
+        },
+      ];
+
+      expect(() => coordinateTransformationSchema.parse(transform)).toThrow();
+    });
+
+    it('should validate mapAxis transformation', () => {
+      const transform = [
+        {
+          type: 'mapAxis',
+          mapAxis: [1, 0],
+        },
+      ];
+
+      expect(() => coordinateTransformationSchema.parse(transform)).not.toThrow();
+    });
+
+    it('should reject mapAxis with an out-of-range index', () => {
+      const transform = [
+        {
+          type: 'mapAxis',
+          mapAxis: [0, 2],
+        },
+      ];
+
+      expect(() => coordinateTransformationSchema.parse(transform)).toThrow();
+    });
+
+    it('should reject mapAxis with duplicate values', () => {
+      const transform = [
+        {
+          type: 'mapAxis',
+          mapAxis: [0, 0],
+        },
+      ];
+
+      expect(() => coordinateTransformationSchema.parse(transform)).toThrow();
+    });
+
     it('should validate transformations with coordinate system references', () => {
       const transform = [
         {

--- a/packages/core/tests/transformations.spec.ts
+++ b/packages/core/tests/transformations.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   Affine,
+  MapAxis,
+  Rotation,
+  Scale,
   buildMatrix4FromTransforms,
   composeTransforms,
 } from '../src/transformations/transformations.js';
@@ -66,6 +69,65 @@ describe('Affine', () => {
     expect(mapped[0]).toBeCloseTo(18);
     expect(mapped[1]).toBeCloseTo(35);
     expect(mapped[2]).toBeCloseTo(0);
+  });
+});
+
+describe('Rotation', () => {
+  it('matches the RFC-5 conformance case (45deg rotation, y/x axis order)', () => {
+    const yx = {
+      name: 'input',
+      axes: [
+        { name: 'y', type: 'space' as const },
+        { name: 'x', type: 'space' as const },
+      ],
+    };
+    const transform = new Rotation(
+      [
+        [0.70710678, -0.70710678],
+        [0.70710678, 0.70710678],
+      ],
+      yx,
+      yx
+    );
+
+    // Raw input point [y=1, x=1] as an x/y/z vector (Matrix4 space): (x=1, y=1, 0).
+    const mapped = transform.toMatrix().transformPoint([1, 1, 0]);
+    // Expect raw output [y=0, x=1.41421356], i.e. xyz vector (x=1.41421356, y=0, 0).
+    expect(mapped[0]).toBeCloseTo(1.41421356);
+    expect(mapped[1]).toBeCloseTo(0);
+  });
+});
+
+describe('MapAxis', () => {
+  it('matches the RFC-5 conformance case (swap y/x)', () => {
+    const yx = {
+      name: 'input',
+      axes: [
+        { name: 'y', type: 'space' as const },
+        { name: 'x', type: 'space' as const },
+      ],
+    };
+    // output[0] (y) <- input[1] (x); output[1] (x) <- input[0] (y)
+    const transform = new MapAxis([1, 0], yx, yx);
+
+    // Raw input point [y=1, x=2] as an x/y/z vector (Matrix4 space): (x=2, y=1, 0).
+    const mapped = transform.toMatrix().transformPoint([2, 1, 0]);
+    // Expect raw output [y=2, x=1], i.e. xyz vector (x=1, y=2, 0).
+    expect(mapped[0]).toBeCloseTo(1); // x_out
+    expect(mapped[1]).toBeCloseTo(2); // y_out
+  });
+});
+
+describe('inverse', () => {
+  it('inverts a scale transformation', () => {
+    const transform = new Scale([2, 4]);
+    const inverted = transform.inverse();
+    expect(inverted.transformPoint([2, 4, 0])).toEqual([1, 1, 0]);
+  });
+
+  it('throws for a singular (non-invertible) transformation', () => {
+    const transform = new Scale([0, 4]);
+    expect(() => transform.inverse()).toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a "dingus" dev harness (`dev_scripts/conformance-dingus/`) that validates SpatialData.js's transform computation against the upstream [RFC-5 OME-Zarr transformations conformance suite](https://github.com/clbarnes/ome_zarr_transformations_conformance) (pinned via `uv`, no external checkout needed).
- Implements the top three items on that harness's own backlog in `packages/core/src/transformations/transformations.ts`:
  - `Rotation` and `MapAxis` transform classes (plus schema support), both built by reusing `Affine`'s existing axis-name-aware matrix construction.
  - A native `BaseTransformation.inverse()` method, so reverse-edge traversal no longer needs a generic dingus-level 4x4 invert.
- Conformance baseline moves from 18 pass / 23 error / 0 fail → **24 pass / 17 error / 0 fail**, with 0 numerical regressions. `baseline-results.tsv` and the README are updated to match.
- Adds unit tests for `Rotation`, `MapAxis`, and `inverse()`, cross-checked against the conformance suite's exact expected coordinates.
- Docs:
  - New "Supported transformation types" summary at the top of `docs/docs/core/transformations.mdx`, and a matching "Current support" summary at the top of the dingus README — both cite the specific pinned conformance-suite commit as the source of truth.
  - Fixes stale docs that still described `MapAxis` as a stub and didn't mention `Rotation` or `inverse()`.
  - Adds a "Maintenance" section documenting how to bump the pinned suite revision and how to tell an expected new `error` row apart from a real `fail` regression.
- Adds a `docs` entry to `.claude/launch.json` so the docs site can be previewed (alongside the existing `vis-demo` entry).

Remaining backlog (`byDimension`, `bijection`, `displacements`, "by path" params, non-spatial axes) is intentionally out of scope for this PR — tracked in the dingus README's maturation backlog.

## Test plan

- [x] `pnpm exec vitest run tests/transformations.spec.ts` in `packages/core` — 9/9 pass
- [x] `./dev_scripts/conformance-dingus/run-conformance.sh` — 24 pass / 17 error / 0 fail (verified against real RFC-5 cases)
- [x] `pnpm build` at the repo root, then previewed `docs/core/transformations` and `docs/core/internals` via the docs dev server — renders correctly, no console/build errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional transformation types, including rotation and axis remapping.
  * Introduced a conformance check workflow for validating coordinate transforms against a reference suite.

* **Bug Fixes**
  * Improved inverse transformation handling, including clearer failures for non-invertible cases.

* **Documentation**
  * Expanded transformation docs with updated support details, examples, and API guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->