### PR TITLE
Points render path: composite + PointsDataEngine + size/overdraw controls

### DIFF
--- a/.changeset/points-render-path-engine.md
+++ b/.changeset/points-render-path-engine.md
@@ -1,0 +1,39 @@
+---
+"@spatialdata/core": patch
+"@spatialdata/layers": patch
+"@spatialdata/vis": patch
+---
+
+Points/transcript rendering pipeline: composite layer, loading engine, and size controls.
+
+Points elements now render through the `@spatialdata/layers` `PointsLayer`
+composite (ADR 0003) instead of the flat inline scatter renderer, reached via a
+store-agnostic `resolvePointsRenderResource` boundary.
+
+- **`@spatialdata/core`** gains the points I/O foundation: bounded/capped
+  loading on `PointsElement` (`loadPoints`, `loadPointsInBounds`,
+  `listFeatures`, aligned row feature codes), Morton tiling metadata, a
+  dictionary-aware feature catalog, and an **opt-in** points worker for
+  off-thread parquet decode/scan. parquet-wasm is now vendored (replacing the
+  npm/CDN dependency) and large reads use row-group range reads with column
+  projection.
+- **`@spatialdata/layers`** owns the render strategies (preloaded scatter,
+  Morton-tiled, GeoArrow stubs), the `PointsLayer` composite, tile-debug
+  overlay, and a new framework-agnostic **`PointsDataEngine`** that holds the
+  points cache, the stable render-resource memo, and the async load
+  orchestration (the first sub-engine of the LayerDataEngine decomposition —
+  React-free and unit-tested).
+- **`@spatialdata/vis`** renders points through the composite/engine and adds a
+  **point size** control to the SpatialCanvas layer panel. Preloaded points are
+  sized in world units so the GPU scales them with zoom (reducing scatter
+  overdraw when zoomed out), clamped to a pixel range.
+
+Fixes surfaced while wiring this up: forever-loading transcripts (the points
+worker is now opt-in), a stale-disabled "Center on layer" button for
+freshly-loaded layers, a per-frame layer flash while panning, and a deck.gl
+sublayer id-collision assertion.
+
+Not yet wired into the UI (present in `core`/`layers`, follow-up — see
+`docs/plans/points-mvp-and-roadmap.md`): feature filtering, colour-by-feature,
+per-point tooltips, and the Morton *tiled* render path (points currently load as
+a capped preload).

--- a/.changeset/points-render-path-engine.md
+++ b/.changeset/points-render-path-engine.md
@@ -4,36 +4,13 @@
 "@spatialdata/vis": patch
 ---
 
-Points/transcript rendering pipeline: composite layer, loading engine, and size controls.
+Points/transcript rendering: composite layer, loading engine, and size controls.
 
-Points elements now render through the `@spatialdata/layers` `PointsLayer`
-composite (ADR 0003) instead of the flat inline scatter renderer, reached via a
-store-agnostic `resolvePointsRenderResource` boundary.
-
-- **`@spatialdata/core`** gains the points I/O foundation: bounded/capped
-  loading on `PointsElement` (`loadPoints`, `loadPointsInBounds`,
-  `listFeatures`, aligned row feature codes), Morton tiling metadata, a
-  dictionary-aware feature catalog, and an **opt-in** points worker for
-  off-thread parquet decode/scan. parquet-wasm is now vendored (replacing the
-  npm/CDN dependency) and large reads use row-group range reads with column
-  projection.
-- **`@spatialdata/layers`** owns the render strategies (preloaded scatter,
-  Morton-tiled, GeoArrow stubs), the `PointsLayer` composite, tile-debug
-  overlay, and a new framework-agnostic **`PointsDataEngine`** that holds the
-  points cache, the stable render-resource memo, and the async load
-  orchestration (the first sub-engine of the LayerDataEngine decomposition —
-  React-free and unit-tested).
-- **`@spatialdata/vis`** renders points through the composite/engine and adds a
-  **point size** control to the SpatialCanvas layer panel. Preloaded points are
-  sized in world units so the GPU scales them with zoom (reducing scatter
-  overdraw when zoomed out), clamped to a pixel range.
-
-Fixes surfaced while wiring this up: forever-loading transcripts (the points
-worker is now opt-in), a stale-disabled "Center on layer" button for
-freshly-loaded layers, a per-frame layer flash while panning, and a deck.gl
-sublayer id-collision assertion.
-
-Not yet wired into the UI (present in `core`/`layers`, follow-up — see
-`docs/plans/points-mvp-and-roadmap.md`): feature filtering, colour-by-feature,
-per-point tooltips, and the Morton *tiled* render path (points currently load as
-a capped preload).
+Points elements render through the `@spatialdata/layers` `PointsLayer` composite
+(ADR 0003) via a store-agnostic `resolvePointsRenderResource` boundary, backed by
+a new React-free `PointsDataEngine` that owns points loading, caching, and
+render-resource resolution. `@spatialdata/core` gains the points I/O foundation
+(bounded/capped loading, Morton tiling metadata, feature catalog, an opt-in
+worker, and vendored parquet-wasm with row-group range reads). SpatialCanvas adds
+a point-size control; preloaded points are sized in world units so they scale
+with zoom, clamped to a pixel range.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,26 @@ _Avoid_: serializable prop, stack entry prop
 A small MDV/control-layer UI area that edits observable state directly while passing plain values through renderer and third-party boundaries.
 _Avoid_: MobX renderer contract
 
+**Points Feature**:
+The categorical identity of a point, read from the points parquet column named by that element's `.zattrs` `feature_key` (e.g. `feature_name` — a gene/transcript species). This is the key that points **filter** and **colour-by** operate on. Distinct from the shape/table sense of "feature" (a column of an annotation `table`); a points element usually has no annotation table — the point *is* its own row.
+_Avoid_: assuming the column is literally `feature_name`; conflating with table-annotation features or `table.vars`
+
+**Feature Code**:
+An integer standing in for a **Points Feature** value. Authoritative only when the store emits an explicit `{feature_key}_codes` column (e.g. `feature_name_codes`), which is a global namespace aligned with the feature catalog. A dictionary-encoded `feature_key` column is **not** a code source: its dictionary indices are local to a chunk/row-group/part and must be mapped through the catalog by decoded string, never treated as global codes.
+_Avoid_: treating dictionary indices as global codes
+
+**Instance Key**:
+The points parquet column named by `.zattrs` `instance_key` (e.g. `cell_id`) — the instance a point belongs to. Reserved for future instance/table linking; not used in the current MVP.
+_Avoid_: wiring instance-key behaviour into MVP filter/colour/tooltip
+
+**Point Attribute Column**:
+Any other column of the same points parquet row (`x`, `y`, `z`, `qv`, `overlaps_nucleus`, …), surfaced in a per-point **tooltip**. Not the filter/colour key.
+_Avoid_: calling the points tooltip a "feature tooltip"; pulling tooltip values from a joined table in MVP
+
+**Feature Highlight**:
+Transient, interactive emphasis of *all* points belonging to one chosen **Points Feature** (e.g. hovering a gene in the catalog panel brightens its points and de-emphasises the rest). It is ephemeral **runtime** state — a cheap recolor/re-emphasis of the already-resident batch with **no reload or refilter** — not part of the serializable colour encoding or **Render Stack** config. Distinct from deck.gl `autoHighlight`, which emphasises a single *picked point*, not a whole feature.
+_Avoid_: persisting highlight into the Stack Entry; conflating with per-object `autoHighlight`; reloading geometry on highlight change
+
 ## Relationships
 
 - A **Render Stack** contains zero or more ordered **Stack Entries**.

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,6 @@
     "@docusaurus/preset-classic": "3.9.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "parquet-wasm": "catalog:",
     "prism-react-renderer": "^2.3.0",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/docs/plans/layer-data-engine-decomposition.md
+++ b/docs/plans/layer-data-engine-decomposition.md
@@ -1,0 +1,189 @@
+# LayerDataEngine decomposition — moving orchestration out of the vis god-hook
+
+**Status:** proposed (not started)
+**Related:** [ADR 0002](../adr/0002-spatially-aware-vector-loading.md), [ADR 0003](../adr/0003-points-render-resource.md), [points preload & feature filter status](points-preload-feature-filter-status.md)
+
+This plan addresses a structural problem surfaced while trying to rebase the
+oversized points-loading branch onto current `main`: **substantial data-loading,
+caching, and orchestration logic lives inside a React hook in `@spatialdata/vis`
+(`SpatialCanvas/useLayerData.ts`) when it should sit at the `@spatialdata/layers`
+level.** The render strategies and store loaders are already correctly placed;
+the *orchestration/resolver* layer on top of them is not.
+
+---
+
+## What is already correctly placed (do not touch)
+
+The points **render** path was decomposed along ADR 0003's lines and is fine:
+
+| Layer | Owns | Files |
+|-------|------|-------|
+| `@spatialdata/core` | Store I/O loaders | `pointsLoader`, `pointsTiling`, `pointsFeatures`, `pointsLimits`, `pointsLoadOptions`, `parquetWasmLoader`, `VPointsSource` (`loadPoints`, `loadRowFeatureCodes`, `listFeatures`, `loadPointsInBounds`) |
+| `@spatialdata/layers` | Render strategies + deck composite | `preloadedScatterStrategy`, `mortonTiledStrategy`, `geoArrowStrategies`, `pointsLoaderAdapter`, `pointsRenderStrategies`, `pointsScatterLayer`, `PointsLayer`, tile-debug modules |
+
+`layers` has **no React dependency** (deck.gl only) — confirmed by absence of any
+`from 'react'` import in `packages/layers/src`. This is what makes it a valid home
+for a framework-agnostic engine.
+
+---
+
+## What is mis-placed
+
+The **orchestration / resolver layer** — deciding *what* to load, caching it, and
+resolving it into render resources — is scattered across `vis/SpatialCanvas`:
+
+- **`useLayerData.ts`** — ~2281 lines on the WIP branch (~1652 on `main`), with
+  **6 `useEffect`, 16 `useRef`, 3 `useMemo`**. It holds an 8-map cache
+  (`loadedDataRef`: `shapes`, `points`, `pointTilingMetadata`, `images`, `labels`,
+  `shapePrebuiltData`, `shapeFillColorData`, `worldBounds`) plus signature and
+  stable-reference caches, and orchestrates preload → catalog → row-codes → filter
+  for every element type. The WIP branch added **~286 lines of points
+  orchestration** into this hook (vs ~13 for shapes).
+- **`pointsLoadPlan.ts`** and **`resolvePointsRenderResource.ts`** — already
+  React-free, importing only `@spatialdata/core` and `@spatialdata/layers`, but
+  filed under `vis`.
+
+### Why this is wrong
+
+1. **Framework-agnostic logic is welded to React.** The cache and orchestration
+   are plain data structures and async flows; they live inside a hook as
+   `useRef`/`useEffect` purely for lifetime management. React is the only reason
+   they are in `vis`.
+2. **Unreachable and untestable headless.** `main` already ships a headless
+   viewer, but none of this logic can run from it, and none of it has unit tests
+   because it is trapped in a hook.
+3. **It contradicts ADR 0003.** The ADR specifies a *thin* vis resolver that
+   "associates element + loader" and "probes once and returns a bundle
+   `{ element, loader }`". That resolver has become a god-hook. Shapes
+   (`loadShapesLayerData`, `loadShapeFillColorData`, feature-state merge) were
+   never extracted at all.
+
+---
+
+## Target decomposition
+
+| Concern | Today | Target home |
+|---------|-------|-------------|
+| Store I/O loaders (`loadPoints`, `loadPointsInBounds`, `listFeatures`, row codes) | `core` ✓ | **`core`** (keep) |
+| Render strategies + `PointsLayer` | `layers` ✓ | **`layers`** (keep) |
+| Load-plan + render-resource resolution (`pointsLoadPlan`, `resolvePointsRenderResource`) | `vis` (React-free already) | **`layers`** — move verbatim |
+| Loaded-data cache (8 maps, world-bounds, signatures) | `vis` (React refs) | **`layers`** — plain cache, no React |
+| Preload / catalog / row-code orchestration (~286 lines) | `vis` hook effects | **`layers`** — engine methods |
+| Shape fill-color, feature-state merge/runtime, pick-event shaping | `vis` hook | **`layers`** (render-domain) |
+| React binding: subscribe, trigger on config change, return props | `vis` | **`vis`** — thin hook only |
+
+### The unifying move: `LayerDataEngine`
+
+A framework-agnostic **`LayerDataEngine`** in `@spatialdata/layers` owns the cache
+and orchestration behind an imperative API. Rough shape:
+
+```ts
+interface LayerDataEngine {
+  // Feed it the current desired state (layer configs, coordinate system, viewport).
+  updateConfig(input: LayerDataInput): void;
+  // Pull current render inputs (deck layer props / render resources) synchronously.
+  getLayerInputs(): LayerInputs;
+  // Notify when async loads settle so a host can re-render / re-pull.
+  subscribe(listener: () => void): () => void;
+  // Load-state introspection for UI (durations, pending/loaded/error per layer).
+  getLoadState(): LayerLoadState;
+  dispose(): void;
+}
+```
+
+- The engine holds what is today `loadedDataRef` and the signature/stable-ref
+  caches as **plain fields** — no React.
+- It calls `core` loaders and `layers` strategies; it does not import React or
+  deck React bindings.
+- `useLayerData` collapses to a **thin adapter**: create/hold the engine in a
+  ref, call `updateConfig` in one effect, `subscribe` to force re-render, return
+  `getLayerInputs()` / `getLoadState()`. Target well under a few hundred lines.
+
+Because `layers` is React-free, the engine is unit-testable and usable from the
+headless viewer.
+
+---
+
+## Why this is worth doing (beyond tidiness)
+
+The engine is the seam the two roadmap goals need:
+
+- **FBO splatting** ([ADR 0003 "FBO-based render caching"](../adr/0003-points-render-resource.md))
+  plugs in here — the engine's tile cache becomes "splat tile → framebuffer"
+  instead of threading tile state through React. Reusable framebuffer helpers
+  attach to the engine, not the hook.
+- **MDV "active link"** (selected genes ↔ `table.vars`) lives here — the engine
+  keeps cached points resident, so a gene-selection recolor is an engine call,
+  not a geometry reload. The same cache is the pick buffer.
+
+So this decomposition is groundwork for the FBO redo, not a detour from it.
+
+---
+
+## Sequencing
+
+1. **Move the two React-free resolver modules into `layers`.** `pointsLoadPlan.ts`
+   and `resolvePointsRenderResource.ts` already import only from `core`/`layers`
+   and import `layers`' own `createPointsRenderResource` — they move `vis → layers`
+   essentially verbatim, with near-zero behavioral risk. Re-export from `vis` if
+   any external consumer imports them. **Proof-of-direction; do this first.**
+2. **Introduce `LayerDataEngine` in `layers`** with the cache + points
+   orchestration extracted from `useLayerData`. Convert the points path of the
+   hook to a thin binding over the engine. Add unit tests exercised without React.
+3. **Migrate shapes** (`loadShapesLayerData`, `loadShapeFillColorData`,
+   feature-state merge/runtime, pick-event shaping) into the engine the same way.
+4. **Migrate images/labels** orchestration for completeness, so the hook is a
+   uniform thin adapter across all four element types.
+5. **Plug the FBO points path into the engine** (separate plan) rather than into
+   the hook.
+
+Land this **through** the decomposition rather than by mechanically rebasing the
+old branch's hook changes onto current `main`. The mechanical rebase was attempted
+and abandoned (see "Provenance" below); it would have poured effort into the
+god-hook we intend to dismantle.
+
+---
+
+## Risks and constraints
+
+- **`vis` public API / MDV.** Some symbols (e.g. `LayerLoadState`,
+  `useSpatialCanvasRendererFromLayerInputs`, pick-event types) are consumed by
+  MDV (see the Track A public-API work). Keep `vis` re-exporting anything moved,
+  or coordinate the move with the MDV integration. Do not silently relocate an
+  exported type out of `vis`.
+- **Behavioral parity first.** Extract without changing load behavior, so the
+  known-broken basic points loading and the Morton-slowness questions can be
+  diagnosed against a faithful port. Performance/strategy changes come after.
+- **Cache lifetime.** React refs currently pin cache lifetime to the hook/component.
+  The engine must be explicitly created/disposed by the host; get disposal right
+  to avoid leaks across coordinate-system / dataset switches.
+- **Incremental, not big-bang.** Each step (1–4) should build and pass tests on
+  its own so the branch never sits in a broken intermediate state for long.
+
+---
+
+## Open questions
+
+1. Does `LayerDataEngine` belong at the top level of `@spatialdata/layers`, or in
+   a dedicated submodule (e.g. `layers/src/engine/`)? Leaning submodule.
+2. Should the engine be one object across all element types, or composed of
+   per-type sub-engines (points/shapes/images/labels) behind a facade? Composed is
+   likely cleaner and matches the migration order.
+3. How much of the load-state/timing UI contract (`LayerLoadState`,
+   `formatLoadDurationMs`, `GeometryLoadStats`) should move vs. stay as a vis
+   presentation concern reading engine state?
+4. Where do the still-open ADR 0002/0003 strategy-selection questions
+   (feature-primary vs Morton vs preloaded) get decided — engine `updateConfig`
+   input, or resolver probe? Probably the resolver, now living in `layers`.
+
+---
+
+## Provenance
+
+Discovered 2026-07-03 while assessing whether to rebase the points-loading branch
+(`backup/points-wip-20260702`) onto current `main` after its safe slices were
+harvested into separate PRs (#75 default-CS, #76 experimental-writer, #77 ADRs).
+A mechanical reconstruction (bring 74 render-path code files onto current `main`,
+3-way-merging 8 overlap files) was set up and then abandoned in favour of this
+decomposition. The WIP is preserved on branch `claude/quizzical-roentgen-3ee079`
+and tag `backup/points-wip-20260702`.

--- a/docs/plans/layer-data-engine-decomposition.md
+++ b/docs/plans/layer-data-engine-decomposition.md
@@ -122,11 +122,22 @@ So this decomposition is groundwork for the FBO redo, not a detour from it.
 
 ## Sequencing
 
-1. **Move the two React-free resolver modules into `layers`.** `pointsLoadPlan.ts`
-   and `resolvePointsRenderResource.ts` already import only from `core`/`layers`
-   and import `layers`' own `createPointsRenderResource` — they move `vis → layers`
-   essentially verbatim, with near-zero behavioral risk. Re-export from `vis` if
-   any external consumer imports them. **Proof-of-direction; do this first.**
+> **Correction (2026-07-03):** current `main` is **bare of the entire points
+> render path** — none of the `core` loaders or `layers` strategies exist there
+> (the harvest took only python/docs/default-CS). So the two resolver modules
+> cannot move to `layers` in isolation; their dependency chain is absent. The
+> reconstruction must proceed in dependency order, core-first. Revised steps:
+
+0. **DONE — `core` points I/O foundation** (commit `4cc91eb`). Points
+   loaders/tiling/features + worker, bounded/capped loading on
+   `VPointsSource`, and the vendored parquet-wasm, brought onto current `main`.
+   Typecheck clean, 120 core tests pass. This is the dependency root.
+1. **`layers` strategies + relocate the two resolver modules here.** Bring the
+   render strategies (`preloadedScatterStrategy`, `mortonTiledStrategy`,
+   `geoArrowStrategies`, `pointsLoaderAdapter`, `PointsLayer`, tile-debug) onto
+   `main`, and land `pointsLoadPlan.ts` + `resolvePointsRenderResource.ts` in
+   `layers` (not `vis`) — they already import only `core`/`layers`, so this is
+   the proof-of-direction placement. Re-export from `vis` for MDV consumers.
 2. **Introduce `LayerDataEngine` in `layers`** with the cache + points
    orchestration extracted from `useLayerData`. Convert the points path of the
    hook to a thin binding over the engine. Add unit tests exercised without React.

--- a/docs/plans/points-mvp-and-roadmap.md
+++ b/docs/plans/points-mvp-and-roadmap.md
@@ -1,0 +1,137 @@
+# Points MVP & roadmap
+
+**Status:** agreed (grilling session 2026-07-06); implementation not started
+**Related:** [CONTEXT.md](../../CONTEXT.md) (domain terms), [ADR 0002](../adr/0002-spatially-aware-vector-loading.md), [ADR 0003](../adr/0003-points-render-resource.md), [LayerDataEngine decomposition](layer-data-engine-decomposition.md), [points preload & feature filter status](points-preload-feature-filter-status.md)
+
+This document defines the **minimum viable feature set** for interactive points
+(transcript) layers and the roadmap around it. It is the product-scope companion
+to the [LayerDataEngine decomposition](layer-data-engine-decomposition.md) plan,
+which owns the *structural* mechanics; this doc owns *what we ship and in what
+order*.
+
+Domain terms (**Points Feature**, **Feature Code**, **Point Attribute Column**,
+**Feature Highlight**, **Instance Key**) are defined in [CONTEXT.md](../../CONTEXT.md)
+and used here without re-definition. Note in particular: a **Points Feature** is
+the value of the column named by the element's `.zattrs` `feature_key` — *not
+assumed to be a gene name* (it may be a protein, probe, or arbitrary categorical
+label).
+
+---
+
+## MVP feature set
+
+| # | Capability | Keys on | New vs reuse | Data-flow |
+|---|------------|---------|--------------|-----------|
+| 1 | **Filter** by Points Feature | Feature Code / catalog | wire existing composite `featureCodes` | in-memory filter over the preloaded batch (preloaded scatter); per-tile `featureCodes` in the viewport (Morton) |
+| 2 | **Colour** by Points Feature — auto palette | Feature Code | **new** in `pointsScatterLayer` | serializable colour encoding on the Stack Entry; `getFillColor` keyed by Feature Code; palette cycles on overflow (collisions accepted) |
+| 2b | **Feature Highlight** (interactive) | Feature Code | **new** | *runtime/ephemeral* `highlightedFeatureCode`; `updateTriggers` on colour/size accessors; **no reload / no refilter** |
+| 3 | **Identify** — hover → Points Feature value | resident batch | pick-wire + reuse tooltip UI | deck hover pick → catalog label for the point's Feature Code; drag-gated like shapes |
+
+**Substrate:** all three ride the `@spatialdata/layers` **`PointsLayer` composite**
+(reached via `resolvePointsRenderResource`), *not* the legacy flat
+`renderPointsLayer`. The composite already models filter + pick and is where the
+future FBO strategy slots in (ADR 0003), so this wiring is not throwaway.
+
+### Why colour + highlight instead of a big palette
+
+A transcript catalog is ~hundreds of features; a categorical palette offers
+~20–40 distinguishable hues. We do **not** try to give every feature a unique
+colour. Distinguishability comes from **interaction**: an auto palette makes the
+layer pleasant, and **Feature Highlight** lets the user pull one feature out of
+the crowd on demand. Highlight is a *cheap recolor of the already-resident batch*
+— the same "recolor without reload" path the FBO redo and the MDV active-link
+both depend on, so this small MVP interaction de-risks the big roadmap items.
+
+### Colour is serializable; highlight is runtime
+
+- **Colour encoding** (`{ mode: 'flat', color } | { mode: 'by-feature', palette }`)
+  is serializable `entry.props` — it persists in the Render Stack.
+- **Feature Highlight** is transient runtime state (a **Runtime Attachment** /
+  MobX Control Island concern) — it must **not** persist into the Stack Entry.
+
+This split is captured in [CONTEXT.md](../../CONTEXT.md); it is deliberate and
+load-bearing (it decides what MDV can drive live vs what a saved config carries).
+
+---
+
+## Cross-cutting constraints (in MVP)
+
+- **Frame-budget rule.** Nothing blocks the main thread for a significant time.
+  Aim for the frame budget; a ~500ms hitch on an *explicit button press* is the
+  outer tolerance, anything worse is a defect. The historical **~30s catalog
+  stall** on plain 12M-row `transcripts` is a *symptom of building the dictionary
+  on the main thread*, not an inherent cost.
+- **Worker offload + status reporting.** Catalog build and parquet decode run on
+  the points worker, with coherent load-state/progress surfaced to the UI. This
+  promotes the status doc's P1 ("unify worker policy") and the load-state UI into
+  MVP scope. (Worker is opt-in per host after commit `8829ff9`; the demo enables
+  it — a dead/opted-in worker must still fall back via a **timeout**, not hang.)
+- **Two independent perf axes** — do not conflate:
+  - *Load-time blocking* (catalog/decode) → worker offload + status. **In MVP.**
+  - *Draw-time overdraw* (zoomed-out, deck redraws every point every frame) →
+    proper fix is **FBO tile rasterisation** (ADR 0003), **post-MVP**. MVP
+    stopgap: **filter-reduces-overdraw** (the dominant "few features" use case
+    draws far fewer points) + existing render cap + point-size control. No LOD /
+    decimation in MVP.
+
+---
+
+## Deferred (noted, not MVP)
+
+- **Configurable Point Attribute Column tooltip** — full "option C": a
+  `TooltipFieldsPanel`-driven set of attribute columns loaded *aligned to the
+  resident batch* (same pattern as `loadRowFeatureCodes`), pick → O(1) index.
+  This is the only genuinely new *loader* work in the tooltip story, hence
+  deferred. Reuses `TooltipFieldsPanel`, `SpatialFeatureTooltip`,
+  `SpatialFeatureTooltipData`. When built, the tooltip-column set becomes
+  serializable config.
+- **Lazy per-row attribute fetch** — "option B": fetch a single picked row's
+  columns on demand. Needs **row-addressable parquet reads** (row-group +
+  in-group offset), awkward for the dictionary/multipart layout. Post-MVP.
+- **Manual per-Feature colour assignment** (click a feature → pick its colour).
+- **MDV active-link** — Points Feature ↔ `table.vars`. There is (as far as we
+  know) no schema mechanism expressing this relationship; it is a
+  community-discussion item and a research question, not MVP. The MVP's
+  resident-batch + Feature Highlight is the substrate it will later plug into.
+- **Instance Key behaviour** (`instance_key`, e.g. `cell_id`) — reserved.
+- **FBO tile rasterisation** for overdraw (separate plan; ADR 0003 §FBO).
+- **Feature-primary / compound index strategy selection** — the open ADR
+  0002/0003 question of how the resolver chooses among preloaded / Morton /
+  feature-primary and how writers advertise indexes.
+
+---
+
+## Implementation sequence
+
+Each step builds and passes tests on its own; the branch never sits broken.
+
+1. **Parity slice.** Extract a **points-only** `LayerDataEngine` into
+   `@spatialdata/layers` (cache + orchestration as plain fields, no React), wire
+   the composite via `resolvePointsRenderResource`, and replace the legacy
+   `renderPointsLayer` call in `useLayerData`. **Acceptance: points still draw and
+   "Center on layer" still works, with no behaviour change**; add headless unit
+   tests that were impossible against the hook. Leave shapes/images/labels on the
+   existing hook path (decompose only what we touch). Commit.
+2. **Filter.** Catalog build (worker + status) → `featureCodes` → composite
+   filter. Filter/catalog panel UI (points equivalent of the shape panels).
+3. **Colour + Highlight.** Auto-palette `by-feature` colour encoding (serializable)
+   in `pointsScatterLayer`; runtime `highlightedFeatureCode` wired to
+   `updateTriggers`; catalog-panel hover drives highlight.
+4. **Identify tooltip.** Hover pick → Points Feature value via the catalog label,
+   rendered through the existing tooltip UI, drag-gated via `featureTooltipHover`.
+
+Steps 2–4 progressively apply the target design (engine-owned orchestration) to
+exactly the functionality being touched, per the incremental decomposition
+strategy — not a big-bang rewrite of the god-hook.
+
+---
+
+## Open questions (carried, not blocking MVP)
+
+1. Default filter state on first load — all features on, or a bounded subset
+   when the catalog is large? (Leaning: all on, since filter is the overdraw
+   escape hatch and "all on" is the least surprising.)
+2. Worker-backed catalog: dictionary-from-metadata fast path vs. same-bytes
+   off-thread decode. (Status doc P0 recommends metadata fast path first.)
+3. Engine submodule placement and one-object-vs-per-type facade — deferred to the
+   decomposition plan's open questions.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,10 +9,18 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./workers": {
+      "types": "./dist/workers/index.d.ts",
+      "import": "./dist/workers/index.js"
+    },
+    "./points-worker": {
+      "import": "./dist/points-worker.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "vendor"
   ],
   "publishConfig": {
     "access": "public"
@@ -31,7 +39,6 @@
     "anndata.js": "catalog:",
     "apache-arrow": "catalog:",
     "ol": "^10.6.1",
-    "parquet-wasm": "catalog:",
     "zarrita": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,44 @@ export * from './types.js';
 export * from './store/index.js';
 export * from './models/index.js';
 export * from './spatialViewFit.js';
+export * from './pointsTiling.js';
+export { mergeFeatureCountsIntoCatalog } from './pointsFeatures.js';
+export {
+  POINTS_PRELOAD_MAX_ROWS,
+  DEFAULT_POINTS_MEMORY_CAP,
+  DEFAULT_POINTS_RENDER_CAP,
+  PointsPreloadTooLargeError,
+  applyRenderCapToColumnar,
+  exceedsPointsPreloadLimit,
+  pointsPreloadTruncatedMessage,
+  pointsFilteredMemoryCapMessage,
+  preloadedColumnarPointCount,
+  resolvePointsMemoryCap,
+  resolvePointsRenderCap,
+} from './pointsLimits.js';
+export type { PointsLoadOptions, PointsLoadProgress, PointsLoadResult } from './pointsLoadOptions.js';
+export {
+  enablePointsWorker,
+  disablePointsWorker,
+  ensurePointsWorker,
+  filterColumnarByFeatureCodesInWorker,
+  isPointsWorkerEnabled,
+  setPointsWorkerDefaultEnabled,
+} from './workers/index.js';
+export {
+  createMortonTiledPointsLoader,
+  createPointsLoaderForElement,
+  createPreloadedColumnarPointsLoader,
+  resolvePointsEncoding,
+  type CorePointsLoader,
+  type ColumnarNdarrayPointsBatch,
+  type PreloadedColumnarInput,
+  type PointsBatch,
+  type PointsBatchFormat,
+  type PointsEncodingKind,
+  type PointsLoadInBoundsOptions,
+  type PointsLoaderCapabilities,
+} from './pointsLoader.js';
 export * from './shapes.js';
 export {
   inferShapesGeometryKindFromParquet,

--- a/packages/core/src/models/VPointsSource.ts
+++ b/packages/core/src/models/VPointsSource.ts
@@ -1,5 +1,94 @@
-import type { Axis } from '../schemas';
 import { basename } from '../Vutils';
+import {
+  buildFeatureCatalogFromColumns,
+  featureCodeMapFromCatalog,
+  mergeFeatureCountsIntoCatalog,
+  resolveRowFeatureCodesFromTable,
+} from '../pointsFeatures.js';
+import {
+  decodeParquetGeometryCappedInWorker,
+  decodeParquetRowFeatureCodesInWorker,
+  ensurePointsWorker,
+  isPointsWorkerEnabled,
+  scanMortonRowGroupsInBoundsInWorker,
+  scanParquetByFeatureCodesInWorker,
+  scanParquetFeatureCatalogInWorker,
+  scanParquetFeatureCountsInWorker,
+} from '../workers/pointsWorkerClient.js';
+import { exceedsPointsPreloadLimit, resolvePointsMemoryCap } from '../pointsLimits.js';
+import type {
+  PointsLoadOptions,
+  PointsLoadProgress,
+  PointsLoadResult,
+} from '../pointsLoadOptions.js';
+
+interface ColumnarPointsChunk {
+  shape: number[];
+  data: ArrayLike<number>[];
+}
+
+function emptyFilteredPointsResult(axisNames: string[], totalRowCount: number): PointsLoadResult {
+  const hasZ = axisNames.includes('z');
+  const empty = new Float32Array(0);
+  const data = hasZ ? [empty, empty, empty] : [empty, empty];
+  return {
+    shape: [data.length, 0],
+    data,
+    totalRowCount,
+    scannedRowCount: 0,
+    filterActive: true,
+  };
+}
+
+function toColumnarPointsChunk(
+  data: { shape?: number[]; data: ArrayLike<number>[] },
+  axisCount: number
+): ColumnarPointsChunk {
+  const rowCount = data.shape?.[1] ?? data.data[0]?.length ?? 0;
+  return {
+    shape: data.shape ?? [axisCount, rowCount],
+    data: data.data,
+  };
+}
+
+function concatColumnarPointChunks(chunks: ColumnarPointsChunk[]): ColumnarPointsChunk {
+  if (chunks.length === 0) {
+    const empty = new Float32Array(0);
+    return { shape: [2, 0], data: [empty, empty] };
+  }
+  const axisCount = chunks[0].shape[0] ?? chunks[0].data.length;
+  const totalRows = chunks.reduce(
+    (sum, chunk) => sum + (chunk.shape[1] ?? chunk.data[0]?.length ?? 0),
+    0
+  );
+  const data = Array.from({ length: axisCount }, (_, axisIndex) => {
+    const merged = new Float32Array(totalRows);
+    let offset = 0;
+    for (const chunk of chunks) {
+      const column = chunk.data[axisIndex];
+      if (!column) {
+        continue;
+      }
+      const values = column instanceof Float32Array ? column : Float32Array.from(column);
+      merged.set(values, offset);
+      offset += values.length;
+    }
+    return merged;
+  });
+  return { shape: [axisCount, totalRows], data };
+}
+import {
+  MORTON_CODE_2D_COLUMN,
+  type PointsInBoundsOptions,
+  type PointsInBoundsResponse,
+  type PointsFeatureCatalog,
+  type PointsTilingMetadata,
+  extractSentinelBoundingBox,
+  featureCodeAllowSet,
+  filterPointsToBounds,
+  mortonIntervalsForBounds,
+} from '../pointsTiling.js';
+import type { Axis } from '../schemas';
 // import { normalizeAxes } from '@vitessce/spatial-utils';
 import SpatialDataTableSource from './VTableSource';
 
@@ -68,7 +157,42 @@ function getParquetPath(arrPath?: string) {
   throw new Error(`Cannot determine parquet path for points array path: ${arrPath}`);
 }
 
+function arrowSchemaFieldNames(table: { schema: { fields?: Array<{ name?: unknown }> } } | null) {
+  return (
+    table?.schema.fields?.flatMap((field) =>
+      typeof field.name === 'string' ? [field.name] : []
+    ) ?? []
+  );
+}
+
+function selectFeatureCodeColumn(fields: string[], featureKey: string | undefined) {
+  const candidates = [
+    featureKey ? `${featureKey}_codes` : undefined,
+    'feature_name_codes',
+    'feature_index',
+  ].filter((value): value is string => typeof value === 'string');
+  return candidates.find((candidate) => fields.includes(candidate));
+}
+
+function checkAbort(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError');
+  }
+}
+
+function rowGroupCountForIndex(metadata: PointsTilingMetadata, rowGroupIndex: number) {
+  if (rowGroupIndex < 0 || rowGroupIndex >= metadata.totalRowGroups) {
+    return 0;
+  }
+  return metadata.rowGroupRowCounts?.[rowGroupIndex] ?? metadata.maxRowsPerGroup;
+}
+
 export default class SpatialDataPointsSource extends SpatialDataTableSource {
+  private readonly pointTilingMetadataCache = new Map<
+    string,
+    Promise<PointsTilingMetadata | null>
+  >();
+
   /**
    *
    * @param path A path to within shapes.
@@ -126,22 +250,62 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
    *  shape: [number, number],
    * }>} A promise for a zarr array containing the data.
    */
-  async loadPoints(elementPath: string) {
+  async loadPoints(
+    elementPath: string,
+    options: PointsLoadOptions = {}
+  ): Promise<PointsLoadResult> {
+    const memoryCap = resolvePointsMemoryCap(options.memoryCap);
+    if (options.featureCodes !== undefined && options.fullDatasetFeatureScan === true) {
+      return this.loadPointsMatchingFeatureCodes(elementPath, {
+        memoryCap,
+        featureCodes: options.featureCodes,
+        onProgress: options.onProgress,
+      });
+    }
+
     const parquetPath = getParquetPath(elementPath);
-
     const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
-    const { axes, spatialdata_attrs: spatialDataAttrs } = zattrs;
+    const { axes } = zattrs;
     const normAxes = normalizeAxes(axes);
-    // todo - use type from schema?
     const axisNames = normAxes.map((axis: { name: string }) => axis.name);
+    const rowCount = await this.resolveParquetRowCount(parquetPath);
+    const truncatePreload = rowCount > memoryCap;
+    const maxRows = truncatePreload ? memoryCap : rowCount;
+    const columnNames = [...axisNames];
 
-    const { feature_key: featureKey } = spatialDataAttrs;
+    ensurePointsWorker();
+    if (isPointsWorkerEnabled()) {
+      try {
+        const payload = await this.readParquetWorkerPayload(parquetPath, { maxRows });
+        const workerGeometry = await decodeParquetGeometryCappedInWorker(
+          {
+            parts: payload.parts,
+            axisNames,
+            columns: columnNames,
+            maxRows,
+          }
+        );
+        if (workerGeometry) {
+          return {
+            shape: workerGeometry.shape as [number, number],
+            data: workerGeometry.data,
+            totalRowCount: rowCount,
+            preloadTruncated: truncatePreload,
+          };
+        }
+      } catch (error) {
+        console.warn(
+          `Worker geometry preload failed for ${elementPath}; falling back to main thread.`,
+          error
+        );
+      }
+    }
 
-    const columnNames = [...axisNames, featureKey].filter(Boolean);
-    const arrowTable = await this.loadParquetTable(parquetPath, columnNames);
-
-    // TODO: this table will also contain the index column, and potentially the featureKey column.
-    // Do something with these here, otherwise they will need to be loaded redundantly.
+    const {
+      table: arrowTable,
+      totalRows,
+      truncated,
+    } = await this.loadParquetTableCapped(parquetPath, columnNames, maxRows);
 
     const axisColumnArrs = axisNames.map((name: string) => {
       const column = arrowTable.getChild(name);
@@ -154,6 +318,890 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
     return {
       shape: [axisColumnArrs.length, arrowTable.numRows],
       data: axisColumnArrs,
+      totalRowCount: totalRows,
+      preloadTruncated: truncated,
+    };
+  }
+
+  private async loadPointsMatchingFeatureCodes(
+    elementPath: string,
+    options: {
+      memoryCap: number;
+      featureCodes: readonly number[];
+      onProgress?: (progress: PointsLoadProgress) => void;
+    }
+  ): Promise<PointsLoadResult> {
+    ensurePointsWorker();
+    const parquetPath = getParquetPath(elementPath);
+    const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
+    const { axes, spatialdata_attrs: spatialDataAttrs } = zattrs;
+    const normAxes = normalizeAxes(axes);
+    const axisNames = normAxes.map((axis: { name: string }) => axis.name);
+    const featureKey = spatialDataAttrs?.feature_key;
+    if (typeof featureKey !== 'string' || featureKey.length === 0) {
+      throw new Error(`Points element "${elementPath}" is missing feature_key metadata.`);
+    }
+
+    const totalRowCount = await this.resolveParquetRowCount(parquetPath);
+    if (options.featureCodes.length === 0) {
+      return emptyFilteredPointsResult(axisNames, totalRowCount);
+    }
+
+    if (!isPointsWorkerEnabled()) {
+      throw new Error(
+        'Feature-filtered points loading requires the points worker and parquet part bytes.'
+      );
+    }
+
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    const schemaTable = datasetMetadata ? null : await this.loadParquetSchemaTable(parquetPath);
+    const fields = datasetMetadata?.schema?.fields
+      ? datasetMetadata.schema.fields.flatMap((field) =>
+          typeof field.name === 'string' ? [field.name] : []
+        )
+      : arrowSchemaFieldNames(schemaTable);
+    const featureCodeColumnName = selectFeatureCodeColumn(fields, featureKey);
+
+    const columnNames = [...axisNames];
+    if (featureCodeColumnName && !columnNames.includes(featureCodeColumnName)) {
+      columnNames.push(featureCodeColumnName);
+    } else if (!columnNames.includes(featureKey)) {
+      columnNames.push(featureKey);
+    }
+
+    const matchedChunks: ColumnarPointsChunk[] = [];
+    let matchedRows = 0;
+    let scannedRows = 0;
+
+    const canUseRowGroups = await this.canLoadParquetRowGroups();
+    const datasetRowGroups = datasetMetadata?.totalNumRowGroups ?? 0;
+
+    if (canUseRowGroups && datasetRowGroups > 0) {
+      for (let rowGroupIndex = 0; rowGroupIndex < datasetRowGroups; rowGroupIndex += 1) {
+        if (matchedRows >= options.memoryCap) {
+          break;
+        }
+        const chunk = await this.readParquetRowGroupBytesByGroupIndex(parquetPath, rowGroupIndex);
+        if (!chunk) {
+          continue;
+        }
+        const partial = await scanParquetByFeatureCodesInWorker({
+          rowGroups: [chunk],
+          axisNames,
+          featureKey,
+          featureCodeColumnName,
+          featureCodes: options.featureCodes,
+          memoryCap: options.memoryCap - matchedRows,
+        });
+        if (!partial) {
+          throw new Error('Feature-filtered points loading requires the points worker.');
+        }
+        scannedRows += partial.scannedRows;
+        if (partial.matchedRows > 0) {
+          matchedChunks.push(toColumnarPointsChunk(partial.data, axisNames.length));
+          matchedRows += partial.matchedRows;
+        }
+        options.onProgress?.({
+          scannedRows,
+          matchedRows,
+          partIndex: rowGroupIndex,
+          partCount: datasetRowGroups,
+        });
+      }
+    } else {
+      let partPaths: string[];
+      if (datasetMetadata?.parts.length && datasetMetadata.parts.length > 0) {
+        partPaths = datasetMetadata.parts.map((part) => part.path);
+      } else {
+        partPaths = [parquetPath];
+      }
+
+      for (let partIndex = 0; partIndex < partPaths.length; partIndex += 1) {
+        const partPath = partPaths[partIndex];
+        if (matchedRows >= options.memoryCap) {
+          break;
+        }
+        const bytes = await this.loadParquetFileBytesAtPath(partPath);
+        if (!bytes || bytes.length === 0) {
+          continue;
+        }
+        const partial = await scanParquetByFeatureCodesInWorker({
+          parts: [bytes],
+          axisNames,
+          featureKey,
+          featureCodeColumnName,
+          featureCodes: options.featureCodes,
+          memoryCap: options.memoryCap - matchedRows,
+        });
+        if (!partial) {
+          throw new Error('Feature-filtered points loading requires the points worker.');
+        }
+        scannedRows += partial.scannedRows;
+        if (partial.matchedRows > 0) {
+          matchedChunks.push(toColumnarPointsChunk(partial.data, axisNames.length));
+          matchedRows += partial.matchedRows;
+        }
+        options.onProgress?.({
+          scannedRows,
+          matchedRows,
+          partIndex,
+          partCount: partPaths.length,
+        });
+      }
+    }
+
+    const data = concatColumnarPointChunks(matchedChunks);
+    return {
+      shape: data.shape,
+      data: data.data,
+      totalRowCount,
+      scannedRowCount: scannedRows,
+      filterActive: true,
+      preloadTruncated: matchedRows >= options.memoryCap,
+    };
+  }
+
+  private async resolveExplicitFeatureCodeColumn(elementPath: string): Promise<{
+    featureKey: string;
+    featureCodeColumnName: string;
+  } | null> {
+    const parquetPath = getParquetPath(elementPath);
+    const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
+    const featureKey = zattrs.spatialdata_attrs?.feature_key;
+    if (typeof featureKey !== 'string' || featureKey.length === 0) {
+      return null;
+    }
+
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    const schemaTable = datasetMetadata ? null : await this.loadParquetSchemaTable(parquetPath);
+    const fields = datasetMetadata?.schema?.fields
+      ? datasetMetadata.schema.fields.flatMap((field) =>
+          typeof field.name === 'string' ? [field.name] : []
+        )
+      : arrowSchemaFieldNames(schemaTable);
+    const featureCodeColumnName = selectFeatureCodeColumn(fields, featureKey);
+    if (!featureCodeColumnName) {
+      return null;
+    }
+    return { featureKey, featureCodeColumnName };
+  }
+
+  async loadFeatureCounts(elementPath: string): Promise<Map<number, number>> {
+    const parquetPath = getParquetPath(elementPath);
+    const resolvedFeatureColumn = await this.resolveExplicitFeatureCodeColumn(elementPath);
+    if (!resolvedFeatureColumn) {
+      return new Map();
+    }
+    const { featureKey, featureCodeColumnName } = resolvedFeatureColumn;
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    const columnNames = [featureKey];
+    if (!columnNames.includes(featureCodeColumnName)) {
+      columnNames.push(featureCodeColumnName);
+    }
+
+    const canUseRowGroups = await this.canLoadParquetRowGroups();
+    const datasetRowGroups = datasetMetadata?.totalNumRowGroups ?? 0;
+
+    ensurePointsWorker();
+    if (isPointsWorkerEnabled()) {
+      try {
+        const payload = await this.readParquetWorkerPayload(parquetPath, {
+          maxRows: Number.POSITIVE_INFINITY,
+          fullPartsForFallback: true,
+          includeRowGroups: true,
+        });
+        const workerCounts = await scanParquetFeatureCountsInWorker(
+          canUseRowGroups && datasetRowGroups > 0 && payload.rowGroups.length > 0
+            ? {
+                rowGroups: payload.rowGroups,
+                featureKey,
+                featureCodeColumnName,
+              }
+            : {
+                parts: payload.parts,
+                featureKey,
+                featureCodeColumnName,
+              }
+        );
+        if (workerCounts) {
+          return workerCounts;
+        }
+      } catch (error) {
+        console.warn(
+          `Worker feature counts failed for ${elementPath}; falling back to main thread.`,
+          error
+        );
+      }
+    }
+
+    if (canUseRowGroups && datasetRowGroups > 0) {
+      const counts = new Map<number, number>();
+      for (let rowGroupIndex = 0; rowGroupIndex < datasetRowGroups; rowGroupIndex += 1) {
+        const table = await this.loadParquetRowGroupByGroupIndex(parquetPath, rowGroupIndex, {
+          columns: columnNames,
+        });
+        if (table && table.numRows > 0) {
+          const { scanTableFeatureCounts } = await import('../workers/pointsWorkerScan.js');
+          scanTableFeatureCounts(table, featureKey, featureCodeColumnName, counts);
+        }
+      }
+      return counts;
+    }
+
+    const { parts } = await this.readParquetDatasetBytesCapped(
+      parquetPath,
+      Number.POSITIVE_INFINITY
+    );
+
+    if (parts.length > 0) {
+      const workerCounts = await scanParquetFeatureCountsInWorker({
+        parts,
+        featureKey,
+        featureCodeColumnName,
+      });
+      if (workerCounts) {
+        return workerCounts;
+      }
+    }
+
+    const rowCodes = await this.loadPointsRowFeatureCodes(elementPath);
+    if (!rowCodes) {
+      return new Map();
+    }
+    const { countFeatureCodesHistogram } = await import('../pointsFeatures.js');
+    return countFeatureCodesHistogram(rowCodes);
+  }
+
+  async listPointsFeaturesWithCounts(elementPath: string): Promise<PointsFeatureCatalog | null> {
+    const catalog = await this.listPointsFeatures(elementPath);
+    if (!catalog) {
+      return null;
+    }
+    try {
+      const counts = await this.loadFeatureCounts(elementPath);
+      return mergeFeatureCountsIntoCatalog(catalog, counts);
+    } catch (error) {
+      console.warn(`Failed to load feature counts for ${elementPath}:`, error);
+      return catalog;
+    }
+  }
+
+  /**
+   * Load per-row feature codes aligned with {@link loadPoints} rows. Deferred from
+   * geometry preload so large datasets do not block the first render. Parquet decode
+   * and code extraction run on the points worker when enabled; falls back to the
+   * main thread when the worker is unavailable.
+   */
+  async loadPointsRowFeatureCodes(
+    elementPath: string,
+    options: {
+      memoryCap?: number;
+      featureCatalog?: PointsFeatureCatalog | null;
+    } = {}
+  ): Promise<ArrayLike<number> | undefined> {
+    const parquetPath = getParquetPath(elementPath);
+    const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
+    const { spatialdata_attrs: spatialDataAttrs } = zattrs;
+    const featureKey = spatialDataAttrs?.feature_key;
+    if (typeof featureKey !== 'string' || featureKey.length === 0) {
+      return undefined;
+    }
+
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    const schemaTable = datasetMetadata ? null : await this.loadParquetSchemaTable(parquetPath);
+    const fields = datasetMetadata?.schema?.fields
+      ? datasetMetadata.schema.fields.flatMap((field) =>
+          typeof field.name === 'string' ? [field.name] : []
+        )
+      : arrowSchemaFieldNames(schemaTable);
+    const featureCodeColumnName = selectFeatureCodeColumn(fields, featureKey);
+    const featureCodeByName = featureCodeColumnName
+      ? undefined
+      : featureCodeMapFromCatalog(
+          options.featureCatalog !== undefined
+            ? options.featureCatalog
+            : await this.listPointsFeatures(elementPath)
+        );
+
+    const rowCount = await this.resolveParquetRowCount(parquetPath);
+    const memoryCap = resolvePointsMemoryCap(options.memoryCap);
+    const maxRows = rowCount > memoryCap ? memoryCap : rowCount;
+
+    const columnNames = [featureKey];
+    if (featureCodeColumnName && !columnNames.includes(featureCodeColumnName)) {
+      columnNames.push(featureCodeColumnName);
+    }
+
+    const featureCodeEntries = featureCodeByName
+      ? [...featureCodeByName.entries()].map(([name, code]) => ({ name, code }))
+      : undefined;
+
+    ensurePointsWorker();
+    if (isPointsWorkerEnabled()) {
+      try {
+        const payload = await this.readParquetWorkerPayload(parquetPath, { maxRows });
+        const workerInput = {
+          columns: columnNames,
+          maxRows,
+          featureKey,
+          featureCodeColumnName,
+          featureCodeEntries,
+        };
+        const workerCodes = await decodeParquetRowFeatureCodesInWorker(
+          payload.rowGroups.length > 0
+            ? { ...workerInput, rowGroups: payload.rowGroups }
+            : { ...workerInput, parts: payload.parts }
+        );
+        if (workerCodes) {
+          return workerCodes;
+        }
+      } catch (error) {
+        console.warn(
+          `Worker row feature codes failed for ${elementPath}; falling back to main thread.`,
+          error
+        );
+      }
+    }
+
+    const { table: arrowTable } = await this.loadParquetTableCapped(
+      parquetPath,
+      columnNames,
+      maxRows
+    );
+    return resolveRowFeatureCodesFromTable(
+      arrowTable,
+      featureKey,
+      featureCodeColumnName,
+      featureCodeByName
+    );
+  }
+
+  async getPointsParquetRowCount(elementPath: string): Promise<number> {
+    const parquetPath = getParquetPath(elementPath);
+    return this.resolveParquetRowCount(parquetPath);
+  }
+
+  async listPointsFeatures(elementPath: string): Promise<PointsFeatureCatalog | null> {
+    const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
+    const featureKey = zattrs.spatialdata_attrs?.feature_key;
+    if (typeof featureKey !== 'string' || featureKey.length === 0) {
+      return null;
+    }
+
+    const parquetPath = getParquetPath(elementPath);
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    const schemaTable = datasetMetadata ? null : await this.loadParquetSchemaTable(parquetPath);
+    const fields = datasetMetadata?.schema?.fields
+      ? datasetMetadata.schema.fields.flatMap((field) =>
+          typeof field.name === 'string' ? [field.name] : []
+        )
+      : arrowSchemaFieldNames(schemaTable);
+    const featureCodeColumnName = selectFeatureCodeColumn(fields, featureKey);
+    const hasMortonColumn = fields.includes(MORTON_CODE_2D_COLUMN);
+
+    const rowCount = await this.resolveParquetRowCount(parquetPath);
+
+    const columns = [featureKey];
+    if (featureCodeColumnName) {
+      columns.push(featureCodeColumnName);
+    }
+    if (hasMortonColumn) {
+      columns.push(MORTON_CODE_2D_COLUMN);
+    }
+
+    if (rowCount > 0 && exceedsPointsPreloadLimit(rowCount)) {
+      return this.listPointsFeaturesByFeatureColumnScan(
+        parquetPath,
+        featureKey,
+        featureCodeColumnName,
+        hasMortonColumn
+      );
+    }
+
+    const arrowTable = await this.loadParquetTable(parquetPath, columns);
+    const nameColumn = arrowTable.getChild(featureKey);
+    const codeColumn = featureCodeColumnName ? arrowTable.getChild(featureCodeColumnName) : null;
+    const mortonColumn = hasMortonColumn ? arrowTable.getChild(MORTON_CODE_2D_COLUMN) : null;
+
+    if (!nameColumn) {
+      return null;
+    }
+
+    return buildFeatureCatalogFromColumns(
+      featureKey,
+      nameColumn,
+      codeColumn,
+      mortonColumn,
+      arrowTable.numRows
+    );
+  }
+
+  /**
+   * Build a feature catalog for oversized datasets by scanning only feature
+   * columns (row-group range reads when available), not x/y geometry.
+   */
+  private async listPointsFeaturesByFeatureColumnScan(
+    parquetPath: string,
+    featureKey: string,
+    featureCodeColumnName: string | undefined,
+    hasMortonColumn: boolean
+  ): Promise<PointsFeatureCatalog | null> {
+    const columnNames = [featureKey];
+    if (featureCodeColumnName) {
+      columnNames.push(featureCodeColumnName);
+    }
+    if (hasMortonColumn) {
+      columnNames.push(MORTON_CODE_2D_COLUMN);
+    }
+
+    ensurePointsWorker();
+    if (isPointsWorkerEnabled()) {
+      try {
+        const payload = await this.readParquetWorkerPayload(parquetPath, {
+          maxRows: Number.POSITIVE_INFINITY,
+          fullPartsForFallback: true,
+          includeRowGroups: true,
+        });
+        const catalog = await scanParquetFeatureCatalogInWorker({
+          rowGroups:
+            featureCodeColumnName && payload.rowGroups.length > 0
+              ? payload.rowGroups
+              : undefined,
+          parts: payload.parts,
+          columns: columnNames,
+          featureKey,
+          featureCodeColumnName,
+          skipMortonSentinels: hasMortonColumn,
+        });
+        if (catalog) {
+          return catalog;
+        }
+      } catch (error) {
+        console.warn(
+          `Worker feature catalog scan failed for ${parquetPath}; falling back to main thread.`,
+          error
+        );
+      }
+    }
+
+    const { accumulateFeatureCatalogFromTable, featureCatalogFromCodeMap, featureCatalogNeedsParquetFallback } =
+      await import('../pointsFeatures.js');
+    const codeToName = new Map<number, string>();
+    const nameToCode = new Map<string, number>();
+    const canUseRowGroups = await this.canLoadParquetRowGroups();
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+
+    if (
+      canUseRowGroups &&
+      datasetMetadata &&
+      datasetMetadata.totalNumRowGroups > 0 &&
+      featureCodeColumnName
+    ) {
+      for (
+        let rowGroupIndex = 0;
+        rowGroupIndex < datasetMetadata.totalNumRowGroups;
+        rowGroupIndex += 1
+      ) {
+        const table = await this.loadParquetRowGroupByGroupIndex(parquetPath, rowGroupIndex, {
+          columns: columnNames,
+        });
+        if (!table || table.numRows === 0) {
+          continue;
+        }
+        accumulateFeatureCatalogFromTable(
+          codeToName,
+          nameToCode,
+          table,
+          featureKey,
+          featureCodeColumnName,
+          { skipMortonSentinels: hasMortonColumn }
+        );
+      }
+    }
+
+    if (featureCatalogNeedsParquetFallback(codeToName)) {
+      codeToName.clear();
+      nameToCode.clear();
+      const arrowTable = await this.loadParquetTable(parquetPath, columnNames);
+      accumulateFeatureCatalogFromTable(
+        codeToName,
+        nameToCode,
+        arrowTable,
+        featureKey,
+        featureCodeColumnName,
+        { skipMortonSentinels: hasMortonColumn }
+      );
+    }
+
+    if (codeToName.size === 0) {
+      return null;
+    }
+    return featureCatalogFromCodeMap(featureKey, codeToName);
+  }
+
+  async getPointsTilingMetadata(elementPath: string): Promise<PointsTilingMetadata | null> {
+    if (this.pointTilingMetadataCache.has(elementPath)) {
+      return this.pointTilingMetadataCache.get(elementPath) ?? null;
+    }
+    const promise = this.loadPointsTilingMetadataUncached(elementPath).catch(error => {
+      this.pointTilingMetadataCache.delete(elementPath);
+      throw error;
+    });
+    this.pointTilingMetadataCache.set(elementPath, promise);
+    return promise;
+  }
+
+  private async loadPointsTilingMetadataUncached(
+    elementPath: string
+  ): Promise<PointsTilingMetadata | null> {
+    const parquetPath = getParquetPath(elementPath);
+    const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
+    const { axes, spatialdata_attrs: spatialDataAttrs } = zattrs;
+    const normAxes = normalizeAxes(axes);
+    const axisNames = normAxes.map((axis: { name: string }) => axis.name);
+    const { feature_key: featureKey } = spatialDataAttrs;
+
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    const schemaTable = datasetMetadata ? null : await this.loadParquetSchemaTable(parquetPath);
+    const fields = datasetMetadata?.schema?.fields
+      ? datasetMetadata.schema.fields.flatMap((field) =>
+          typeof field.name === 'string' ? [field.name] : []
+        )
+      : arrowSchemaFieldNames(schemaTable);
+
+    const featureCodeColumnName = selectFeatureCodeColumn(fields, featureKey);
+    if (
+      !fields.includes('x') ||
+      !fields.includes('y') ||
+      !fields.includes(MORTON_CODE_2D_COLUMN) ||
+      !featureCodeColumnName
+    ) {
+      return null;
+    }
+
+    const canLoadRowGroups = await this.canLoadParquetRowGroups();
+    const firstRowGroupRowCount = datasetMetadata?.rowGroupRows?.[0] ?? 0;
+    const hasValidSentinelRowGroup = firstRowGroupRowCount >= 2 && firstRowGroupRowCount <= 4;
+    const firstRowGroup =
+      datasetMetadata && canLoadRowGroups && hasValidSentinelRowGroup
+        ? await this.loadParquetRowGroupByGroupIndex(parquetPath, 0, {
+            columns: ['x', 'y', MORTON_CODE_2D_COLUMN],
+            limit: 4,
+          })
+        : null;
+    const bounds = firstRowGroup
+      ? (extractSentinelBoundingBox(firstRowGroup) ?? undefined)
+      : undefined;
+    const rowGroupSizes = datasetMetadata?.rowGroupRows ?? [];
+
+    const metadata: PointsTilingMetadata = {
+      kind: 'morton-points',
+      parquetPath,
+      axisNames,
+      featureKey,
+      featureCodeColumnName,
+      mortonCodeColumnName: MORTON_CODE_2D_COLUMN,
+      totalRows: datasetMetadata?.totalNumRows ?? 0,
+      totalRowGroups: datasetMetadata?.totalNumRowGroups ?? 0,
+      maxRowsPerGroup: rowGroupSizes.length ? Math.max(...rowGroupSizes) : 0,
+      rowGroupRowCounts: datasetMetadata?.rowGroupRows,
+      supportsRowGroupRangeReads: Boolean(datasetMetadata && canLoadRowGroups && bounds),
+      bounds,
+    };
+
+    return metadata;
+  }
+
+  async loadPointsInBounds(
+    elementPath: string,
+    options: PointsInBoundsOptions
+  ): Promise<PointsInBoundsResponse> {
+    checkAbort(options.signal);
+    const metadata = await this.getPointsTilingMetadata(elementPath);
+    if (metadata?.supportsRowGroupRangeReads && metadata.bounds) {
+      const rowGroupResult = await this.loadMortonPointsInBounds(elementPath, metadata, options);
+      if (rowGroupResult) {
+        return rowGroupResult;
+      }
+    }
+    checkAbort(options.signal);
+    const full = await this.loadPointsWithOptionalFeatureCodes(elementPath, metadata, options);
+    checkAbort(options.signal);
+    return filterPointsToBounds(
+      full.data,
+      options.bounds,
+      undefined,
+      options.featureCodes,
+      full.featureCodes
+    );
+  }
+
+  private async loadPointsWithOptionalFeatureCodes(
+    elementPath: string,
+    metadata: PointsTilingMetadata | null,
+    options: PointsInBoundsOptions
+  ) {
+    const parquetPath = getParquetPath(elementPath);
+    const zattrs = await this.loadSpatialDataElementAttrs(elementPath);
+    const { axes, spatialdata_attrs: spatialDataAttrs } = zattrs;
+    const normAxes = normalizeAxes(axes);
+    const axisNames = normAxes.map((axis: { name: string }) => axis.name);
+    const { feature_key: featureKey } = spatialDataAttrs;
+    let featureCodeColumnName = metadata?.featureCodeColumnName;
+    const needsFeatureFilter = options.featureCodes !== undefined;
+    if (!featureCodeColumnName && needsFeatureFilter) {
+      const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+      const schemaTable = datasetMetadata ? null : await this.loadParquetSchemaTable(parquetPath);
+      const fields = datasetMetadata?.schema?.fields
+        ? datasetMetadata.schema.fields.flatMap((field) =>
+            typeof field.name === 'string' ? [field.name] : []
+          )
+        : arrowSchemaFieldNames(schemaTable);
+      featureCodeColumnName = selectFeatureCodeColumn(fields, featureKey);
+    }
+    const resolvedFeatureCodeColumn =
+      typeof featureCodeColumnName === 'string' ? featureCodeColumnName : undefined;
+    const featureCodeByName = resolvedFeatureCodeColumn
+      ? undefined
+      : featureCodeMapFromCatalog(await this.listPointsFeatures(elementPath));
+    const columnNames = [...axisNames];
+    if (needsFeatureFilter) {
+      if (resolvedFeatureCodeColumn) {
+        columnNames.push(resolvedFeatureCodeColumn);
+      } else if (typeof featureKey === 'string' && !columnNames.includes(featureKey)) {
+        columnNames.push(featureKey);
+      }
+    }
+    const featureCodeEntries = featureCodeByName
+      ? [...featureCodeByName.entries()].map(([name, code]) => ({ name, code }))
+      : undefined;
+
+    ensurePointsWorker();
+    if (isPointsWorkerEnabled()) {
+      try {
+        const payload = await this.readParquetWorkerPayload(parquetPath, {
+          maxRows: Number.POSITIVE_INFINITY,
+          fullPartsForFallback: true,
+          includeRowGroups: true,
+        });
+        const workerResult = await decodeParquetGeometryCappedInWorker(
+          payload.rowGroups.length > 0
+            ? {
+                rowGroups: payload.rowGroups,
+                axisNames,
+                columns: columnNames,
+                maxRows: Number.POSITIVE_INFINITY,
+                featureKey: needsFeatureFilter ? featureKey : undefined,
+                featureCodeColumnName: resolvedFeatureCodeColumn,
+                featureCodeEntries,
+              }
+            : {
+                parts: payload.parts,
+                axisNames,
+                columns: columnNames,
+                maxRows: Number.POSITIVE_INFINITY,
+                featureKey: needsFeatureFilter ? featureKey : undefined,
+                featureCodeColumnName: resolvedFeatureCodeColumn,
+                featureCodeEntries,
+              }
+        );
+        if (workerResult) {
+          return {
+            data: {
+              shape: workerResult.shape as [number, number],
+              data: workerResult.data,
+            },
+            featureCodes: workerResult.featureCodes,
+          };
+        }
+      } catch (error) {
+        console.warn(
+          `Worker bounds geometry load failed for ${elementPath}; falling back to main thread.`,
+          error
+        );
+      }
+    }
+
+    const arrowTable = await this.loadParquetTable(parquetPath, columnNames);
+    const axisColumnArrs = axisNames.map((name: string) => {
+      const column = arrowTable.getChild(name);
+      if (!column) {
+        throw new Error(`Column "${name}" not found in the arrow table.`);
+      }
+      return column.toArray();
+    });
+    const featureCodes = needsFeatureFilter
+      ? resolveRowFeatureCodesFromTable(
+          arrowTable,
+          featureKey,
+          resolvedFeatureCodeColumn,
+          featureCodeByName
+        )
+      : undefined;
+    return {
+      data: {
+        shape: [axisColumnArrs.length, arrowTable.numRows],
+        data: axisColumnArrs,
+      },
+      featureCodes,
+    };
+  }
+
+  private async bisectRowGroupsRight(
+    parquetPath: string,
+    totalRowGroups: number,
+    targetValue: number
+  ) {
+    let lo = 0;
+    let hi = totalRowGroups;
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      const extent = await this.loadParquetRowGroupColumnExtent(
+        parquetPath,
+        MORTON_CODE_2D_COLUMN,
+        mid
+      );
+      const max = extent?.max;
+      if (max === null || max === undefined || targetValue <= max) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return lo;
+  }
+
+  private async loadMortonPointsInBounds(
+    elementPath: string,
+    metadata: PointsTilingMetadata,
+    options: PointsInBoundsOptions
+  ): Promise<PointsInBoundsResponse | null> {
+    if (!metadata.bounds || metadata.totalRowGroups <= 0) {
+      return null;
+    }
+    checkAbort(options.signal);
+    const allowedFeatureCodes = featureCodeAllowSet(options.featureCodes);
+    const intervals = mortonIntervalsForBounds(metadata.bounds, options.bounds);
+    const rowGroupSet = new Set<number>();
+    for (const [start, end] of intervals) {
+      const first = await this.bisectRowGroupsRight(
+        metadata.parquetPath,
+        metadata.totalRowGroups,
+        start
+      );
+      const last = await this.bisectRowGroupsRight(
+        metadata.parquetPath,
+        metadata.totalRowGroups,
+        end
+      );
+      for (let rowGroup = first; rowGroup <= last; rowGroup++) {
+        if (rowGroup >= 0 && rowGroup < metadata.totalRowGroups) {
+          rowGroupSet.add(rowGroup);
+        }
+      }
+    }
+    const rowGroups = [...rowGroupSet].sort((a, b) => a - b);
+    const totalRowsUpperBound = rowGroups.reduce(
+      (sum, rowGroup) => sum + rowGroupCountForIndex(metadata, rowGroup),
+      0
+    );
+    if (totalRowsUpperBound === 0) {
+      return null;
+    }
+
+    const xs: number[] = [];
+    const ys: number[] = [];
+    const zs: number[] = [];
+    const hasZ = metadata.axisNames.includes('z');
+    const filterByFeature = allowedFeatureCodes !== null;
+    const featureCodeColumnName =
+      filterByFeature && metadata.featureCodeColumnName
+        ? metadata.featureCodeColumnName
+        : undefined;
+
+    ensurePointsWorker();
+    if (isPointsWorkerEnabled()) {
+      const rowGroupChunks = [];
+      for (const rowGroup of rowGroups) {
+        checkAbort(options.signal);
+        const chunk = await this.readParquetRowGroupBytesByGroupIndex(
+          metadata.parquetPath,
+          rowGroup
+        );
+        if (chunk) {
+          rowGroupChunks.push(chunk);
+        }
+      }
+      if (rowGroupChunks.length > 0) {
+        try {
+          const workerResult = await scanMortonRowGroupsInBoundsInWorker({
+            rowGroups: rowGroupChunks,
+            bounds: options.bounds,
+            axisNames: metadata.axisNames,
+            mortonCodeColumnName: metadata.mortonCodeColumnName,
+            featureCodeColumnName,
+            featureCodes: options.featureCodes,
+          });
+          if (workerResult) {
+            return {
+              data: workerResult.data,
+              shape: workerResult.shape as [number, number],
+              bounds: options.bounds,
+              loadMode: 'row-groups',
+              tiling: metadata,
+            };
+          }
+        } catch (error) {
+          console.warn(
+            `Worker morton tile load failed for ${elementPath}; falling back to main thread.`,
+            error
+          );
+        }
+      }
+    }
+
+    const rowGroupColumns = [
+      'x',
+      'y',
+      ...(hasZ ? ['z'] : []),
+      metadata.mortonCodeColumnName,
+      ...(featureCodeColumnName ? [featureCodeColumnName] : []),
+    ];
+    for (const rowGroup of rowGroups) {
+      checkAbort(options.signal);
+      const table = await this.loadParquetRowGroupByGroupIndex(metadata.parquetPath, rowGroup, {
+        columns: rowGroupColumns,
+      });
+      if (!table) {
+        continue;
+      }
+      const { scanMortonTableInBounds } = await import('../workers/pointsWorkerScan.js');
+      scanMortonTableInBounds({
+        table,
+        rowGroupIndex: rowGroup,
+        bounds: options.bounds,
+        axisNames: metadata.axisNames,
+        mortonCodeColumnName: metadata.mortonCodeColumnName,
+        featureCodeColumnName,
+        featureCodes: options.featureCodes,
+        xs,
+        ys,
+        zs,
+      });
+    }
+
+    if (xs.length === 0) {
+      return null;
+    }
+
+    return {
+      data: hasZ
+        ? [new Float32Array(xs), new Float32Array(ys), new Float32Array(zs)]
+        : [new Float32Array(xs), new Float32Array(ys)],
+      shape: [hasZ ? 3 : 2, xs.length],
+      bounds: options.bounds,
+      loadMode: 'row-groups',
+      tiling: metadata,
     };
   }
 }

--- a/packages/core/src/models/VShapesSource.ts
+++ b/packages/core/src/models/VShapesSource.ts
@@ -23,14 +23,27 @@ const log = console;
 
 // import SpatialDataTableSource from './SpatialDataTableSource.js';
 
-import type { TypedArray as ZarrTypedArray, Chunk, NumberDataType } from 'zarrita';
 import type { Table as ArrowTable } from 'apache-arrow';
 import type { Vector } from 'apache-arrow/vector';
-import SpatialDataTableSource from './VTableSource';
+import type { Chunk, NumberDataType, TypedArray as ZarrTypedArray } from 'zarrita';
+import type { SpatialBounds } from '../pointsTiling.js';
 import type { ShapesGeometryKind, ShapesRenderData } from '../shapes';
+import SpatialDataTableSource from './VTableSource';
 export type PolygonShape = Array<Array<[number, number]>>;
 //nb, not totally happy with this type.
 export type ZarrNumericArray = ZarrTypedArray<NumberDataType> | BigInt64Array | Array<number>;
+
+export interface ShapesInBoundsOptions {
+  bounds: SpatialBounds;
+  zoom?: number;
+  signal?: AbortSignal;
+  columns?: string[];
+}
+
+export type ShapesInBoundsResult = ShapesRenderData & {
+  bounds: SpatialBounds;
+  loadMode: 'full-filter';
+};
 
 // If the array path starts with table/something/rest
 // capture table/something.
@@ -62,6 +75,12 @@ function getParquetPath(arrPath?: string) {
     return `${elementPrefix}/shapes.parquet`;
   }
   throw new Error(`Cannot determine parquet path for shapes array path: ${arrPath}`);
+}
+
+function checkAbort(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError');
+  }
 }
 
 /**
@@ -363,11 +382,10 @@ export default class SpatialDataShapesSource extends SpatialDataTableSource {
     // However this may complicate applying transformations, at least in the current way.
     // Reference: https://deck.gl/docs/api-reference/layers/polygon-layer#data-accessors
     return arr.map((geom: ArrayBuffer) => {
-      const coords =
-      wkb
-      .readGeometry(geom)
-      // @ts-expect-error - getCoordinates is not a method of Geometry, check this<<<
-          .getCoordinates();
+      const coords = wkb
+        .readGeometry(geom)
+        // @ts-expect-error - getCoordinates is not a method of Geometry, check this<<<
+        .getCoordinates();
       // Take first polygon (if multipolygon)
       return coords[0];
     });
@@ -499,6 +517,20 @@ export default class SpatialDataShapesSource extends SpatialDataTableSource {
       polygons,
       geometryColumnName: 'geometry',
       rowIndexByFeatureIndex: new Int32Array(featureIds.length).fill(-1),
+    };
+  }
+
+  async loadShapesInBounds(
+    elementPath: string,
+    options: ShapesInBoundsOptions
+  ): Promise<ShapesInBoundsResult> {
+    checkAbort(options.signal);
+    const renderData = await this.loadShapesRenderData(elementPath);
+    checkAbort(options.signal);
+    return {
+      ...renderData,
+      bounds: options.bounds,
+      loadMode: 'full-filter',
     };
   }
 

--- a/packages/core/src/models/VTableSource.ts
+++ b/packages/core/src/models/VTableSource.ts
@@ -1,58 +1,51 @@
 // this is a direct copy of the Vitessce implementation, with changes mostly to make it more normal TypeScript.
 
-import { tableFromIPC, type Table as ArrowTable } from 'apache-arrow';
+import { type Table as ArrowTable, tableFromIPC } from 'apache-arrow';
 import type { DataSourceParams } from '../Vutils';
+import {
+  getParquetModule,
+  type ParquetModule,
+  type ParquetRowGroupReadOptions,
+  type ParquetWasmMetadata,
+} from '../parquetWasmLoader.js';
 import type { TableColumnData } from '../types';
 import AnnDataSource from './VAnnDataSource';
+
+export type { ParquetRowGroupReadOptions };
+
+function parquetColumnValueToNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  return null;
+}
+
+export interface ParquetPartMetadata {
+  path: string;
+  schema: ArrowTable['schema'];
+  schemaBytes: Uint8Array;
+  metadata: ParquetWasmMetadata;
+}
+
+export interface ParquetDatasetMetadata {
+  totalNumRows: number;
+  totalNumRowGroups: number;
+  numRowsByPart: number[];
+  numRowGroupsByPart: number[];
+  numRowsPerGroupByPart: number[];
+  rowGroupRows: number[];
+  schema: ArrowTable['schema'] | null;
+  parts: ParquetPartMetadata[];
+}
 
 // Note: This file also serves as the parent for
 // SpatialDataPointsSource and SpatialDataShapesSource,
 // because when a table annotates points and shapes, it can be helpful to
 // have all of the required functionality to load the
 // table data and the parquet data.
-
-async function getParquetModule() {
-  // Dynamic import for code-splitting. parquet-wasm is a WebAssembly module
-  // that needs to be initialized before use in browser environments.
-  // In Node.js, the module loads WASM synchronously so no init is needed.
-  //
-  // TODO: Replace with a more civilised parquet module that's built in a way we can actually consume.
-  // - probably ultimately may be using geoarrow-wasm / investigate deck.gl arrow layer
-  //   think about how that fits our 'core' (no deck deps) vs 'vis' structure etc.
-
-  // Try local import first (works in Node.js, tests, and production builds)
-  try {
-    const module = await import('parquet-wasm');
-    if (typeof module.default === 'function') {
-      await module.default();
-    }
-    return { readParquet: module.readParquet, readSchema: module.readSchema };
-  } catch (error) {
-    // Local import failed, try CDN fallback (needed in vite dev server)
-    // Reference: https://observablehq.com/@kylebarron/geoparquet-on-the-web
-    console.warn(
-      '[VTableSource] Local parquet-wasm import failed, falling back to CDN version. ' +
-        'This is a temporary workaround pending a better parquet module solution.',
-      error
-    );
-
-    try {
-      const cdnModule = await import(
-        // @ts-expect-error - CDN import not recognized by TypeScript
-        'https://cdn.vitessce.io/parquet-wasm@2c23652/esm/parquet_wasm.js'
-      );
-      await cdnModule.default();
-      return { readParquet: cdnModule.readParquet, readSchema: cdnModule.readSchema };
-    } catch (cdnError) {
-      // Both imports failed, throw an error
-      const localErrorMsg = error instanceof Error ? error.message : String(error);
-      const cdnErrorMsg = cdnError instanceof Error ? cdnError.message : String(cdnError);
-      throw new Error(
-        `Failed to load parquet-wasm from both local package and CDN. Local error: ${localErrorMsg}. CDN error: ${cdnErrorMsg}`
-      );
-    }
-  }
-}
 
 /**
  * Get the name of the index column from an Apache Arrow table.
@@ -162,6 +155,14 @@ function hasParquetTailMagic(bytes: Uint8Array) {
   return bytes.length >= 8 && hasParquetMagic(bytes, bytes.length - 4);
 }
 
+function toSafeNumber(value: number | bigint, label: string) {
+  const n = typeof value === 'bigint' ? Number(value) : value;
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new Error(`Invalid parquet ${label}: ${String(value)}`);
+  }
+  return n;
+}
+
 /**
  * This class is a parent class for tables, shapes, and points.
  * This is because these share functionality, for example:
@@ -170,10 +171,7 @@ function hasParquetTailMagic(bytes: Uint8Array) {
  * - logic for manipulating spatialdata element paths is shared across all elements.
  */
 export default class SpatialDataTableSource extends AnnDataSource {
-  static parquetModulePromise: Promise<{
-    readParquet: (bytes: Uint8Array, options?: { columns?: string[] }) => any;
-    readSchema: (bytes: Uint8Array) => any;
-  }>;
+  static parquetModulePromise: Promise<ParquetModule>;
   rootAttrs: { softwareVersion: string; formatVersion: string } | null;
   // biome-ignore lint/suspicious/noExplicitAny: elementAttrs type should be a tree-ish thing
   elementAttrs: Record<string, any>;
@@ -186,6 +184,8 @@ export default class SpatialDataTableSource extends AnnDataSource {
    * `loadPolygonShapes` all target the same file).
    */
   parquetTableCache: Record<string, Promise<ArrowTable>>;
+  /** Morton min/max per row group — avoids re-decoding row groups during bisect. */
+  rowGroupColumnExtentCache: Map<string, { min: number | null; max: number | null }>;
   obsIndices: Record<string, Promise<string[]>>;
   varIndices: Record<string, Promise<string[]>>;
   varAliases: Record<string, string[]>;
@@ -206,6 +206,7 @@ export default class SpatialDataTableSource extends AnnDataSource {
     // TODO: change to column-specific storage.
     this.parquetTableBytes = {};
     this.parquetTableCache = {};
+    this.rowGroupColumnExtentCache = new Map();
 
     // Table-specific properties
     this.obsIndices = {};
@@ -322,44 +323,12 @@ export default class SpatialDataTableSource extends AnnDataSource {
   async loadParquetSchemaBytes(parquetPath: string) {
     const { store } = this.storeRoot;
     if (store.getRange) {
-      // Step 1: Fetch last 8 bytes to get footer length and magic number
-      const TAIL_LENGTH = 8;
       let lastError: Error | null = null;
 
       for (const candidatePath of getParquetCandidatePaths(parquetPath)) {
         try {
-          const tailBytes = await store.getRange(`/${candidatePath}`, {
-            suffixLength: TAIL_LENGTH,
-          });
-          const normalizedTailBytes = toUint8Array(tailBytes);
-          if (!normalizedTailBytes || !hasParquetTailMagic(normalizedTailBytes)) {
-            continue;
-          }
-
-          // Step 2: Extract footer length and magic number
-          // little-endian
-          const footerLength = new DataView(
-            normalizedTailBytes.buffer,
-            normalizedTailBytes.byteOffset,
-            normalizedTailBytes.byteLength
-          ).getInt32(0, true);
-
-          // Step 3. Fetch the full footer bytes
-          const footerBytes = await store.getRange(`/${candidatePath}`, {
-            suffixLength: footerLength + TAIL_LENGTH,
-          });
-          const normalizedFooterBytes = toUint8Array(footerBytes);
-          if (
-            !normalizedFooterBytes ||
-            normalizedFooterBytes.length !== footerLength + TAIL_LENGTH ||
-            !hasParquetTailMagic(normalizedFooterBytes)
-          ) {
-            lastError = new Error(`Failed to load parquet footer bytes for ${parquetPath}`);
-            continue;
-          }
-
-          // Step 4: Return the footer bytes
-          return normalizedFooterBytes;
+          const footerBytes = await this.loadParquetFooterBytesForPath(candidatePath);
+          if (footerBytes) return footerBytes;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
         }
@@ -369,6 +338,394 @@ export default class SpatialDataTableSource extends AnnDataSource {
     }
     // Store does not support getRange.
     return null;
+  }
+
+  private async loadParquetFooterBytesForPath(path: string): Promise<Uint8Array | null> {
+    const { store } = this.storeRoot;
+    if (!store.getRange) {
+      return null;
+    }
+    const tailLength = 8;
+    const tailBytes = await store.getRange(`/${path}`, {
+      suffixLength: tailLength,
+    });
+    const normalizedTailBytes = toUint8Array(tailBytes);
+    if (!normalizedTailBytes || !hasParquetTailMagic(normalizedTailBytes)) {
+      return null;
+    }
+
+    const footerLength = new DataView(
+      normalizedTailBytes.buffer,
+      normalizedTailBytes.byteOffset,
+      normalizedTailBytes.byteLength
+    ).getInt32(0, true);
+
+    const footerBytes = await store.getRange(`/${path}`, {
+      suffixLength: footerLength + tailLength,
+    });
+    const normalizedFooterBytes = toUint8Array(footerBytes);
+    if (
+      !normalizedFooterBytes ||
+      normalizedFooterBytes.length !== footerLength + tailLength ||
+      !hasParquetTailMagic(normalizedFooterBytes)
+    ) {
+      return null;
+    }
+    return normalizedFooterBytes;
+  }
+
+  async loadParquetSchemaTable(parquetPath: string): Promise<ArrowTable | null> {
+    const schemaBytes = await this.loadParquetSchemaBytes(parquetPath);
+    if (!schemaBytes) {
+      return null;
+    }
+    const { readSchema } = await SpatialDataTableSource.parquetModulePromise;
+    const wasmSchema = readSchema(schemaBytes);
+    return tableFromIPC(wasmSchema.intoIPCStream());
+  }
+
+  private readParquetFooterBytesFromFileBytes(bytes: Uint8Array): Uint8Array | null {
+    if (bytes.length < 8) {
+      return null;
+    }
+    const footerLength = new DataView(
+      bytes.buffer,
+      bytes.byteOffset + bytes.length - 8,
+      8
+    ).getInt32(0, true);
+    const totalFooterSize = footerLength + 8;
+    if (totalFooterSize <= 0 || totalFooterSize > bytes.length) {
+      return null;
+    }
+    return bytes.subarray(bytes.length - totalFooterSize);
+  }
+
+  private async loadParquetPartMetadataFromFullFile(
+    path: string
+  ): Promise<ParquetPartMetadata | null> {
+    const { readMetadata, readSchema } = await SpatialDataTableSource.parquetModulePromise;
+    if (!readMetadata) {
+      return null;
+    }
+    const fileBytes = await this.loadParquetFileBytesAtPath(path);
+    if (!fileBytes) {
+      return null;
+    }
+    const schemaBytes = this.readParquetFooterBytesFromFileBytes(fileBytes);
+    if (!schemaBytes) {
+      return null;
+    }
+    const schemaTable = await tableFromIPC(readSchema(schemaBytes).intoIPCStream());
+    return {
+      path,
+      schema: schemaTable.schema,
+      schemaBytes,
+      metadata: readMetadata(schemaBytes),
+    };
+  }
+
+  private async countRowsFromFullParquetFile(path: string): Promise<number> {
+    const fileBytes = await this.loadParquetFileBytesAtPath(path);
+    if (!fileBytes) {
+      return 0;
+    }
+    const { readParquet } = await SpatialDataTableSource.parquetModulePromise;
+    const table = await tableFromIPC(readParquet(fileBytes, { columns: ['x'] }).intoIPCStream());
+    return table.numRows;
+  }
+
+  protected async resolveParquetRowCount(parquetPath: string): Promise<number> {
+    const datasetMetadata = await this.loadParquetDatasetMetadata(parquetPath);
+    if (datasetMetadata?.totalNumRows) {
+      return datasetMetadata.totalNumRows;
+    }
+
+    const directPart = await this.loadParquetPartMetadataFromFullFile(parquetPath);
+    if (directPart) {
+      return directPart.metadata.fileMetadata().numRows();
+    }
+
+    let totalRows = 0;
+    let foundPart = false;
+    for (let partIndex = 0; ; partIndex += 1) {
+      const partPath = `${parquetPath}/part.${partIndex}.parquet`;
+      const part = await this.loadParquetPartMetadataFromFullFile(partPath);
+      if (part) {
+        foundPart = true;
+        totalRows += part.metadata.fileMetadata().numRows();
+        continue;
+      }
+      const columnCount = await this.countRowsFromFullParquetFile(partPath);
+      if (columnCount > 0) {
+        foundPart = true;
+        totalRows += columnCount;
+        continue;
+      }
+      break;
+    }
+    if (foundPart) {
+      return totalRows;
+    }
+
+    return this.countRowsFromFullParquetFile(parquetPath);
+  }
+
+  private async loadParquetPartMetadata(path: string): Promise<ParquetPartMetadata | null> {
+    const { readMetadata, readSchema } = await SpatialDataTableSource.parquetModulePromise;
+    if (!readMetadata) {
+      return null;
+    }
+    const schemaBytes = await this.loadParquetFooterBytesForPath(path);
+    if (!schemaBytes) {
+      return null;
+    }
+    const schemaTable = await tableFromIPC(readSchema(schemaBytes).intoIPCStream());
+    return {
+      path,
+      schema: schemaTable.schema,
+      schemaBytes,
+      metadata: readMetadata(schemaBytes),
+    };
+  }
+
+  async loadParquetDatasetMetadata(parquetPath: string): Promise<ParquetDatasetMetadata | null> {
+    const { readMetadata } = await SpatialDataTableSource.parquetModulePromise;
+    const { store } = this.storeRoot;
+    if (!readMetadata || !store.getRange) {
+      return null;
+    }
+
+    const directPart = await this.loadParquetPartMetadata(parquetPath);
+    const parts: ParquetPartMetadata[] = [];
+    if (directPart) {
+      parts.push(directPart);
+    } else {
+      for (let partIndex = 0; ; partIndex++) {
+        const part = await this.loadParquetPartMetadata(`${parquetPath}/part.${partIndex}.parquet`);
+        if (!part) {
+          break;
+        }
+        parts.push(part);
+      }
+    }
+
+    if (parts.length === 0) {
+      return null;
+    }
+
+    const numRowsByPart = parts.map((part) => part.metadata.fileMetadata().numRows());
+    const numRowGroupsByPart = parts.map((part) => part.metadata.numRowGroups());
+    const numRowsPerGroupByPart = parts.map((part) =>
+      part.metadata.numRowGroups() > 0 ? part.metadata.rowGroup(0).numRows() : 0
+    );
+    const rowGroupRows = parts.flatMap((part) =>
+      Array.from({ length: part.metadata.numRowGroups() }, (_value, rowGroupIndex) =>
+        part.metadata.rowGroup(rowGroupIndex).numRows()
+      )
+    );
+    return {
+      totalNumRows: numRowsByPart.reduce((acc, cur) => acc + cur, 0),
+      totalNumRowGroups: numRowGroupsByPart.reduce((acc, cur) => acc + cur, 0),
+      numRowsByPart,
+      numRowGroupsByPart,
+      numRowsPerGroupByPart,
+      rowGroupRows,
+      schema: parts[0]?.schema ?? null,
+      parts,
+    };
+  }
+
+  async canLoadParquetRowGroups(): Promise<boolean> {
+    const module = await SpatialDataTableSource.parquetModulePromise;
+    return (
+      typeof module.readMetadata === 'function' && typeof module.readParquetRowGroup === 'function'
+    );
+  }
+
+  /**
+   * Fetch compressed row-group bytes via range read (no parquet decode on the caller thread).
+   */
+  protected async readParquetRowGroupBytesByGroupIndex(
+    parquetPath: string,
+    rowGroupIndex: number
+  ): Promise<{
+    schemaBytes: Uint8Array;
+    rowGroupBytes: Uint8Array;
+    rowGroupIndex: number;
+    globalRowGroupIndex: number;
+  } | null> {
+    const { store } = this.storeRoot;
+    if (!store.getRange) {
+      return null;
+    }
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    if (!dataset || rowGroupIndex < 0 || rowGroupIndex >= dataset.totalNumRowGroups) {
+      return null;
+    }
+
+    let cumulativeRowGroups = 0;
+    for (const part of dataset.parts) {
+      const partRowGroupCount = part.metadata.numRowGroups();
+      if (rowGroupIndex >= cumulativeRowGroups + partRowGroupCount) {
+        cumulativeRowGroups += partRowGroupCount;
+        continue;
+      }
+      const relativeRowGroupIndex = rowGroupIndex - cumulativeRowGroups;
+      const rowGroup = part.metadata.rowGroup(relativeRowGroupIndex);
+      const offset = toSafeNumber(rowGroup.fileOffset(), 'row-group file offset');
+      const length = toSafeNumber(rowGroup.compressedSize(), 'row-group compressed size');
+      const bytes = await store.getRange(`/${part.path}`, { offset, length });
+      const rowGroupBytes = toUint8Array(bytes);
+      if (!rowGroupBytes) {
+        return null;
+      }
+      return {
+        schemaBytes: part.schemaBytes,
+        rowGroupBytes,
+        rowGroupIndex: relativeRowGroupIndex,
+        globalRowGroupIndex: rowGroupIndex,
+      };
+    }
+    return null;
+  }
+
+  protected async readParquetRowGroupsBytesCapped(
+    parquetPath: string,
+    maxRows: number
+  ): Promise<
+    Array<{
+      schemaBytes: Uint8Array;
+      rowGroupBytes: Uint8Array;
+      rowGroupIndex: number;
+    }>
+  > {
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    if (!dataset || dataset.totalNumRowGroups <= 0) {
+      return [];
+    }
+
+    const chunks: Array<{
+      schemaBytes: Uint8Array;
+      rowGroupBytes: Uint8Array;
+      rowGroupIndex: number;
+    }> = [];
+    let accumulated = 0;
+    for (let rowGroupIndex = 0; rowGroupIndex < dataset.totalNumRowGroups; rowGroupIndex += 1) {
+      if (accumulated >= maxRows) {
+        break;
+      }
+      const chunk = await this.readParquetRowGroupBytesByGroupIndex(parquetPath, rowGroupIndex);
+      if (!chunk) {
+        continue;
+      }
+      chunks.push(chunk);
+      const rowCount = dataset.rowGroupRows[rowGroupIndex];
+      if (typeof rowCount === 'number' && Number.isFinite(rowCount)) {
+        accumulated += rowCount;
+      } else {
+        accumulated = maxRows;
+      }
+    }
+    return chunks;
+  }
+
+  /**
+   * Row-group and part byte payloads for worker-side parquet decode.
+   */
+  protected async readParquetWorkerPayload(
+    parquetPath: string,
+    options: {
+      maxRows: number;
+      fullPartsForFallback?: boolean;
+      /** When false (default), only part bytes are fetched for worker decode. */
+      includeRowGroups?: boolean;
+    }
+  ): Promise<{
+    rowGroups: Array<{
+      schemaBytes: Uint8Array;
+      rowGroupBytes: Uint8Array;
+      rowGroupIndex: number;
+    }>;
+    parts: Uint8Array[];
+  }> {
+    const includeRowGroups = options.includeRowGroups === true;
+    const canUseRowGroups = includeRowGroups && (await this.canLoadParquetRowGroups());
+    const rowGroups = canUseRowGroups
+      ? await this.readParquetRowGroupsBytesCapped(parquetPath, options.maxRows)
+      : [];
+    const partsMaxRows = options.fullPartsForFallback
+      ? Number.POSITIVE_INFINITY
+      : options.maxRows;
+    const { parts } = await this.readParquetDatasetBytesCapped(parquetPath, partsMaxRows);
+    return { rowGroups, parts };
+  }
+
+  async loadParquetRowGroupByGroupIndex(
+    parquetPath: string,
+    rowGroupIndex: number,
+    readOptions?: ParquetRowGroupReadOptions
+  ): Promise<ArrowTable | null> {
+    const { readParquetRowGroup } = await SpatialDataTableSource.parquetModulePromise;
+    if (!readParquetRowGroup) {
+      return null;
+    }
+    const chunk = await this.readParquetRowGroupBytesByGroupIndex(parquetPath, rowGroupIndex);
+    if (!chunk) {
+      return null;
+    }
+    return tableFromIPC(
+      readParquetRowGroup(
+        chunk.schemaBytes,
+        chunk.rowGroupBytes,
+        chunk.rowGroupIndex,
+        readOptions
+      ).intoIPCStream()
+    );
+  }
+
+  async loadParquetRowGroupColumnExtent(
+    parquetPath: string,
+    columnName: string,
+    rowGroupIndex: number
+  ): Promise<{ min: number | null; max: number | null } | null> {
+    const cacheKey = `${parquetPath}::${rowGroupIndex}::${columnName}`;
+    const cached = this.rowGroupColumnExtentCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    const rowCount = dataset?.rowGroupRows?.[rowGroupIndex];
+    if (!rowCount) {
+      return null;
+    }
+    const columnOptions: ParquetRowGroupReadOptions = { columns: [columnName] };
+    const minTable = await this.loadParquetRowGroupByGroupIndex(
+      parquetPath,
+      rowGroupIndex,
+      { ...columnOptions, limit: 1 }
+    );
+    const minColumn = minTable?.getChild(columnName);
+    if (!minColumn || minColumn.length === 0) {
+      return null;
+    }
+    let maxValue: number | null = parquetColumnValueToNumber(minColumn.get(0));
+    if (rowCount > 1) {
+      const maxTable = await this.loadParquetRowGroupByGroupIndex(parquetPath, rowGroupIndex, {
+        ...columnOptions,
+        offset: rowCount - 1,
+        limit: 1,
+      });
+      const maxColumn = maxTable?.getChild(columnName);
+      if (maxColumn && maxColumn.length > 0) {
+        maxValue = parquetColumnValueToNumber(maxColumn.get(0));
+      }
+    }
+    const extent = {
+      min: parquetColumnValueToNumber(minColumn.get(0)),
+      max: maxValue,
+    };
+    this.rowGroupColumnExtentCache.set(cacheKey, extent);
+    return extent;
   }
 
   /**
@@ -409,75 +766,408 @@ export default class SpatialDataTableSource extends AnnDataSource {
     return tablePromise;
   }
 
-  private async _loadParquetTableUncached(parquetPath: string, columns?: string[]): Promise<ArrowTable> {
-    const { readParquet, readSchema } = await SpatialDataTableSource.parquetModulePromise;
+  private async discoverMultipartPartPaths(parquetPath: string): Promise<string[]> {
+    const partPaths: string[] = [];
+    for (let partIndex = 0; ; partIndex += 1) {
+      const partPath = `${parquetPath}/part.${partIndex}.parquet`;
+      const bytes = await this.loadParquetFileBytesAtPath(partPath);
+      if (!bytes) {
+        break;
+      }
+      partPaths.push(partPath);
+    }
+    return partPaths;
+  }
 
-    const options = {
-      columns,
-    };
+  private async loadMultipartParquetTableFromPartPaths(
+    parquetPath: string,
+    partPaths: string[],
+    columns: string[] | undefined,
+    readParquet: ParquetModule['readParquet'],
+    readSchema: ParquetModule['readSchema']
+  ): Promise<ArrowTable> {
+    const tables: ArrowTable[] = [];
+    for (const partPath of partPaths) {
+      const parquetBytes = await this.loadParquetFileBytesAtPath(partPath);
+      if (!parquetBytes) {
+        throw new Error(`Failed to load parquet part at ${partPath}.`);
+      }
+      tables.push(
+        await this.readParquetTableFromFileBytes(
+          parquetBytes,
+          columns,
+          readParquet,
+          readSchema,
+          parquetPath
+        )
+      );
+    }
+    if (tables.length === 0) {
+      throw new Error(`Failed to load multipart parquet data from ${parquetPath}.`);
+    }
+    return tables.slice(1).reduce((merged, part) => merged.concat(part), tables[0]);
+  }
 
-    let indexColumnName: string | undefined;
+  protected async readParquetDatasetBytes(parquetPath: string): Promise<Uint8Array[]> {
+    const capped = await this.readParquetDatasetBytesCapped(parquetPath, Number.POSITIVE_INFINITY);
+    return capped.parts;
+  }
 
-    if (columns?.length) {
-      // If columns are specified, we also want to ensure that the index column is included.
-      // Otherwise, the user wants the full table anyway.
-
-      // We first try to load the schema bytes to determine the index column name.
-      // Perhaps in the future SpatialData can store the index column name
-      // in the .zattrs so that we do not need to load the schema first,
-      // since only certain stores such as FetchStores support getRange.
-      // Reference: https://github.com/scverse/spatialdata/issues/958
-      try {
-        const schemaBytes = await this.loadParquetSchemaBytes(parquetPath);
-        if (schemaBytes) {
-          const wasmSchema = readSchema(schemaBytes);
-          const arrowTableForSchema = await tableFromIPC(wasmSchema.intoIPCStream());
-          indexColumnName = tableToIndexColumnName(arrowTableForSchema);
+  /**
+   * Read parquet part bytes up to a row cap. Uses dataset metadata to avoid
+   * loading parts beyond the cap when row counts per part are known.
+   */
+  protected async readParquetDatasetBytesCapped(
+    parquetPath: string,
+    maxRows: number
+  ): Promise<{ parts: Uint8Array[]; totalRows: number; truncated: boolean }> {
+    const totalRows = await this.resolveParquetRowCount(parquetPath);
+    if (totalRows <= maxRows) {
+      const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+      if (dataset?.parts.length) {
+        const parts: Uint8Array[] = [];
+        for (const part of dataset.parts) {
+          const bytes = await this.loadParquetFileBytesAtPath(part.path);
+          if (!bytes) {
+            // Strict fail — see docs/plans/parquet-io-error-handling.md
+            throw new Error(`Missing parquet part bytes at ${part.path}`);
+          }
+          parts.push(bytes);
         }
-      } catch (e: unknown) {
-        // If we fail to load the schema bytes, we can proceed to try to load the full table bytes,
-        // for instance if range requests are not supported but the full table can be loaded.
-        //@ts-expect-error e.message not a property of e: unknown
-        console.warn(`Failed to load parquet schema bytes for ${parquetPath}: ${e.message}`);
+        return { parts, totalRows, truncated: false };
+      }
+      const bytes = await this.loadParquetFileBytesAtPath(parquetPath);
+      return { parts: bytes ? [bytes] : [], totalRows, truncated: false };
+    }
+
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    let partPaths: string[] = [];
+    if (dataset?.parts.length) {
+      partPaths = dataset.parts.map((part) => part.path);
+    } else {
+      const discovered = await this.discoverMultipartPartPaths(parquetPath);
+      partPaths = discovered.length > 0 ? discovered : [parquetPath];
+    }
+
+    const numRowsByPart = dataset?.numRowsByPart ?? [];
+    const parts: Uint8Array[] = [];
+    let accumulated = 0;
+    for (let partIndex = 0; partIndex < partPaths.length; partIndex += 1) {
+      const remaining = maxRows - accumulated;
+      if (remaining <= 0) {
+        break;
+      }
+      const partPath = partPaths[partIndex];
+      const bytes = await this.loadParquetFileBytesAtPath(partPath);
+      if (!bytes) {
+        // Strict fail (sibling capped table loader uses continue) — docs/plans/parquet-io-error-handling.md
+        throw new Error(`Missing parquet bytes at ${partPath}`);
+      }
+      parts.push(bytes);
+      const partRows = numRowsByPart[partIndex];
+      if (typeof partRows === 'number' && Number.isFinite(partRows)) {
+        accumulated += partRows;
+      } else {
+        accumulated = maxRows;
+      }
+      if (accumulated >= maxRows) {
+        break;
       }
     }
-    // Load the full table bytes.
 
-    // TODO: can we avoid loading the full table bytes
-    // if we only need a subset of columns?
-    // For example, if the store supports
-    // getRange like above to get the schema bytes.
-    // See https://github.com/kylebarron/parquet-wasm/issues/758
+    return { parts, totalRows, truncated: true };
+  }
+
+  async loadParquetTableCapped(
+    parquetPath: string,
+    columns: string[] | undefined,
+    maxRows: number,
+    options: { useRowGroupReads?: boolean } = {}
+  ): Promise<{ table: ArrowTable; totalRows: number; truncated: boolean }> {
+    const totalRows = await this.resolveParquetRowCount(parquetPath);
+    const truncated = totalRows > maxRows;
+    const targetRows = truncated ? maxRows : totalRows;
+
+    if (options.useRowGroupReads === true && (await this.canLoadParquetRowGroups())) {
+      try {
+        const table = await this._loadParquetTableRowGroupsCapped(
+          parquetPath,
+          columns,
+          targetRows
+        );
+        return { table, totalRows, truncated };
+      } catch (error) {
+        console.warn(
+          `Row-group parquet read failed for ${parquetPath}; falling back to full-file decode.`,
+          error
+        );
+      }
+    }
+
+    if (!truncated) {
+      const table = await this.loadParquetTable(parquetPath, columns);
+      return { table, totalRows, truncated: false };
+    }
+    const table = await this._loadParquetTableUncachedCapped(parquetPath, columns, maxRows);
+    return { table, totalRows, truncated: true };
+  }
+
+  /**
+   * Load up to {@link maxRows} via per-row-group range reads and optional column
+   * projection. Avoids fetching entire parquet part files when the store supports
+   * byte-range reads.
+   */
+  private async _loadParquetTableRowGroupsCapped(
+    parquetPath: string,
+    columns: string[] | undefined,
+    maxRows: number
+  ): Promise<ArrowTable> {
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    if (!dataset || dataset.totalNumRowGroups <= 0) {
+      throw new Error(`No row groups available for ${parquetPath}.`);
+    }
+
+    const { readSchema } = await SpatialDataTableSource.parquetModulePromise;
+    const resolvedColumns = columns?.length
+      ? await this.resolveParquetTableColumns(
+          parquetPath,
+          columns,
+          readSchema,
+          dataset.parts[0]?.schemaBytes
+        )
+      : undefined;
+    const readOptions: ParquetRowGroupReadOptions | undefined = resolvedColumns?.length
+      ? { columns: resolvedColumns }
+      : undefined;
+
+    const tables: ArrowTable[] = [];
+    let accumulated = 0;
+    for (let rowGroupIndex = 0; rowGroupIndex < dataset.totalNumRowGroups; rowGroupIndex += 1) {
+      if (accumulated >= maxRows) {
+        break;
+      }
+      let table = await this.loadParquetRowGroupByGroupIndex(
+        parquetPath,
+        rowGroupIndex,
+        readOptions
+      );
+      if (!table || table.numRows === 0) {
+        continue;
+      }
+      const remaining = maxRows - accumulated;
+      if (table.numRows > remaining) {
+        table = table.slice(0, remaining);
+      }
+      tables.push(table);
+      accumulated += table.numRows;
+    }
+
+    if (tables.length === 0) {
+      throw new Error(`Failed to load row-group capped parquet data from ${parquetPath}.`);
+    }
+    return tables.slice(1).reduce((merged, part) => merged.concat(part), tables[0]);
+  }
+
+  private async _loadParquetTableUncachedCapped(
+    parquetPath: string,
+    columns: string[] | undefined,
+    maxRows: number
+  ): Promise<ArrowTable> {
+    const { readParquet, readSchema } = await SpatialDataTableSource.parquetModulePromise;
+
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    let partPaths: string[] = [];
+    if (dataset?.parts.length) {
+      partPaths = dataset.parts.map((part) => part.path);
+    } else {
+      const discovered = await this.discoverMultipartPartPaths(parquetPath);
+      partPaths = discovered.length > 0 ? discovered : [parquetPath];
+    }
+
+    const tables: ArrowTable[] = [];
+    let accumulated = 0;
+    for (let partIndex = 0; partIndex < partPaths.length; partIndex += 1) {
+      const remaining = maxRows - accumulated;
+      if (remaining <= 0) {
+        break;
+      }
+      const partPath = partPaths[partIndex];
+      const parquetBytes = await this.loadParquetFileBytesAtPath(partPath);
+      if (!parquetBytes) {
+        continue;
+      }
+      const partTable = await this.readParquetTableFromFileBytes(
+        parquetBytes,
+        columns,
+        readParquet,
+        readSchema,
+        parquetPath
+      );
+      if (partTable.numRows <= remaining) {
+        tables.push(partTable);
+        accumulated += partTable.numRows;
+      } else {
+        tables.push(partTable.slice(0, remaining));
+        break;
+      }
+    }
+
+    if (tables.length === 0) {
+      throw new Error(`Failed to load capped parquet data from ${parquetPath}.`);
+    }
+    return tables.slice(1).reduce((merged, part) => merged.concat(part), tables[0]);
+  }
+
+  protected async loadParquetFileBytesAtPath(path: string): Promise<Uint8Array | null> {
+    try {
+      const parquetBytes = await this.storeRoot.store.get(`/${path}`);
+      const normalizedBytes = toUint8Array(parquetBytes);
+      if (!normalizedBytes || !isParquetFileBytes(normalizedBytes)) {
+        return null;
+      }
+      return normalizedBytes;
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveParquetTableColumns(
+    parquetPath: string,
+    columns: string[] | undefined,
+    readSchema: ParquetModule['readSchema'],
+    schemaBytesFromPath?: Uint8Array | null
+  ): Promise<string[] | undefined> {
+    if (!columns?.length) {
+      return undefined;
+    }
+
+    let indexColumnName: string | undefined;
+    try {
+      const schemaBytes = schemaBytesFromPath ?? (await this.loadParquetSchemaBytes(parquetPath));
+      if (schemaBytes) {
+        const wasmSchema = readSchema(schemaBytes);
+        const arrowTableForSchema = await tableFromIPC(wasmSchema.intoIPCStream());
+        indexColumnName = tableToIndexColumnName(arrowTableForSchema);
+      }
+    } catch (e: unknown) {
+      //@ts-expect-error e.message not a property of e: unknown
+      console.warn(`Failed to load parquet schema bytes for ${parquetPath}: ${e.message}`);
+    }
+
+    if (indexColumnName && !columns.includes(indexColumnName)) {
+      return [...columns, indexColumnName];
+    }
+    return columns;
+  }
+
+  private async readParquetTableFromFileBytes(
+    parquetBytes: Uint8Array,
+    columns: string[] | undefined,
+    readParquet: ParquetModule['readParquet'],
+    readSchema: ParquetModule['readSchema'],
+    parquetPath: string
+  ): Promise<ArrowTable> {
+    let normalizedBytes = parquetBytes;
+    if (!ArrayBuffer.isView(normalizedBytes)) {
+      normalizedBytes = new Uint8Array(normalizedBytes);
+    }
+
+    let resolvedColumns = columns;
+    if (columns?.length) {
+      resolvedColumns = await this.resolveParquetTableColumns(
+        parquetPath,
+        columns,
+        readSchema
+      );
+      const wasmSchema = readSchema(normalizedBytes);
+      const arrowTableForSchema = await tableFromIPC(wasmSchema.intoIPCStream());
+      const indexColumnName = tableToIndexColumnName(arrowTableForSchema);
+      if (indexColumnName && resolvedColumns && !resolvedColumns.includes(indexColumnName)) {
+        resolvedColumns = [...resolvedColumns, indexColumnName];
+      }
+    }
+
+    const wasmTable = readParquet(
+      normalizedBytes,
+      resolvedColumns?.length ? { columns: resolvedColumns } : undefined
+    );
+    return tableFromIPC(wasmTable.intoIPCStream());
+  }
+
+  private async loadMultipartParquetTable(
+    parquetPath: string,
+    columns: string[] | undefined,
+    dataset: ParquetDatasetMetadata,
+    readParquet: ParquetModule['readParquet'],
+    readSchema: ParquetModule['readSchema']
+  ): Promise<ArrowTable> {
+    const resolvedColumns = columns?.length
+      ? await this.resolveParquetTableColumns(
+          parquetPath,
+          columns,
+          readSchema,
+          dataset.parts[0]?.schemaBytes
+        )
+      : undefined;
+
+    const tables: ArrowTable[] = [];
+    for (const part of dataset.parts) {
+      const parquetBytes = await this.loadParquetFileBytesAtPath(part.path);
+      if (!parquetBytes) {
+        throw new Error(`Failed to load parquet part at ${part.path}.`);
+      }
+      const wasmTable = readParquet(
+        parquetBytes,
+        resolvedColumns?.length ? { columns: resolvedColumns } : undefined
+      );
+      tables.push(await tableFromIPC(wasmTable.intoIPCStream()));
+    }
+
+    if (tables.length === 0) {
+      throw new Error(`Failed to load multipart parquet data from ${parquetPath}.`);
+    }
+    return tables.slice(1).reduce((merged, part) => merged.concat(part), tables[0]);
+  }
+
+  private async _loadParquetTableUncached(
+    parquetPath: string,
+    columns?: string[]
+  ): Promise<ArrowTable> {
+    const { readParquet, readSchema } = await SpatialDataTableSource.parquetModulePromise;
+
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    if (dataset && dataset.parts.length > 1) {
+      return this.loadMultipartParquetTable(
+        parquetPath,
+        columns,
+        dataset,
+        readParquet,
+        readSchema
+      );
+    }
+
+    const partPaths = await this.discoverMultipartPartPaths(parquetPath);
+    if (partPaths.length > 1) {
+      return this.loadMultipartParquetTableFromPartPaths(
+        parquetPath,
+        partPaths,
+        columns,
+        readParquet,
+        readSchema
+      );
+    }
+
     let parquetBytes = await this.loadParquetBytes(parquetPath);
     if (!parquetBytes) {
       throw new Error('Failed to load parquet data from store.');
     }
-    if (!ArrayBuffer.isView(parquetBytes)) {
-      // This is required because in vitessce-python the
-      // experimental.invoke store wrapper can return an ArrayBuffer,
-      // but readParquet expects a Uint8Array.
-      parquetBytes = new Uint8Array(parquetBytes);
-    }
-
-    if (columns?.length && !indexColumnName) {
-      // The user requested specific columns, but we did not load the schema bytes
-      // to successfully get the index column name.
-      // Here we try again to get the index column name, but this
-      // time from the full table bytes (rather than only the schema-bytes).
-      const wasmSchema = readSchema(parquetBytes);
-      /** @type {import('apache-arrow').Table} */
-      const arrowTableForSchema = await tableFromIPC(wasmSchema.intoIPCStream());
-      indexColumnName = tableToIndexColumnName(arrowTableForSchema);
-    }
-
-    if (options.columns?.length && indexColumnName) {
-      options.columns = [...options.columns, indexColumnName];
-    }
-
-    const wasmTable = readParquet(parquetBytes, options);
-    /** @type {import('apache-arrow').Table} */
-    const arrowTable = await tableFromIPC(wasmTable.intoIPCStream());
-    return arrowTable;
+    return this.readParquetTableFromFileBytes(
+      parquetBytes,
+      columns,
+      readParquet,
+      readSchema,
+      parquetPath
+    );
   }
 
   // TABLE-SPECIFIC METHODS

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -12,6 +12,7 @@ import {
   shapesAttrsSchema,
   tableAttrsSchema,
 } from '../schemas';
+import type { PointsLoadOptions } from '../pointsLoadOptions.js';
 import type { ShapesRenderData } from '../shapes';
 import { isSpatialData, loadFeatureRowIndexByFeatureIndex } from '../tableAssociations';
 import { type BaseTransformation, Identity, parseTransforms } from '../transformations';
@@ -30,6 +31,7 @@ import { Err, Ok } from '../types';
 import SpatialDataPointsSource from './VPointsSource';
 import SpatialDataShapesSource from './VShapesSource';
 import SpatialDataTableSource from './VTableSource';
+import type { PointsFeatureCatalog } from '../pointsTiling.js';
 
 /**
  * Parameters for creating element instances.
@@ -494,6 +496,10 @@ export class ShapesElement extends AbstractSpatialElement<'shapes', ShapesAttrs>
     });
     return renderData;
   }
+
+  async loadShapesInBounds(options: Parameters<SpatialDataShapesSource['loadShapesInBounds']>[1]) {
+    return this.vShapes.loadShapesInBounds(`shapes/${this.key}`, options);
+  }
 }
 
 // ============================================
@@ -528,11 +534,39 @@ export class PointsElement extends AbstractSpatialElement<'points', PointsAttrs>
     return this.attrs.coordinateTransformations;
   }
 
-  async loadPoints() {
-    //Error: Unexpected response status 500 INTERNAL SERVER ERROR
-    //IsADirectoryError: [Errno 21] Is a directory: '/MySpatialData.zarr/points/key/points.parquet'
-    //we have points.parquet/part.0.parquet etc.
-    return this.vPoints.loadPoints(`points/${this.key}`);
+  async loadPoints(options?: PointsLoadOptions) {
+    return this.vPoints.loadPoints(`points/${this.key}`, options);
+  }
+
+  async loadRowFeatureCodes(options?: {
+    memoryCap?: number;
+    featureCatalog?: PointsFeatureCatalog | null;
+  }) {
+    return this.vPoints.loadPointsRowFeatureCodes(`points/${this.key}`, options);
+  }
+
+  async loadFeatureCounts() {
+    return this.vPoints.loadFeatureCounts(`points/${this.key}`);
+  }
+
+  async listFeaturesWithCounts() {
+    return this.vPoints.listPointsFeaturesWithCounts(`points/${this.key}`);
+  }
+
+  async getPointsTilingMetadata() {
+    return this.vPoints.getPointsTilingMetadata(`points/${this.key}`);
+  }
+
+  async loadPointsInBounds(options: Parameters<SpatialDataPointsSource['loadPointsInBounds']>[1]) {
+    return this.vPoints.loadPointsInBounds(`points/${this.key}`, options);
+  }
+
+  async listFeatures() {
+    return this.vPoints.listPointsFeatures(`points/${this.key}`);
+  }
+
+  async getParquetRowCount() {
+    return this.vPoints.getPointsParquetRowCount(`points/${this.key}`);
   }
 }
 

--- a/packages/core/src/parquetWasmLoader.ts
+++ b/packages/core/src/parquetWasmLoader.ts
@@ -1,0 +1,121 @@
+export interface ParquetWasmTableLike {
+  intoIPCStream(): Uint8Array;
+}
+
+export interface ParquetWasmFileMetadata {
+  numRows(): number;
+}
+
+export interface ParquetWasmRowGroupMetadata {
+  numRows(): number;
+  fileOffset(): number | bigint;
+  compressedSize(): number | bigint;
+}
+
+export interface ParquetWasmMetadata {
+  fileMetadata(): ParquetWasmFileMetadata;
+  numRowGroups(): number;
+  rowGroup(index: number): ParquetWasmRowGroupMetadata;
+}
+
+export interface ParquetRowGroupReadOptions {
+  columns?: string[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface ParquetModule {
+  readParquet: (bytes: Uint8Array, options?: ParquetRowGroupReadOptions) => ParquetWasmTableLike;
+  readSchema: (bytes: Uint8Array) => ParquetWasmTableLike;
+  readMetadata?: (bytes: Uint8Array) => ParquetWasmMetadata;
+  readParquetRowGroup?: (
+    schemaBytes: Uint8Array,
+    rowGroupBytes: Uint8Array,
+    rowGroupIndex: number,
+    options?: ParquetRowGroupReadOptions
+  ) => ParquetWasmTableLike;
+}
+
+function normalizeParquetModule(module: unknown): ParquetModule {
+  if (typeof module !== 'object' || module === null) {
+    throw new Error('parquet-wasm module did not load as an object');
+  }
+  // External WASM builds have drifted API surfaces and incomplete declarations;
+  // keep the boundary narrow and capability-check every optional method.
+  const candidate = module as Record<string, unknown>;
+  const { readParquet, readSchema, readMetadata, readParquetRowGroup } = candidate;
+  if (typeof readParquet !== 'function' || typeof readSchema !== 'function') {
+    throw new Error('parquet-wasm module is missing required readParquet/readSchema APIs');
+  }
+  return {
+    readParquet: readParquet as ParquetModule['readParquet'],
+    readSchema: readSchema as ParquetModule['readSchema'],
+    readMetadata:
+      typeof readMetadata === 'function'
+        ? (readMetadata as ParquetModule['readMetadata'])
+        : undefined,
+    readParquetRowGroup:
+      typeof readParquetRowGroup === 'function'
+        ? (readParquetRowGroup as ParquetModule['readParquetRowGroup'])
+        : undefined,
+  };
+}
+
+async function initializeParquetModule(module: unknown) {
+  if (typeof module !== 'object' || module === null) {
+    return;
+  }
+  const record = module as Record<string, unknown>;
+  const initSync = record.initSync;
+  const defaultInit = record.default;
+
+  // Vitest/Node load the vendored browser ESM glue; initialize WASM from disk
+  // because undici cannot fetch file:// URLs.
+  if (import.meta.url.startsWith('file:') && typeof initSync === 'function') {
+    const [{ readFileSync }, { fileURLToPath }, { dirname, join }] = await Promise.all([
+      import('node:fs'),
+      import('node:url'),
+      import('node:path'),
+    ]);
+    const wasmPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '../vendor/parquet-wasm/parquet_wasm_bg.wasm'
+    );
+    initSync({ module: readFileSync(wasmPath) });
+    return;
+  }
+
+  if (typeof defaultInit === 'function') {
+    await defaultInit();
+  }
+}
+
+function parquetModuleSupportsRowGroupReads(module: ParquetModule): boolean {
+  return (
+    typeof module.readMetadata === 'function' && typeof module.readParquetRowGroup === 'function'
+  );
+}
+
+async function loadVendoredParquetModule(): Promise<ParquetModule> {
+  const module: unknown = await import(
+    /* @vite-ignore */
+    '../vendor/parquet-wasm/parquet_wasm.js'
+  );
+  await initializeParquetModule(module);
+  const normalized = normalizeParquetModule(module);
+  if (!parquetModuleSupportsRowGroupReads(normalized)) {
+    throw new Error(
+      'Vendored parquet-wasm is missing required row-group APIs (readMetadata, readParquetRowGroup)'
+    );
+  }
+  return normalized;
+}
+
+let parquetModulePromise: Promise<ParquetModule> | undefined;
+
+export function getParquetModule(): Promise<ParquetModule> {
+  if (!parquetModulePromise) {
+    parquetModulePromise = loadVendoredParquetModule();
+  }
+  return parquetModulePromise;
+}

--- a/packages/core/src/pointsFeatures.ts
+++ b/packages/core/src/pointsFeatures.ts
@@ -1,0 +1,310 @@
+import { Type } from 'apache-arrow';
+import type { Table, Vector } from 'apache-arrow';
+import {
+  isMortonSentinelValue,
+  MORTON_CODE_2D_COLUMN,
+  type PointsFeatureCatalog,
+  type PointsFeatureEntry,
+} from './pointsTiling.js';
+
+function dictionaryStrings(column: Vector): string[] | null {
+  if (column.type.typeId !== Type.Dictionary) {
+    return null;
+  }
+  for (const chunk of column.data) {
+    const dictionary = chunk.dictionary;
+    if (dictionary && dictionary.length > 0) {
+      return dictionary.toArray().map((value: unknown) => (value == null ? '' : String(value)));
+    }
+  }
+  return null;
+}
+
+function resolveFeatureName(nameValue: unknown, dictionary: string[] | null): string {
+  if (nameValue == null) {
+    return '';
+  }
+  if (dictionary && typeof nameValue === 'number' && Number.isFinite(nameValue)) {
+    return dictionary[nameValue] ?? '';
+  }
+  return String(nameValue);
+}
+
+export function buildFeatureCatalogFromColumns(
+  featureKey: string,
+  nameColumn: Vector,
+  codeColumn: Vector | null,
+  mortonColumn: Vector | null,
+  numRows: number
+): PointsFeatureCatalog {
+  const codeToName = new Map<number, string>();
+  const nameToCode = new Map<string, number>();
+  accumulateFeatureCatalogFromVectors(
+    codeToName,
+    nameToCode,
+    nameColumn,
+    codeColumn,
+    mortonColumn,
+    numRows
+  );
+  return featureCatalogFromCodeMap(featureKey, codeToName);
+}
+
+export function accumulateFeatureCatalogFromTable(
+  codeToName: Map<number, string>,
+  nameToCode: Map<string, number>,
+  table: Table,
+  featureKey: string,
+  featureCodeColumnName: string | undefined,
+  options: { skipMortonSentinels?: boolean } = {}
+): void {
+  const nameColumn = table.getChild(featureKey);
+  if (!nameColumn) {
+    return;
+  }
+  const codeColumn = featureCodeColumnName ? table.getChild(featureCodeColumnName) : null;
+  const mortonColumn =
+    options.skipMortonSentinels === true ? table.getChild(MORTON_CODE_2D_COLUMN) : null;
+  accumulateFeatureCatalogFromVectors(
+    codeToName,
+    nameToCode,
+    nameColumn,
+    codeColumn,
+    mortonColumn,
+    table.numRows
+  );
+}
+
+export function featureCatalogFromCodeMap(
+  featureKey: string,
+  codeToName: Map<number, string>
+): PointsFeatureCatalog {
+  const entries: PointsFeatureEntry[] = [...codeToName.entries()]
+    .sort((left, right) => left[0] - right[0])
+    .map(([code, name]) => ({ code, name }));
+  return { featureKey, entries };
+}
+
+/** Row-group reads can yield empty names for dictionary-only columns; prefer readParquet. */
+export function featureCatalogNeedsParquetFallback(codeToName: Map<number, string>): boolean {
+  if (codeToName.size === 0) {
+    return true;
+  }
+  return [...codeToName.values()].every((name) => name.length === 0);
+}
+
+export function featureCodeMapFromCatalog(
+  catalog: PointsFeatureCatalog | null | undefined
+): Map<string, number> | undefined {
+  if (!catalog) {
+    return undefined;
+  }
+  return new Map(catalog.entries.map((entry) => [entry.name, entry.code]));
+}
+
+function accumulateFeatureCatalogFromVectors(
+  codeToName: Map<number, string>,
+  nameToCode: Map<string, number>,
+  nameColumn: Vector,
+  codeColumn: Vector | null,
+  mortonColumn: Vector | null,
+  numRows: number
+): void {
+  const dictionary = dictionaryStrings(nameColumn);
+
+  for (let rowIndex = 0; rowIndex < numRows; rowIndex += 1) {
+    if (mortonColumn && rowIndex < 4 && isMortonSentinelValue(mortonColumn.get(rowIndex))) {
+      continue;
+    }
+    const name = resolveFeatureName(nameColumn.get(rowIndex), dictionary);
+    if (codeColumn) {
+      const codeValue = codeColumn.get(rowIndex);
+      const code = typeof codeValue === 'number' ? codeValue : Number(codeValue);
+      if (!Number.isFinite(code)) {
+        continue;
+      }
+      if (!codeToName.has(code)) {
+        codeToName.set(code, name);
+      }
+      continue;
+    }
+    if (!nameToCode.has(name)) {
+      nameToCode.set(name, nameToCode.size);
+    }
+    const code = nameToCode.get(name);
+    if (code !== undefined && !codeToName.has(code)) {
+      codeToName.set(code, name);
+    }
+  }
+}
+
+export function mergeDictionaryFeatureCatalogEntries(
+  codeToName: Map<number, string>,
+  nameColumn: Vector
+): boolean {
+  const dictionary = dictionaryStrings(nameColumn);
+  if (dictionary && dictionary.length > 0) {
+    for (let code = 0; code < dictionary.length; code += 1) {
+      if (!codeToName.has(code)) {
+        codeToName.set(code, dictionary[code] ?? '');
+      }
+    }
+    return true;
+  }
+
+  const numRows = nameColumn.length;
+  if (numRows <= 0) {
+    return false;
+  }
+  let added = false;
+  for (let row = 0; row < numRows; row += 1) {
+    const code = getDictionaryIndexAt(nameColumn, row);
+    if (code === null || !Number.isFinite(code) || codeToName.has(code)) {
+      continue;
+    }
+    const decoded = nameColumn.get(row);
+    const name = decoded == null ? '' : String(decoded);
+    if (name.length > 0) {
+      codeToName.set(code, name);
+      added = true;
+    }
+  }
+  return added;
+}
+
+export function buildFeatureCatalogFromDictionaryOnly(
+  featureKey: string,
+  nameColumn: Vector,
+  _codeColumn: Vector | null
+): PointsFeatureCatalog | null {
+  const codeToName = new Map<number, string>();
+  if (!mergeDictionaryFeatureCatalogEntries(codeToName, nameColumn)) {
+    return null;
+  }
+  if (codeToName.size === 0) {
+    return null;
+  }
+  return featureCatalogFromCodeMap(featureKey, codeToName);
+}
+
+export function isDictionaryFeatureColumn(column: Vector): boolean {
+  return column.type.typeId === Type.Dictionary;
+}
+
+function getDictionaryIndexAt(column: Vector, row: number): number | null {
+  if (!isDictionaryFeatureColumn(column) || row < 0 || row >= column.length) {
+    return null;
+  }
+  let currentRow = 0;
+  for (const chunk of column.data) {
+    const values = chunk.values;
+    if (!values) {
+      continue;
+    }
+    const chunkLength = chunk.length ?? values.length;
+    if (row < currentRow + chunkLength) {
+      const valueIndex = (chunk.offset ?? 0) + (row - currentRow);
+      if (valueIndex < 0 || valueIndex >= values.length) {
+        return null;
+      }
+      const index = values[valueIndex];
+      if (typeof index === 'number' && Number.isFinite(index)) {
+        return index;
+      }
+      if (typeof index === 'bigint') {
+        return Number(index);
+      }
+      const asNumber = Number(index);
+      return Number.isFinite(asNumber) ? asNumber : null;
+    }
+    currentRow += chunkLength;
+  }
+  return null;
+}
+
+function dictionaryIndexArray(column: Vector, numRows: number): Int32Array | null {
+  if (!isDictionaryFeatureColumn(column)) {
+    return null;
+  }
+  const rowCount = Math.min(numRows, column.length);
+  if (rowCount <= 0) {
+    return null;
+  }
+  const out = new Int32Array(rowCount);
+  for (let row = 0; row < rowCount; row += 1) {
+    const index = getDictionaryIndexAt(column, row);
+    out[row] = index !== null && Number.isFinite(index) ? index : 0;
+  }
+  return out;
+}
+
+/** Per-row integer codes for feature filtering (explicit codes column or dictionary indices). */
+export function resolveRowFeatureCodesFromTable(
+  table: Table,
+  featureKey: string,
+  featureCodeColumnName: string | undefined,
+  featureCodeByName?: ReadonlyMap<string, number>
+): ArrayLike<number> | undefined {
+  const nameColumn = table.getChild(featureKey);
+  if (featureCodeColumnName) {
+    return table.getChild(featureCodeColumnName)?.toArray();
+  }
+  if (!nameColumn) {
+    return undefined;
+  }
+  const dictionary = dictionaryStrings(nameColumn);
+
+  if (!featureCodeByName) {
+    return undefined;
+  }
+
+  const out = new Int32Array(table.numRows);
+  for (let rowIndex = 0; rowIndex < table.numRows; rowIndex += 1) {
+    const name = resolveFeatureName(nameColumn.get(rowIndex), dictionary);
+    out[rowIndex] = featureCodeByName.get(name) ?? -1;
+  }
+  return out;
+}
+
+export function featureFilterNeedsRowCodes(
+  featureCodes: readonly number[] | undefined,
+  featureCodeColumnName: string | undefined,
+  featureKey: string,
+  fields: string[]
+): boolean {
+  if (featureCodes === undefined) {
+    return false;
+  }
+  if (featureCodeColumnName) {
+    return true;
+  }
+  return fields.includes(featureKey);
+}
+
+/** Histogram of integer feature codes (single pass, worker-safe). */
+export function countFeatureCodesHistogram(
+  sourceFeatureCodes: ArrayLike<number>
+): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (let index = 0; index < sourceFeatureCodes.length; index += 1) {
+    const code = sourceFeatureCodes[index];
+    if (typeof code !== 'number' || !Number.isFinite(code)) {
+      continue;
+    }
+    counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function mergeFeatureCountsIntoCatalog(
+  catalog: PointsFeatureCatalog,
+  counts: ReadonlyMap<number, number>
+): PointsFeatureCatalog {
+  return {
+    ...catalog,
+    entries: catalog.entries.map((entry) => ({
+      ...entry,
+      count: counts.get(entry.code) ?? entry.count,
+    })),
+  };
+}

--- a/packages/core/src/pointsLimits.ts
+++ b/packages/core/src/pointsLimits.ts
@@ -1,0 +1,109 @@
+/** Maximum rows allowed for full-table points preload (canonical scatter path). */
+export const POINTS_PRELOAD_MAX_ROWS = 4_000_000;
+
+/** Default in-memory row cap for preloaded scatter (layer override via props panel). */
+export const DEFAULT_POINTS_MEMORY_CAP = POINTS_PRELOAD_MAX_ROWS;
+
+/** Default render row cap — points kept in memory may exceed this. */
+export const DEFAULT_POINTS_RENDER_CAP = POINTS_PRELOAD_MAX_ROWS;
+
+export interface PointsColumnarLike {
+  shape: number[];
+  data: ArrayLike<number>[];
+  pointCount?: number;
+}
+
+export function resolvePointsMemoryCap(configured?: number): number {
+  if (configured !== undefined && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return DEFAULT_POINTS_MEMORY_CAP;
+}
+
+export function resolvePointsRenderCap(configured?: number): number | undefined {
+  if (configured === undefined) {
+    return DEFAULT_POINTS_RENDER_CAP;
+  }
+  if (!Number.isFinite(configured) || configured <= 0) {
+    return undefined;
+  }
+  return Math.floor(configured);
+}
+
+export function columnarPointCount(shape: number[], data: ArrayLike<number>[]): number {
+  if (shape.length >= 2 && Number.isFinite(shape[1])) {
+    return shape[1];
+  }
+  return data[0]?.length ?? shape[0] ?? 0;
+}
+
+export function applyRenderCapToColumnar<T extends PointsColumnarLike>(
+  batch: T,
+  renderCap: number | undefined
+): T {
+  if (renderCap === undefined) {
+    return batch;
+  }
+  const pointCount = batch.pointCount ?? columnarPointCount(batch.shape, batch.data);
+  if (pointCount <= renderCap) {
+    return batch;
+  }
+  const axisCount = batch.shape[0] ?? batch.data.length;
+  const nextData = batch.data.map((column) => {
+    if (column instanceof Float32Array) {
+      return column.subarray(0, renderCap);
+    }
+    return Float32Array.from(column as ArrayLike<number>).subarray(0, renderCap);
+  });
+  return {
+    ...batch,
+    data: nextData,
+    shape: [axisCount, renderCap],
+    pointCount: renderCap,
+  };
+}
+
+export class PointsPreloadTooLargeError extends Error {
+  readonly rowCount: number;
+  readonly maxRows: number;
+
+  constructor(rowCount: number, maxRows: number = POINTS_PRELOAD_MAX_ROWS) {
+    super(
+      `${rowCount.toLocaleString()} points exceeds the ${maxRows.toLocaleString()} preload limit — use a Morton-sorted element or tiled path`
+    );
+    this.name = 'PointsPreloadTooLargeError';
+    this.rowCount = rowCount;
+    this.maxRows = maxRows;
+  }
+}
+
+export function preloadedColumnarPointCount(shape: number[], data: ArrayLike<number>[]): number {
+  if (shape.length >= 2 && Number.isFinite(shape[1])) {
+    return shape[1];
+  }
+  const fromData = data[0]?.length;
+  if (typeof fromData === 'number') {
+    return fromData;
+  }
+  return shape[0] ?? 0;
+}
+
+export function exceedsPointsPreloadLimit(rowCount: number): boolean {
+  return rowCount > POINTS_PRELOAD_MAX_ROWS;
+}
+
+export function pointsPreloadTruncatedMessage(loadedCount: number, totalCount: number): string {
+  return `Showing ${loadedCount.toLocaleString()} of ${totalCount.toLocaleString()} points (preload limit ${POINTS_PRELOAD_MAX_ROWS.toLocaleString()})`;
+}
+
+export function pointsFilteredMemoryCapMessage(
+  loadedCount: number,
+  memoryCap: number,
+  scannedRows?: number
+): string {
+  const scanned =
+    scannedRows !== undefined
+      ? ` after scanning ${scannedRows.toLocaleString()} rows`
+      : '';
+  return `Showing ${loadedCount.toLocaleString()} matching points (memory cap ${memoryCap.toLocaleString()}${scanned})`;
+}

--- a/packages/core/src/pointsLoadOptions.ts
+++ b/packages/core/src/pointsLoadOptions.ts
@@ -1,0 +1,31 @@
+export interface PointsLoadProgress {
+  scannedRows: number;
+  matchedRows: number;
+  partIndex: number;
+  partCount: number;
+}
+
+export interface PointsLoadOptions {
+  /** Max rows to retain in memory (unfiltered cap or filtered match cap). */
+  memoryCap?: number;
+  /** When set, scan the dataset for matching features instead of capping raw rows first. */
+  featureCodes?: readonly number[];
+  /** Progress callback for filtered scans (main thread). */
+  onProgress?: (progress: PointsLoadProgress) => void;
+  /**
+   * When true with {@link featureCodes}, scan the full dataset for matches (slow).
+   * Default UI uses in-memory runtime filtering instead.
+   */
+  fullDatasetFeatureScan?: boolean;
+}
+
+export interface PointsLoadResult {
+  shape: number[];
+  data: ArrayLike<number>[];
+  featureCodes?: ArrayLike<number>;
+  totalRowCount?: number;
+  preloadTruncated?: boolean;
+  /** Rows scanned when loading with an active feature filter. */
+  scannedRowCount?: number;
+  filterActive?: boolean;
+}

--- a/packages/core/src/pointsLoader.ts
+++ b/packages/core/src/pointsLoader.ts
@@ -1,0 +1,191 @@
+import type { PointsElement } from './models/index.js';
+import type { PointsLoadMode } from './types.js';
+import type {
+  PointsInBoundsResponse,
+  PointsTilingMetadata,
+  SpatialBounds,
+} from './pointsTiling.js';
+
+export type PointsEncodingKind =
+  | 'preloaded-columnar'
+  | 'morton-tiled'
+  | 'geoarrow-binary'
+  | 'geoarrow-tiled';
+
+export type PointsBatchFormat = 'columnar-ndarray' | 'arrow-record-batch';
+
+export interface PointsLoaderCapabilities {
+  kind: PointsEncodingKind;
+  batchFormat: PointsBatchFormat;
+  bounds?: SpatialBounds;
+  supportsViewportTiles: boolean;
+  supportsFeatureCodes?: boolean;
+}
+
+export interface ColumnarNdarrayPointsBatch {
+  format: 'columnar-ndarray';
+  data: ArrayLike<number>[];
+  shape: number[];
+  bounds?: SpatialBounds;
+  loadMode?: PointsLoadMode;
+  pointCount?: number;
+}
+
+export type PointsBatch = ColumnarNdarrayPointsBatch;
+
+export interface PointsLoadInBoundsOptions {
+  bounds: SpatialBounds;
+  featureCodes?: readonly number[];
+  signal?: AbortSignal;
+}
+
+export interface CorePointsLoader {
+  readonly capabilities: PointsLoaderCapabilities;
+  loadInBounds(options: PointsLoadInBoundsOptions): Promise<PointsBatch | null>;
+  loadAll?(options?: { signal?: AbortSignal }): Promise<PointsBatch>;
+}
+
+export interface PreloadedColumnarInput {
+  shape: number[];
+  data: ArrayLike<number>[];
+}
+
+export function resolvePointsEncoding(
+  preloaded: PreloadedColumnarInput | null | undefined,
+  metadata: PointsTilingMetadata | null | undefined,
+  wantsOptimized: boolean
+): PointsEncodingKind {
+  if (preloaded) {
+    return 'preloaded-columnar';
+  }
+  if (wantsOptimized && metadata?.supportsRowGroupRangeReads && metadata.bounds) {
+    return 'morton-tiled';
+  }
+  return 'preloaded-columnar';
+}
+
+function columnarPointCount(shape: number[], data: ArrayLike<number>[]): number {
+  if (shape.length >= 2 && Number.isFinite(shape[1])) {
+    return shape[1];
+  }
+  const fromData = data[0]?.length;
+  if (typeof fromData === 'number') {
+    return fromData;
+  }
+  return shape[0] ?? 0;
+}
+
+function toColumnarBatch(
+  result: PointsInBoundsResponse | PreloadedColumnarInput,
+  overrides?: Partial<ColumnarNdarrayPointsBatch>
+): ColumnarNdarrayPointsBatch {
+  const shape = result.shape ?? [];
+  const data = result.data;
+  const pointCount = columnarPointCount(shape, data);
+  return {
+    format: 'columnar-ndarray',
+    data,
+    shape,
+    bounds: 'bounds' in result ? result.bounds : overrides?.bounds,
+    loadMode: 'loadMode' in result ? result.loadMode : overrides?.loadMode,
+    pointCount,
+    ...overrides,
+  };
+}
+
+export function createMortonTiledPointsLoader(
+  element: PointsElement,
+  metadata: PointsTilingMetadata
+): CorePointsLoader {
+  const capabilities: PointsLoaderCapabilities = {
+    kind: 'morton-tiled',
+    batchFormat: 'columnar-ndarray',
+    bounds: metadata.bounds,
+    supportsViewportTiles: true,
+    supportsFeatureCodes: Boolean(metadata.featureKey),
+  };
+
+  return {
+    capabilities,
+    async loadInBounds(options: PointsLoadInBoundsOptions): Promise<PointsBatch | null> {
+      const result = await element.loadPointsInBounds(options);
+      return toColumnarBatch(result);
+    },
+  };
+}
+
+export function createPreloadedColumnarPointsLoader(
+  element: PointsElement,
+  preloaded: PreloadedColumnarInput
+): CorePointsLoader {
+  const batch = toColumnarBatch(preloaded, { loadMode: 'full-filter' });
+  const capabilities: PointsLoaderCapabilities = {
+    kind: 'preloaded-columnar',
+    batchFormat: 'columnar-ndarray',
+    bounds: inferBoundsFromColumnar(preloaded),
+    supportsViewportTiles: false,
+    supportsFeatureCodes: true,
+  };
+
+  return {
+    capabilities,
+    async loadInBounds(options: PointsLoadInBoundsOptions): Promise<PointsBatch | null> {
+      void element;
+      void options;
+      return batch;
+    },
+    async loadAll() {
+      return batch;
+    },
+  };
+}
+
+function inferBoundsFromColumnar(preloaded: PreloadedColumnarInput) {
+  const xs = preloaded.data[0];
+  const ys = preloaded.data[1];
+  if (!xs || !ys || preloaded.shape[0] === 0) {
+    return undefined;
+  }
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  const count = preloaded.shape[0];
+  for (let index = 0; index < count; index += 1) {
+    const x = xs[index];
+    const y = ys[index];
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) {
+    return undefined;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+export function createPointsLoaderForElement(
+  element: PointsElement,
+  options: {
+    preloaded?: PreloadedColumnarInput | null;
+    tilingMetadata?: PointsTilingMetadata | null;
+    wantsOptimized: boolean;
+  }
+): CorePointsLoader | null {
+  const encoding = resolvePointsEncoding(
+    options.preloaded,
+    options.tilingMetadata,
+    options.wantsOptimized
+  );
+
+  if (encoding === 'morton-tiled' && options.tilingMetadata?.bounds) {
+    return createMortonTiledPointsLoader(element, options.tilingMetadata);
+  }
+
+  if (options.preloaded) {
+    return createPreloadedColumnarPointsLoader(element, options.preloaded);
+  }
+
+  return null;
+}

--- a/packages/core/src/pointsTiling.ts
+++ b/packages/core/src/pointsTiling.ts
@@ -1,0 +1,373 @@
+import type { Table as ArrowTable } from 'apache-arrow';
+import type { AxisAlignedBounds, PointsColumnarData } from './spatialViewFit.js';
+
+export const MORTON_CODE_2D_COLUMN = 'morton_code_2d';
+export const MORTON_CODE_EXTREME_VALUE_INDICATOR = 0;
+export const MORTON_CODE_BITS_PER_AXIS = 16;
+export const MORTON_CODE_VALUE_MAX = 2 ** MORTON_CODE_BITS_PER_AXIS - 1;
+
+export type SpatialBounds = AxisAlignedBounds;
+
+export interface PointsFeatureEntry {
+  code: number;
+  name: string;
+  /** Row count in the dataset or loaded sample, when known. */
+  count?: number;
+}
+
+export interface PointsFeatureCatalog {
+  featureKey: string;
+  entries: PointsFeatureEntry[];
+}
+
+export interface PointsInBoundsOptions {
+  bounds: SpatialBounds;
+  /** Integer codes matching `{feature_key}_codes` in the Morton Parquet artifact. */
+  featureCodes?: readonly number[];
+  zoom?: number;
+  signal?: AbortSignal;
+  columns?: string[];
+}
+
+export interface PointsTilingMetadata {
+  kind: 'morton-points';
+  parquetPath: string;
+  axisNames: string[];
+  featureKey?: string;
+  featureCodeColumnName: string;
+  mortonCodeColumnName: typeof MORTON_CODE_2D_COLUMN;
+  totalRows: number;
+  totalRowGroups: number;
+  maxRowsPerGroup: number;
+  rowGroupRowCounts?: number[];
+  supportsRowGroupRangeReads: boolean;
+  bounds?: SpatialBounds;
+}
+
+export type PointsInBoundsResponse = PointsColumnarData & {
+  bounds: SpatialBounds;
+  loadMode: 'row-groups' | 'full-filter';
+  tiling?: PointsTilingMetadata;
+  featureIndices?: ArrayLike<number>;
+};
+
+export function origCoordToNormCoord(x: number, y: number, bbox: SpatialBounds): [number, number] {
+  const xRange = bbox.maxX - bbox.minX;
+  const yRange = bbox.maxY - bbox.minY;
+  if (xRange <= 0 || yRange <= 0) {
+    return [0, 0];
+  }
+  return [
+    Math.max(
+      0,
+      Math.min(
+        MORTON_CODE_VALUE_MAX,
+        Math.floor(((x - bbox.minX) / xRange) * MORTON_CODE_VALUE_MAX)
+      )
+    ),
+    Math.max(
+      0,
+      Math.min(
+        MORTON_CODE_VALUE_MAX,
+        Math.floor(((y - bbox.minY) / yRange) * MORTON_CODE_VALUE_MAX)
+      )
+    ),
+  ];
+}
+
+function intersects(
+  ax0: number,
+  ay0: number,
+  ax1: number,
+  ay1: number,
+  bx0: number,
+  by0: number,
+  bx1: number,
+  by1: number
+) {
+  return !(ax1 < bx0 || bx1 < ax0 || ay1 < by0 || by1 < ay0);
+}
+
+function contained(
+  ix0: number,
+  iy0: number,
+  ix1: number,
+  iy1: number,
+  ox0: number,
+  oy0: number,
+  ox1: number,
+  oy1: number
+) {
+  return ox0 <= ix0 && ix0 <= ix1 && ix1 <= ox1 && oy0 <= iy0 && iy0 <= iy1 && iy1 <= oy1;
+}
+
+function cellRange(prefix: number, level: number, bits: number): [number, number] {
+  const shift = 2 * (bits - level);
+  const power = 2 ** shift;
+  return [prefix * power, (prefix + 1) * power - 1];
+}
+
+export function mergeAdjacentIntervals(
+  intervals: Array<[number, number]>
+): Array<[number, number]> {
+  if (intervals.length === 0) {
+    return [];
+  }
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [sorted[0]];
+  for (const [lo, hi] of sorted.slice(1)) {
+    const last = merged[merged.length - 1];
+    if (lo <= last[1] + 1) {
+      last[1] = Math.max(last[1], hi);
+    } else {
+      merged.push([lo, hi]);
+    }
+  }
+  return merged;
+}
+
+export function zcoverRectangle(
+  rx0: number,
+  ry0: number,
+  rx1: number,
+  ry1: number,
+  bits = MORTON_CODE_BITS_PER_AXIS
+): Array<[number, number]> {
+  const maxCoord = 2 ** bits - 1;
+  const x0 = Math.max(0, Math.min(maxCoord, Math.min(rx0, rx1)));
+  const x1 = Math.max(0, Math.min(maxCoord, Math.max(rx0, rx1)));
+  const y0 = Math.max(0, Math.min(maxCoord, Math.min(ry0, ry1)));
+  const y1 = Math.max(0, Math.min(maxCoord, Math.max(ry0, ry1)));
+
+  const intervals: Array<[number, number]> = [];
+  const stack: Array<[number, number, number, number, number, number]> = [
+    [0, 0, 0, 0, maxCoord, maxCoord],
+  ];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    const [prefix, level, xmin, ymin, xmax, ymax] = current;
+    if (!intersects(xmin, ymin, xmax, ymax, x0, y0, x1, y1)) {
+      continue;
+    }
+    if (contained(xmin, ymin, xmax, ymax, x0, y0, x1, y1) || level === bits) {
+      intervals.push(cellRange(prefix, level, bits));
+      continue;
+    }
+
+    const midx = Math.floor((xmin + xmax) / 2);
+    const midy = Math.floor((ymin + ymax) / 2);
+    const nextPrefix = prefix * 4;
+    stack.push([nextPrefix + 0, level + 1, xmin, ymin, midx, midy]);
+    stack.push([nextPrefix + 1, level + 1, midx + 1, ymin, xmax, midy]);
+    stack.push([nextPrefix + 2, level + 1, xmin, midy + 1, midx, ymax]);
+    stack.push([nextPrefix + 3, level + 1, midx + 1, midy + 1, xmax, ymax]);
+  }
+
+  return mergeAdjacentIntervals(intervals);
+}
+
+export function mortonIntervalsForBounds(
+  allPointsBounds: SpatialBounds,
+  queryBounds: SpatialBounds
+): Array<[number, number]> {
+  const [x0, y0] = origCoordToNormCoord(queryBounds.minX, queryBounds.minY, allPointsBounds);
+  const [x1, y1] = origCoordToNormCoord(queryBounds.maxX, queryBounds.maxY, allPointsBounds);
+  return zcoverRectangle(x0, y0, x1, y1);
+}
+
+function getNumericValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  return null;
+}
+
+export function isMortonSentinelValue(value: unknown): boolean {
+  return getNumericValue(value) === MORTON_CODE_EXTREME_VALUE_INDICATOR;
+}
+
+export function extractSentinelBoundingBox(
+  table: ArrowTable,
+  xColumnName = 'x',
+  yColumnName = 'y',
+  mortonColumnName = MORTON_CODE_2D_COLUMN
+): SpatialBounds | null {
+  const xColumn = table.getChild(xColumnName);
+  const yColumn = table.getChild(yColumnName);
+  const mortonColumn = table.getChild(mortonColumnName);
+  if (!xColumn || !yColumn || !mortonColumn) {
+    return null;
+  }
+
+  const maxRows = Math.min(4, table.numRows);
+  const xs: number[] = [];
+  const ys: number[] = [];
+  for (let i = 0; i < maxRows; i++) {
+    if (!isMortonSentinelValue(mortonColumn.get(i))) {
+      break;
+    }
+    const x = getNumericValue(xColumn.get(i));
+    const y = getNumericValue(yColumn.get(i));
+    if (x === null || y === null) {
+      continue;
+    }
+    xs.push(x);
+    ys.push(y);
+  }
+  if (xs.length < 2 || ys.length < 2) {
+    return null;
+  }
+  return {
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys),
+  };
+}
+
+export function featureCodeAllowSet(
+  featureCodes: readonly number[] | undefined
+): Set<number> | null {
+  if (featureCodes === undefined) {
+    return null;
+  }
+  return new Set(featureCodes);
+}
+
+export function rowMatchesFeatureCode(code: unknown, allowed: Set<number> | null): boolean {
+  if (!allowed) {
+    return true;
+  }
+  return typeof code === 'number' && Number.isFinite(code) && allowed.has(code);
+}
+
+/**
+ * Future investigation: scan+compact loops below are hot paths for large
+ * preloaded datasets. Candidates include WASM SIMD and WebGPU compute (e.g.
+ * typegpu) for parallel index selection and column compaction. Worker offload
+ * is the near-term fix; GPU/WASM is a follow-up benchmark task.
+ *
+ * FBO-based render caching for viewport-stable layers should plug into the
+ * broader Render Stack compositing story (Group Entry, Viv/deck stacking) via
+ * shared cache utilities — not a points-only optimization.
+ */
+export function filterColumnarByFeatureCodes(
+  data: PointsColumnarData,
+  featureCodes: readonly number[] | undefined,
+  sourceFeatureCodes?: ArrayLike<number>
+): PointsColumnarData {
+  const allowedFeatureCodes = featureCodeAllowSet(featureCodes);
+  if (allowedFeatureCodes === null || !sourceFeatureCodes) {
+    return data;
+  }
+  if (allowedFeatureCodes.size === 0) {
+    const axisCount = data.shape?.[0] ?? data.data.length;
+    const empty = new Float32Array(0);
+    const emptyData = axisCount >= 3 && data.data[2] ? [empty, empty, empty] : [empty, empty];
+    return { shape: [axisCount, 0], data: emptyData };
+  }
+
+  const xs = data.data[0];
+  const ys = data.data[1];
+  const zs = data.data[2];
+  const keep: number[] = [];
+  const n = Math.min(xs?.length ?? 0, ys?.length ?? 0);
+  for (let index = 0; index < n; index += 1) {
+    if (!rowMatchesFeatureCode(sourceFeatureCodes[index], allowedFeatureCodes)) {
+      continue;
+    }
+    keep.push(index);
+  }
+
+  if (keep.length === n) {
+    return data;
+  }
+
+  const outX = new Float32Array(keep.length);
+  const outY = new Float32Array(keep.length);
+  const outZ = zs ? new Float32Array(keep.length) : undefined;
+  for (let index = 0; index < keep.length; index += 1) {
+    const sourceIndex = keep[index];
+    outX[index] = xs[sourceIndex];
+    outY[index] = ys[sourceIndex];
+    if (outZ) {
+      outZ[index] = zs[sourceIndex] ?? 0;
+    }
+  }
+
+  return {
+    shape: [outZ ? 3 : 2, keep.length],
+    data: outZ ? [outX, outY, outZ] : [outX, outY],
+  };
+}
+
+export function filterPointsToBounds(
+  data: PointsColumnarData,
+  bounds: SpatialBounds,
+  featureIndices?: ArrayLike<number>,
+  featureCodes?: readonly number[],
+  sourceFeatureCodes?: ArrayLike<number>
+): PointsInBoundsResponse {
+  const allowedFeatureCodes = featureCodeAllowSet(featureCodes);
+  const xs = data.data[0];
+  const ys = data.data[1];
+  const zs = data.data[2];
+  const keep: number[] = [];
+  const n = Math.min(xs?.length ?? 0, ys?.length ?? 0);
+  for (let i = 0; i < n; i++) {
+    const x = xs[i];
+    const y = ys[i];
+    if (
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      x < bounds.minX ||
+      x > bounds.maxX ||
+      y < bounds.minY ||
+      y > bounds.maxY
+    ) {
+      continue;
+    }
+    if (
+      allowedFeatureCodes &&
+      !rowMatchesFeatureCode(sourceFeatureCodes?.[i], allowedFeatureCodes)
+    ) {
+      continue;
+    }
+    keep.push(i);
+  }
+
+  const outX = new Float32Array(keep.length);
+  const outY = new Float32Array(keep.length);
+  const outZ = zs ? new Float32Array(keep.length) : undefined;
+  const outFeatureIndices = featureIndices ? new Uint32Array(keep.length) : undefined;
+  for (let i = 0; i < keep.length; i++) {
+    const sourceIndex = keep[i];
+    outX[i] = xs[sourceIndex];
+    outY[i] = ys[sourceIndex];
+    if (outZ) {
+      outZ[i] = zs?.[sourceIndex] ?? 0;
+    }
+    if (outFeatureIndices) {
+      outFeatureIndices[i] = featureIndices?.[sourceIndex] ?? 0;
+    }
+  }
+
+  return {
+    data: outZ ? [outX, outY, outZ] : [outX, outY],
+    shape: [outZ ? 3 : 2, keep.length],
+    bounds,
+    loadMode: 'full-filter',
+    featureIndices: outFeatureIndices,
+  };
+}
+
+export function boundsFromStoredPointsBounds(bounds: SpatialBounds): SpatialBounds {
+  return bounds;
+}

--- a/packages/core/src/spatialViewFit.ts
+++ b/packages/core/src/spatialViewFit.ts
@@ -22,7 +22,7 @@ export type OrthographicViewState2D = {
 
 /** Ndarray-style columnar points: data[0]=x, data[1]=y, optional data[2]=z. */
 export type PointsColumnarData = {
-  data: number[][];
+  data: ArrayLike<number>[];
   shape?: number[];
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -94,3 +94,4 @@ export type SDataProps = {
   selection?: ElementName[];
   rootStore: ConsolidatedStore;
 };
+export type PointsLoadMode = 'row-groups' | 'full-filter' | 'clipped';

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -1,0 +1,26 @@
+export {
+  buildFeatureCatalogInWorker,
+  countFeatureCodesInWorker,
+  decodeParquetGeometryCappedInWorker,
+  decodeParquetPartsInWorker,
+  decodeParquetRowFeatureCodesInWorker,
+  disablePointsWorker,
+  enablePointsWorker,
+  ensurePointsWorker,
+  filterColumnarByFeatureCodesInWorker,
+  isPointsWorkerEnabled,
+  scanMortonRowGroupsInBoundsInWorker,
+  scanParquetByFeatureCodesInWorker,
+  scanParquetFeatureCatalogInWorker,
+  scanParquetFeatureCountsInWorker,
+  setPointsWorkerDefaultEnabled,
+  transferablesForParquetPayload,
+} from './pointsWorkerClient.js';
+
+export type {
+  PointsWorkerMessage,
+  PointsWorkerRequest,
+  PointsWorkerResponse,
+  ParquetRowGroupBytesChunk,
+  ParquetWorkerPayload,
+} from './pointsWorkerProtocol.js';

--- a/packages/core/src/workers/points-worker.ts
+++ b/packages/core/src/workers/points-worker.ts
@@ -1,0 +1,472 @@
+import { tableFromIPC, tableToIPC } from 'apache-arrow';
+import {
+  buildFeatureCatalogFromColumns,
+} from '../pointsFeatures.js';
+import {
+  filterColumnarByFeatureCodes,
+} from '../pointsTiling.js';
+import { getParquetModule, type ParquetModule } from '../parquetWasmLoader.js';
+import type { PointsWorkerMessage, PointsWorkerRequest, PointsWorkerResponse } from './pointsWorkerProtocol.js';
+import {
+  countFeatureCodesFromArray,
+  decodeParquetPartsToTable,
+  decodeParquetPayloadToTable,
+  extractGeometryColumnar,
+  extractRowFeatureCodesFromTable,
+  histogramToSortedArrays,
+  scanFeatureCatalogFromPayload,
+  scanMortonTableInBounds,
+  scanTableByFeatureCodes,
+  scanTableFeatureCounts,
+} from './pointsWorkerScan.js';
+
+function toFloat32Array(values: ArrayLike<number>): Float32Array {
+  if (values instanceof Float32Array) {
+    return values;
+  }
+  return Float32Array.from(values);
+}
+
+function handleFilterColumnar(request: Extract<PointsWorkerRequest, { type: 'filterColumnarByFeatureCodes' }>) {
+  const filtered = filterColumnarByFeatureCodes(
+    {
+      shape: request.zs ? [3, request.xs.length] : [2, request.xs.length],
+      data: request.zs ? [request.xs, request.ys, request.zs] : [request.xs, request.ys],
+    },
+    request.featureCodes,
+    request.sourceFeatureCodes
+  );
+  const xs = toFloat32Array(filtered.data[0]);
+  const ys = toFloat32Array(filtered.data[1]);
+  const zs = filtered.data[2] ? toFloat32Array(filtered.data[2]) : undefined;
+  const shape: number[] =
+    filtered.shape && filtered.shape.length > 0
+      ? filtered.shape
+      : zs
+        ? [3, xs.length]
+        : [2, xs.length];
+  return {
+    ok: true as const,
+    result: {
+      kind: 'columnar' as const,
+      shape,
+      xs,
+      ys,
+      ...(zs ? { zs } : {}),
+    },
+  };
+}
+
+async function handleDecodeParquet(
+  request: Extract<PointsWorkerRequest, { type: 'decodeParquetParts' }>
+): Promise<PointsWorkerResponse> {
+  const { readParquet } = await getParquetModule();
+  const merged = await decodeParquetPartsToTable(
+    readParquet,
+    request.parts,
+    request.columns,
+    request.maxRows
+  );
+  return {
+    ok: true,
+    result: {
+      kind: 'parquetTable',
+      tableIpc: tableToIPC(merged),
+    },
+  };
+}
+
+async function handleDecodeParquetRowFeatureCodes(
+  request: Extract<PointsWorkerRequest, { type: 'decodeParquetRowFeatureCodes' }>
+): Promise<PointsWorkerResponse> {
+  const parquetModule = await getParquetModule();
+  const table = await decodeParquetPayloadToTable(
+    parquetModule.readParquet,
+    parquetModule.readParquetRowGroup,
+    request,
+    request.columns,
+    request.maxRows
+  );
+  const featureCodeByName = request.featureCodeEntries
+    ? new Map(request.featureCodeEntries.map((entry) => [entry.name, entry.code]))
+    : undefined;
+  const codes = extractRowFeatureCodesFromTable(
+    table,
+    request.featureKey,
+    request.featureCodeColumnName,
+    featureCodeByName
+  );
+  return {
+    ok: true,
+    result: {
+      kind: 'rowFeatureCodes',
+      codes,
+      numRows: table.numRows,
+    },
+  };
+}
+
+async function handleScanParquetFeatureCatalog(
+  request: Extract<PointsWorkerRequest, { type: 'scanParquetFeatureCatalog' }>
+): Promise<PointsWorkerResponse> {
+  const parquetModule = await getParquetModule();
+  const catalog = await scanFeatureCatalogFromPayload(
+    parquetModule.readParquet,
+    parquetModule.readParquetRowGroup,
+    request
+  );
+  if (!catalog) {
+    return { ok: false, error: 'No features found in parquet catalog scan' };
+  }
+  return { ok: true, result: { kind: 'catalog', catalog } };
+}
+
+async function handleDecodeParquetGeometryCapped(
+  request: Extract<PointsWorkerRequest, { type: 'decodeParquetGeometryCapped' }>
+): Promise<PointsWorkerResponse> {
+  const parquetModule = await getParquetModule();
+  const table = await decodeParquetPayloadToTable(
+    parquetModule.readParquet,
+    parquetModule.readParquetRowGroup,
+    request,
+    request.columns,
+    request.maxRows
+  );
+  const geometry = extractGeometryColumnar(table, request.axisNames);
+  const featureCodeByName = request.featureCodeEntries
+    ? new Map(request.featureCodeEntries.map((entry) => [entry.name, entry.code]))
+    : undefined;
+  const featureCodes =
+    request.featureKey !== undefined
+      ? extractRowFeatureCodesFromTable(
+          table,
+          request.featureKey,
+          request.featureCodeColumnName,
+          featureCodeByName
+        )
+      : undefined;
+  return {
+    ok: true,
+    result: {
+      kind: 'columnar',
+      ...geometry,
+      ...(featureCodes ? { featureCodes } : {}),
+    },
+  };
+}
+
+function handleCountFeatureCodes(
+  request: Extract<PointsWorkerRequest, { type: 'countFeatureCodes' }>
+): PointsWorkerResponse {
+  const { codes, countValues } = countFeatureCodesFromArray(request.sourceFeatureCodes);
+  return {
+    ok: true,
+    result: {
+      kind: 'featureCounts',
+      codes,
+      counts: countValues,
+    },
+  };
+}
+
+async function scanTablesForFeatureCounts(
+  parquetModule: ParquetModule,
+  request: Extract<PointsWorkerRequest, { type: 'scanParquetFeatureCounts' }>
+): Promise<Map<number, number>> {
+  const columns = [
+    request.featureKey,
+    ...(request.featureCodeColumnName ? [request.featureCodeColumnName] : []),
+  ];
+  const counts = new Map<number, number>();
+
+  if (request.rowGroups?.length && parquetModule.readParquetRowGroup) {
+    for (const chunk of request.rowGroups) {
+      const table = tableFromIPC(
+        parquetModule.readParquetRowGroup(
+          chunk.schemaBytes,
+          chunk.rowGroupBytes,
+          chunk.rowGroupIndex,
+          { columns }
+        ).intoIPCStream()
+      );
+      scanTableFeatureCounts(table, request.featureKey, request.featureCodeColumnName, counts);
+    }
+    return counts;
+  }
+
+  for (const part of request.parts ?? []) {
+    const table = tableFromIPC(parquetModule.readParquet(part, { columns }).intoIPCStream());
+    scanTableFeatureCounts(table, request.featureKey, request.featureCodeColumnName, counts);
+  }
+  return counts;
+}
+
+async function handleScanParquetFeatureCounts(
+  request: Extract<PointsWorkerRequest, { type: 'scanParquetFeatureCounts' }>
+): Promise<PointsWorkerResponse> {
+  const parquetModule = await getParquetModule();
+  const counts = await scanTablesForFeatureCounts(parquetModule, request);
+  const { codes, countValues } = histogramToSortedArrays(counts);
+  return {
+    ok: true,
+    result: {
+      kind: 'featureCounts',
+      codes,
+      counts: countValues,
+    },
+  };
+}
+
+async function scanPayloadByFeatureCodes(
+  parquetModule: ParquetModule,
+  request: Extract<PointsWorkerRequest, { type: 'scanParquetByFeatureCodes' }>,
+  input: {
+    matchedRows: number;
+    xs: number[];
+    ys: number[];
+    zs: number[];
+    scannedRows: number;
+  }
+): Promise<{ matchedRows: number; scannedRows: number }> {
+  const hasZ = request.axisNames.includes('z');
+  const columns = [
+    ...request.axisNames,
+    request.featureKey,
+    ...(request.featureCodeColumnName ? [request.featureCodeColumnName] : []),
+  ];
+
+  if (request.rowGroups?.length && parquetModule.readParquetRowGroup) {
+    for (const chunk of request.rowGroups) {
+      if (input.matchedRows >= request.memoryCap) {
+        break;
+      }
+      const table = tableFromIPC(
+        parquetModule.readParquetRowGroup(
+          chunk.schemaBytes,
+          chunk.rowGroupBytes,
+          chunk.rowGroupIndex,
+          { columns }
+        ).intoIPCStream()
+      );
+      input.scannedRows += table.numRows;
+      input.matchedRows = scanTableByFeatureCodes({
+        table,
+        axisNames: request.axisNames,
+        featureKey: request.featureKey,
+        featureCodeColumnName: request.featureCodeColumnName,
+        featureCodes: request.featureCodes,
+        memoryCap: request.memoryCap,
+        matchedRows: input.matchedRows,
+        xs: input.xs,
+        ys: input.ys,
+        zs: input.zs,
+      });
+    }
+    return { matchedRows: input.matchedRows, scannedRows: input.scannedRows };
+  }
+
+  for (const part of request.parts ?? []) {
+    if (input.matchedRows >= request.memoryCap) {
+      break;
+    }
+    const table = tableFromIPC(parquetModule.readParquet(part, { columns }).intoIPCStream());
+    input.scannedRows += table.numRows;
+    input.matchedRows = scanTableByFeatureCodes({
+      table,
+      axisNames: request.axisNames,
+      featureKey: request.featureKey,
+      featureCodeColumnName: request.featureCodeColumnName,
+      featureCodes: request.featureCodes,
+      memoryCap: request.memoryCap,
+      matchedRows: input.matchedRows,
+      xs: input.xs,
+      ys: input.ys,
+      zs: input.zs,
+    });
+  }
+  return { matchedRows: input.matchedRows, scannedRows: input.scannedRows };
+}
+
+async function handleScanParquetByFeatureCodes(
+  request: Extract<PointsWorkerRequest, { type: 'scanParquetByFeatureCodes' }>
+): Promise<PointsWorkerResponse> {
+  const parquetModule = await getParquetModule();
+  const hasZ = request.axisNames.includes('z');
+  const xs: number[] = [];
+  const ys: number[] = [];
+  const zs: number[] = [];
+  const { matchedRows, scannedRows } = await scanPayloadByFeatureCodes(parquetModule, request, {
+    matchedRows: 0,
+    xs,
+    ys,
+    zs,
+    scannedRows: 0,
+  });
+  const outX = Float32Array.from(xs);
+  const outY = Float32Array.from(ys);
+  const outZ = hasZ ? Float32Array.from(zs) : undefined;
+  const shape = outZ ? [3, outX.length] : [2, outX.length];
+  return {
+    ok: true,
+    result: {
+      kind: 'columnarScan',
+      shape,
+      xs: outX,
+      ys: outY,
+      ...(outZ ? { zs: outZ } : {}),
+      matchedRows,
+      scannedRows,
+    },
+  };
+}
+
+async function handleScanMortonRowGroupsInBounds(
+  request: Extract<PointsWorkerRequest, { type: 'scanMortonRowGroupsInBounds' }>
+): Promise<PointsWorkerResponse> {
+  const parquetModule = await getParquetModule();
+  if (!parquetModule.readParquetRowGroup) {
+    return { ok: false, error: 'parquet-wasm readParquetRowGroup is unavailable in points worker' };
+  }
+  const hasZ = request.axisNames.includes('z');
+  const columns = [
+    'x',
+    'y',
+    ...(hasZ ? ['z'] : []),
+    request.mortonCodeColumnName,
+    ...(request.featureCodeColumnName ? [request.featureCodeColumnName] : []),
+  ];
+  const xs: number[] = [];
+  const ys: number[] = [];
+  const zs: number[] = [];
+  for (const chunk of request.rowGroups) {
+    const table = tableFromIPC(
+      parquetModule.readParquetRowGroup(
+        chunk.schemaBytes,
+        chunk.rowGroupBytes,
+        chunk.rowGroupIndex,
+        { columns }
+      ).intoIPCStream()
+    );
+    scanMortonTableInBounds({
+      table,
+      rowGroupIndex: chunk.globalRowGroupIndex ?? chunk.rowGroupIndex,
+      bounds: request.bounds,
+      axisNames: request.axisNames,
+      mortonCodeColumnName: request.mortonCodeColumnName,
+      featureCodeColumnName: request.featureCodeColumnName,
+      featureCodes: request.featureCodes,
+      xs,
+      ys,
+      zs,
+    });
+  }
+  const outX = Float32Array.from(xs);
+  const outY = Float32Array.from(ys);
+  const outZ = hasZ ? Float32Array.from(zs) : undefined;
+  const shape = outZ ? [3, outX.length] : [2, outX.length];
+  return {
+    ok: true,
+    result: {
+      kind: 'columnar',
+      shape,
+      xs: outX,
+      ys: outY,
+      ...(outZ ? { zs: outZ } : {}),
+    },
+  };
+}
+
+function handleBuildFeatureCatalog(
+  request: Extract<PointsWorkerRequest, { type: 'buildFeatureCatalog' }>
+): PointsWorkerResponse {
+  const table = tableFromIPC(request.tableIpc);
+  const nameColumn = table.getChild(request.featureKey);
+  if (!nameColumn) {
+    return { ok: false, error: `Feature column "${request.featureKey}" not found` };
+  }
+  const codeColumnName = table.schema.fields
+    .map((field) => field.name)
+    .find((name): name is string => typeof name === 'string' && name.endsWith('_codes'));
+  const codeColumn = codeColumnName ? table.getChild(codeColumnName) : null;
+  const mortonColumn = table.getChild('morton_code_2d');
+  const catalog = buildFeatureCatalogFromColumns(
+    request.featureKey,
+    nameColumn,
+    codeColumn,
+    mortonColumn,
+    table.numRows
+  );
+  return { ok: true, result: { kind: 'catalog', catalog } };
+}
+
+async function handleRequest(request: PointsWorkerRequest): Promise<PointsWorkerResponse> {
+  switch (request.type) {
+    case 'filterColumnarByFeatureCodes':
+      return handleFilterColumnar(request);
+    case 'decodeParquetParts':
+      return handleDecodeParquet(request);
+    case 'buildFeatureCatalog':
+      return handleBuildFeatureCatalog(request);
+    case 'decodeParquetRowFeatureCodes':
+      return handleDecodeParquetRowFeatureCodes(request);
+    case 'scanParquetFeatureCatalog':
+      return handleScanParquetFeatureCatalog(request);
+    case 'decodeParquetGeometryCapped':
+      return handleDecodeParquetGeometryCapped(request);
+    case 'countFeatureCodes':
+      return handleCountFeatureCodes(request);
+    case 'scanParquetFeatureCounts':
+      return handleScanParquetFeatureCounts(request);
+    case 'scanParquetByFeatureCodes':
+      return handleScanParquetByFeatureCodes(request);
+    case 'scanMortonRowGroupsInBounds':
+      return handleScanMortonRowGroupsInBounds(request);
+    default: {
+      const _exhaustive: never = request;
+      return { ok: false, error: `Unknown request type: ${String(_exhaustive)}` };
+    }
+  }
+}
+
+self.onmessage = (event: MessageEvent<PointsWorkerMessage>) => {
+  const message = event.data;
+  if (message.direction !== 'request') {
+    return;
+  }
+  void handleRequest(message.request)
+    .then((response) => {
+      const reply: PointsWorkerMessage = { id: message.id, direction: 'response', response };
+      const transferables: Transferable[] = [];
+      if (response.ok) {
+        if (response.result.kind === 'columnar' || response.result.kind === 'columnarScan') {
+          transferables.push(response.result.xs.buffer, response.result.ys.buffer);
+          if (response.result.zs) {
+            transferables.push(response.result.zs.buffer);
+          }
+          if (response.result.kind === 'columnar' && response.result.featureCodes) {
+            transferables.push(response.result.featureCodes.buffer);
+          }
+        } else if (response.result.kind === 'parquetTable') {
+          transferables.push(response.result.tableIpc.buffer);
+        } else if (response.result.kind === 'rowFeatureCodes') {
+          transferables.push(response.result.codes.buffer);
+        } else if (response.result.kind === 'featureCounts') {
+          transferables.push(response.result.codes.buffer, response.result.counts.buffer);
+        }
+      }
+      self.postMessage(reply, transferables);
+    })
+    .catch((error: unknown) => {
+      const reply: PointsWorkerMessage = {
+        id: message.id,
+        direction: 'response',
+        response: {
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      };
+      self.postMessage(reply);
+    });
+};
+
+export {};

--- a/packages/core/src/workers/pointsWorkerClient.ts
+++ b/packages/core/src/workers/pointsWorkerClient.ts
@@ -1,0 +1,465 @@
+import { tableFromIPC } from 'apache-arrow';
+import type { PointsColumnarData } from '../spatialViewFit.js';
+import type { PointsFeatureCatalog } from '../pointsTiling.js';
+import {
+  columnarDataFromWorkerResult,
+  type ParquetRowGroupBytesChunk,
+  type ParquetWorkerPayload,
+  type PointsBounds,
+  type PointsWorkerMessage,
+  type PointsWorkerRequest,
+  type PointsWorkerResponse,
+} from './pointsWorkerProtocol.js';
+
+let worker: Worker | undefined;
+let nextRequestId = 0;
+const pending = new Map<
+  number,
+  { resolve: (value: unknown) => void; reject: (error: Error) => void }
+>();
+
+let enabled = false;
+let defaultEnabled = typeof window !== 'undefined';
+
+function ensureWorkerListener() {
+  if (!worker) {
+    return;
+  }
+  worker.onmessage = (event: MessageEvent<PointsWorkerMessage>) => {
+    const message = event.data;
+    if (message.direction !== 'response') {
+      return;
+    }
+    const entry = pending.get(message.id);
+    if (!entry) {
+      return;
+    }
+    pending.delete(message.id);
+    if (message.response.ok) {
+      entry.resolve(message.response.result);
+    } else {
+      entry.reject(new Error(message.response.error));
+    }
+  };
+  worker.onerror = (event) => {
+    for (const [, entry] of pending) {
+      entry.reject(new Error(event.message || 'Points worker error'));
+    }
+    pending.clear();
+  };
+}
+
+function postRequest<T>(request: PointsWorkerRequest, transferables: Transferable[] = []): Promise<T> {
+  const activeWorker = worker;
+  if (!activeWorker) {
+    return Promise.reject(new Error('Points worker is not enabled'));
+  }
+  const id = ++nextRequestId;
+  return new Promise<T>((resolve, reject) => {
+    pending.set(id, { resolve: resolve as (value: unknown) => void, reject });
+    const message: PointsWorkerMessage = { id, direction: 'request', request };
+    if (transferables.length > 0) {
+      activeWorker.postMessage(message, transferables);
+    } else {
+      activeWorker.postMessage(message);
+    }
+  });
+}
+
+export function transferablesForParquetPayload(
+  parts?: Uint8Array[],
+  rowGroups?: ParquetRowGroupBytesChunk[]
+): Transferable[] {
+  const transferables: Transferable[] = [];
+  if (parts) {
+    for (const part of parts) {
+      transferables.push(part.buffer);
+    }
+  }
+  if (rowGroups) {
+    for (const chunk of rowGroups) {
+      transferables.push(chunk.schemaBytes.buffer, chunk.rowGroupBytes.buffer);
+    }
+  }
+  return transferables;
+}
+
+function transferablesForRequest(request: PointsWorkerRequest): Transferable[] {
+  switch (request.type) {
+    case 'decodeParquetRowFeatureCodes':
+    case 'scanParquetFeatureCounts':
+    case 'decodeParquetGeometryCapped':
+    case 'scanParquetByFeatureCodes':
+    case 'scanParquetFeatureCatalog':
+      return transferablesForParquetPayload(request.parts, request.rowGroups);
+    case 'scanMortonRowGroupsInBounds':
+      return transferablesForParquetPayload(undefined, request.rowGroups);
+  }
+  return [];
+}
+
+export function isPointsWorkerEnabled(): boolean {
+  return enabled && worker !== undefined;
+}
+
+export function enablePointsWorker(options: { workerUrl?: string | URL } = {}) {
+  if (typeof Worker === 'undefined') {
+    return;
+  }
+  if (worker) {
+    disablePointsWorker();
+  }
+  if (options.workerUrl) {
+    worker = new Worker(options.workerUrl, { type: 'module' });
+  } else {
+    // Inline URL so Vite dev apps can bundle the worker; @vite-ignore keeps lib build
+    // emitting a runtime relative URL to dist/points-worker.js (not /assets/...).
+    worker = new Worker(
+      new URL(/* @vite-ignore */ './points-worker.js', import.meta.url),
+      { type: 'module' }
+    );
+  }
+  ensureWorkerListener();
+  enabled = true;
+}
+
+export function disablePointsWorker() {
+  enabled = false;
+  if (worker) {
+    worker.terminate();
+    worker = undefined;
+  }
+  for (const [, entry] of pending) {
+    entry.reject(new Error('Points worker disabled'));
+  }
+  pending.clear();
+}
+
+export function setPointsWorkerDefaultEnabled(value: boolean) {
+  defaultEnabled = value;
+}
+
+export function ensurePointsWorker(options: { workerUrl?: string | URL } = {}) {
+  if (!enabled && defaultEnabled) {
+    enablePointsWorker(options);
+  }
+}
+
+export async function filterColumnarByFeatureCodesInWorker(
+  data: PointsColumnarData,
+  featureCodes: readonly number[] | undefined,
+  sourceFeatureCodes: ArrayLike<number>
+): Promise<PointsColumnarData> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    const { filterColumnarByFeatureCodes } = await import('../pointsTiling.js');
+    return filterColumnarByFeatureCodes(data, featureCodes, sourceFeatureCodes);
+  }
+
+  const xs = data.data[0] instanceof Float32Array
+    ? data.data[0]
+    : Float32Array.from(data.data[0] as ArrayLike<number>);
+  const ys = data.data[1] instanceof Float32Array
+    ? data.data[1]
+    : Float32Array.from(data.data[1] as ArrayLike<number>);
+  const zs = data.data[2]
+    ? data.data[2] instanceof Float32Array
+      ? data.data[2]
+      : Float32Array.from(data.data[2] as ArrayLike<number>)
+    : undefined;
+
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>({
+    type: 'filterColumnarByFeatureCodes',
+    xs,
+    ys,
+    zs,
+    featureCodes,
+    sourceFeatureCodes,
+  });
+
+  if (result.kind !== 'columnar') {
+    throw new Error('Unexpected points worker response for filterColumnarByFeatureCodes');
+  }
+  return columnarDataFromWorkerResult(result);
+}
+
+export type DecodeParquetRowFeatureCodesInput = {
+  parts?: Uint8Array[];
+  rowGroups?: ParquetRowGroupBytesChunk[];
+  columns: string[];
+  maxRows?: number;
+  featureKey: string;
+  featureCodeColumnName?: string;
+  featureCodeEntries?: ReadonlyArray<{ name: string; code: number }>;
+};
+
+export async function decodeParquetRowFeatureCodesInWorker(
+  input: DecodeParquetRowFeatureCodesInput
+): Promise<Int32Array | null> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    return null;
+  }
+  if (!input.parts?.length && !input.rowGroups?.length) {
+    return null;
+  }
+  if (input.parts?.length && input.rowGroups?.length) {
+    throw new Error('decodeParquetRowFeatureCodesInWorker requires parts or rowGroups, not both');
+  }
+  const request: Extract<PointsWorkerRequest, { type: 'decodeParquetRowFeatureCodes' }> = {
+    type: 'decodeParquetRowFeatureCodes',
+    ...input,
+  };
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>(
+    request,
+    transferablesForRequest(request)
+  );
+  if (result.kind !== 'rowFeatureCodes') {
+    throw new Error('Unexpected points worker response for decodeParquetRowFeatureCodes');
+  }
+  return result.codes;
+}
+
+export type ScanParquetFeatureCatalogInput = {
+  rowGroups?: ParquetRowGroupBytesChunk[];
+  parts: Uint8Array[];
+  columns: string[];
+  featureKey: string;
+  featureCodeColumnName?: string;
+  skipMortonSentinels?: boolean;
+};
+
+export async function scanParquetFeatureCatalogInWorker(
+  input: ScanParquetFeatureCatalogInput
+): Promise<PointsFeatureCatalog | null> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled() || input.parts.length === 0) {
+    return null;
+  }
+  const request: Extract<PointsWorkerRequest, { type: 'scanParquetFeatureCatalog' }> = {
+    type: 'scanParquetFeatureCatalog',
+    ...input,
+  };
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>(
+    request,
+    transferablesForRequest(request)
+  );
+  if (result.kind !== 'catalog') {
+    throw new Error('Unexpected points worker response for scanParquetFeatureCatalog');
+  }
+  return result.catalog;
+}
+
+export type DecodeParquetGeometryCappedInput = ParquetWorkerPayload & {
+  axisNames: string[];
+  columns: string[];
+  maxRows: number;
+  featureKey?: string;
+  featureCodeColumnName?: string;
+  featureCodeEntries?: ReadonlyArray<{ name: string; code: number }>;
+};
+
+export async function decodeParquetGeometryCappedInWorker(
+  input: DecodeParquetGeometryCappedInput
+): Promise<{
+  shape: number[];
+  data: ArrayLike<number>[];
+  featureCodes?: Int32Array;
+} | null> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    return null;
+  }
+  if (!input.parts?.length && !input.rowGroups?.length) {
+    return null;
+  }
+  if (input.parts?.length && input.rowGroups?.length) {
+    throw new Error('decodeParquetGeometryCappedInWorker requires parts or rowGroups, not both');
+  }
+  const request: Extract<PointsWorkerRequest, { type: 'decodeParquetGeometryCapped' }> = {
+    type: 'decodeParquetGeometryCapped',
+    ...input,
+  };
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>(
+    request,
+    transferablesForRequest(request)
+  );
+  if (result.kind !== 'columnar') {
+    throw new Error('Unexpected points worker response for decodeParquetGeometryCapped');
+  }
+  const data = result.zs ? [result.xs, result.ys, result.zs] : [result.xs, result.ys];
+  return {
+    shape: result.shape,
+    data,
+    featureCodes: result.featureCodes,
+  };
+}
+
+export async function countFeatureCodesInWorker(
+  sourceFeatureCodes: ArrayLike<number>
+): Promise<Map<number, number>> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    const { countFeatureCodesHistogram } = await import('../pointsFeatures.js');
+    return countFeatureCodesHistogram(sourceFeatureCodes);
+  }
+  const codesArray =
+    sourceFeatureCodes instanceof Int32Array
+      ? sourceFeatureCodes
+      : Int32Array.from(sourceFeatureCodes);
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>({
+    type: 'countFeatureCodes',
+    sourceFeatureCodes: codesArray,
+  });
+  if (result.kind !== 'featureCounts') {
+    throw new Error('Unexpected points worker response for countFeatureCodes');
+  }
+  const counts = new Map<number, number>();
+  for (let index = 0; index < result.codes.length; index += 1) {
+    counts.set(result.codes[index], result.counts[index]);
+  }
+  return counts;
+}
+
+export type ScanParquetFeatureCountsInput = ParquetWorkerPayload & {
+  featureKey: string;
+  featureCodeColumnName?: string;
+};
+
+export async function scanParquetFeatureCountsInWorker(
+  input: ScanParquetFeatureCountsInput
+): Promise<Map<number, number> | null> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    return null;
+  }
+  if (!input.parts?.length && !input.rowGroups?.length) {
+    return null;
+  }
+  const request: Extract<PointsWorkerRequest, { type: 'scanParquetFeatureCounts' }> = {
+    type: 'scanParquetFeatureCounts',
+    ...input,
+  };
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>(
+    request,
+    transferablesForRequest(request)
+  );
+  if (result.kind !== 'featureCounts') {
+    throw new Error('Unexpected points worker response for scanParquetFeatureCounts');
+  }
+  const counts = new Map<number, number>();
+  for (let index = 0; index < result.codes.length; index += 1) {
+    counts.set(result.codes[index], result.counts[index]);
+  }
+  return counts;
+}
+
+export type ScanParquetByFeatureCodesInput = ParquetWorkerPayload & {
+  axisNames: string[];
+  featureKey: string;
+  featureCodeColumnName?: string;
+  featureCodes: readonly number[];
+  memoryCap: number;
+};
+
+export async function scanParquetByFeatureCodesInWorker(
+  input: ScanParquetByFeatureCodesInput
+): Promise<{
+  data: PointsColumnarData;
+  matchedRows: number;
+  scannedRows: number;
+} | null> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    return null;
+  }
+  if (!input.parts?.length && !input.rowGroups?.length) {
+    return null;
+  }
+  const request: Extract<PointsWorkerRequest, { type: 'scanParquetByFeatureCodes' }> = {
+    type: 'scanParquetByFeatureCodes',
+    ...input,
+  };
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>(
+    request,
+    transferablesForRequest(request)
+  );
+  if (result.kind !== 'columnarScan') {
+    throw new Error('Unexpected points worker response for scanParquetByFeatureCodes');
+  }
+  return {
+    data: columnarDataFromWorkerResult(result),
+    matchedRows: result.matchedRows,
+    scannedRows: result.scannedRows,
+  };
+}
+
+export type ScanMortonRowGroupsInBoundsInput = {
+  rowGroups: ParquetRowGroupBytesChunk[];
+  bounds: PointsBounds;
+  axisNames: string[];
+  mortonCodeColumnName: string;
+  featureCodeColumnName?: string;
+  featureCodes?: readonly number[];
+};
+
+export async function scanMortonRowGroupsInBoundsInWorker(
+  input: ScanMortonRowGroupsInBoundsInput
+): Promise<PointsColumnarData | null> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled() || input.rowGroups.length === 0) {
+    return null;
+  }
+  const request: Extract<PointsWorkerRequest, { type: 'scanMortonRowGroupsInBounds' }> = {
+    type: 'scanMortonRowGroupsInBounds',
+    ...input,
+  };
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>(
+    request,
+    transferablesForRequest(request)
+  );
+  if (result.kind !== 'columnar') {
+    throw new Error('Unexpected points worker response for scanMortonRowGroupsInBounds');
+  }
+  return columnarDataFromWorkerResult(result);
+}
+
+export async function decodeParquetPartsInWorker(
+  parts: Uint8Array[],
+  columns?: string[],
+  maxRows?: number
+): Promise<ReturnType<typeof tableFromIPC>> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    throw new Error('Points worker is required for decodeParquetPartsInWorker');
+  }
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>({
+    type: 'decodeParquetParts',
+    parts,
+    columns,
+    maxRows,
+  });
+  if (result.kind !== 'parquetTable') {
+    throw new Error('Unexpected points worker response for decodeParquetParts');
+  }
+  return tableFromIPC(result.tableIpc);
+}
+
+export async function buildFeatureCatalogInWorker(
+  featureKey: string,
+  tableIpc: Uint8Array
+): Promise<PointsFeatureCatalog> {
+  ensurePointsWorker();
+  if (!isPointsWorkerEnabled()) {
+    throw new Error('Points worker is required for buildFeatureCatalogInWorker');
+  }
+  const result = await postRequest<Extract<PointsWorkerResponse, { ok: true }>['result']>({
+    type: 'buildFeatureCatalog',
+    featureKey,
+    tableIpc,
+  });
+  if (result.kind !== 'catalog') {
+    throw new Error('Unexpected points worker response for buildFeatureCatalog');
+  }
+  return result.catalog;
+}

--- a/packages/core/src/workers/pointsWorkerClient.ts
+++ b/packages/core/src/workers/pointsWorkerClient.ts
@@ -19,7 +19,13 @@ const pending = new Map<
 >();
 
 let enabled = false;
-let defaultEnabled = typeof window !== 'undefined';
+// Points worker is opt-in: hosts call enablePointsWorker() (or
+// setPointsWorkerDefaultEnabled(true)) once they have wired the worker bundle.
+// Auto-enabling in every browser caused loadPoints() to hang forever wherever
+// the worker isn't functionally wired (e.g. Vite dev serving core from source),
+// because the worker branch awaits a response that never arrives and the
+// main-thread fallback only triggers on a rejection, not a stuck promise.
+let defaultEnabled = false;
 
 function ensureWorkerListener() {
   if (!worker) {

--- a/packages/core/src/workers/pointsWorkerProtocol.ts
+++ b/packages/core/src/workers/pointsWorkerProtocol.ts
@@ -1,0 +1,148 @@
+import type { PointsColumnarData } from '../spatialViewFit.js';
+import type { PointsFeatureCatalog } from '../pointsTiling.js';
+
+export type ParquetRowGroupBytesChunk = {
+  schemaBytes: Uint8Array;
+  rowGroupBytes: Uint8Array;
+  rowGroupIndex: number;
+  /** Dataset-wide row group index (for morton sentinel handling). */
+  globalRowGroupIndex?: number;
+};
+
+export type ParquetWorkerPayload = {
+  parts?: Uint8Array[];
+  rowGroups?: ParquetRowGroupBytesChunk[];
+};
+
+export type PointsBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+};
+
+export type PointsWorkerRequest =
+  | {
+      type: 'filterColumnarByFeatureCodes';
+      xs: Float32Array;
+      ys: Float32Array;
+      zs?: Float32Array;
+      /** Omitted = all features; empty = none. */
+      featureCodes?: readonly number[];
+      sourceFeatureCodes: ArrayLike<number>;
+    }
+  | {
+      type: 'decodeParquetParts';
+      parts: Uint8Array[];
+      columns?: string[];
+      /** When set, decode stops after this many rows (across parts). */
+      maxRows?: number;
+    }
+  | {
+      type: 'buildFeatureCatalog';
+      featureKey: string;
+      tableIpc: Uint8Array;
+    }
+  | {
+      type: 'decodeParquetRowFeatureCodes';
+      parts?: Uint8Array[];
+      rowGroups?: ParquetRowGroupBytesChunk[];
+      columns: string[];
+      maxRows?: number;
+      featureKey: string;
+      featureCodeColumnName?: string;
+      /** Serialized catalog for dict-only elements (no *_codes column). */
+      featureCodeEntries?: ReadonlyArray<{ name: string; code: number }>;
+    }
+  | {
+      type: 'countFeatureCodes';
+      sourceFeatureCodes: ArrayLike<number>;
+    }
+  | {
+      type: 'scanParquetFeatureCounts';
+      parts?: Uint8Array[];
+      rowGroups?: ParquetRowGroupBytesChunk[];
+      featureKey: string;
+      featureCodeColumnName?: string;
+    }
+  | {
+      type: 'scanParquetFeatureCatalog';
+      rowGroups?: ParquetRowGroupBytesChunk[];
+      parts: Uint8Array[];
+      columns: string[];
+      featureKey: string;
+      featureCodeColumnName?: string;
+      skipMortonSentinels?: boolean;
+    }
+  | {
+      type: 'decodeParquetGeometryCapped';
+      parts?: Uint8Array[];
+      rowGroups?: ParquetRowGroupBytesChunk[];
+      axisNames: string[];
+      columns: string[];
+      maxRows: number;
+      featureKey?: string;
+      featureCodeColumnName?: string;
+      featureCodeEntries?: ReadonlyArray<{ name: string; code: number }>;
+    }
+  | {
+      type: 'scanParquetByFeatureCodes';
+      parts?: Uint8Array[];
+      rowGroups?: ParquetRowGroupBytesChunk[];
+      axisNames: string[];
+      featureKey: string;
+      featureCodeColumnName?: string;
+      featureCodes: readonly number[];
+      memoryCap: number;
+    }
+  | {
+      type: 'scanMortonRowGroupsInBounds';
+      rowGroups: ParquetRowGroupBytesChunk[];
+      bounds: PointsBounds;
+      axisNames: string[];
+      mortonCodeColumnName: string;
+      featureCodeColumnName?: string;
+      featureCodes?: readonly number[];
+    };
+
+export type PointsWorkerColumnarResult = {
+  kind: 'columnar';
+  shape: number[];
+  xs: Float32Array;
+  ys: Float32Array;
+  zs?: Float32Array;
+  featureCodes?: Int32Array;
+};
+
+export type PointsWorkerScanResult = Omit<PointsWorkerColumnarResult, 'kind' | 'featureCodes'> & {
+  kind: 'columnarScan';
+  matchedRows: number;
+  scannedRows: number;
+};
+
+export type PointsWorkerResponse =
+  | {
+      ok: true;
+      result:
+        | PointsWorkerColumnarResult
+        | PointsWorkerScanResult
+        | { kind: 'parquetTable'; tableIpc: Uint8Array }
+        | { kind: 'catalog'; catalog: PointsFeatureCatalog }
+        | { kind: 'rowFeatureCodes'; codes: Int32Array; numRows: number }
+        | { kind: 'featureCounts'; codes: Int32Array; counts: Uint32Array };
+    }
+  | { ok: false; error: string };
+
+export type PointsWorkerMessage = {
+  id: number;
+} & (
+  | { direction: 'request'; request: PointsWorkerRequest }
+  | { direction: 'response'; response: PointsWorkerResponse }
+);
+
+export function columnarDataFromWorkerResult(
+  result: PointsWorkerColumnarResult | PointsWorkerScanResult
+): PointsColumnarData {
+  const data = result.zs ? [result.xs, result.ys, result.zs] : [result.xs, result.ys];
+  return { shape: result.shape, data };
+}

--- a/packages/core/src/workers/pointsWorkerScan.ts
+++ b/packages/core/src/workers/pointsWorkerScan.ts
@@ -1,0 +1,378 @@
+import { tableFromIPC, type Table } from 'apache-arrow';
+import {
+  accumulateFeatureCatalogFromTable,
+  countFeatureCodesHistogram,
+  featureCatalogFromCodeMap,
+  featureCatalogNeedsParquetFallback,
+  resolveRowFeatureCodesFromTable,
+} from '../pointsFeatures.js';
+import type { PointsFeatureCatalog } from '../pointsTiling.js';
+import {
+  featureCodeAllowSet,
+  isMortonSentinelValue,
+  rowMatchesFeatureCode,
+} from '../pointsTiling.js';
+
+type ParquetWasmTableLike = { intoIPCStream(): Uint8Array };
+type ParquetModule = {
+  readParquet: (bytes: Uint8Array, options?: { columns?: string[] }) => ParquetWasmTableLike;
+};
+
+export type ParquetRowGroupBytesChunk = {
+  schemaBytes: Uint8Array;
+  rowGroupBytes: Uint8Array;
+  rowGroupIndex: number;
+  globalRowGroupIndex?: number;
+};
+
+type ReadParquetRowGroup = (
+  schemaBytes: Uint8Array,
+  rowGroupBytes: Uint8Array,
+  rowGroupIndex: number,
+  options?: { columns?: string[] }
+) => ParquetWasmTableLike;
+
+export async function decodeParquetPartsToTable(
+  readParquet: ParquetModule['readParquet'],
+  parts: Uint8Array[],
+  columns: string[] | undefined,
+  maxRows?: number
+): Promise<Table> {
+  const tables: Table[] = [];
+  let accumulated = 0;
+  for (const part of parts) {
+    const table = tableFromIPC(readParquet(part, { columns }).intoIPCStream());
+    if (maxRows === undefined) {
+      tables.push(table);
+      continue;
+    }
+    const remaining = maxRows - accumulated;
+    if (table.numRows <= remaining) {
+      tables.push(table);
+      accumulated += table.numRows;
+    } else {
+      tables.push(table.slice(0, remaining));
+      break;
+    }
+    if (accumulated >= maxRows) {
+      break;
+    }
+  }
+  if (tables.length === 0) {
+    throw new Error('No parquet tables to decode');
+  }
+  return tables.slice(1).reduce((merged, part) => merged.concat(part), tables[0]);
+}
+
+export async function decodeParquetRowGroupsToTable(
+  readParquetRowGroup: ReadParquetRowGroup,
+  chunks: ParquetRowGroupBytesChunk[],
+  columns: string[] | undefined,
+  maxRows?: number
+): Promise<Table> {
+  const readOptions = columns?.length ? { columns } : undefined;
+  const tables: Table[] = [];
+  let accumulated = 0;
+  for (const chunk of chunks) {
+    const table = tableFromIPC(
+      readParquetRowGroup(
+        chunk.schemaBytes,
+        chunk.rowGroupBytes,
+        chunk.rowGroupIndex,
+        readOptions
+      ).intoIPCStream()
+    );
+    if (maxRows === undefined) {
+      tables.push(table);
+      continue;
+    }
+    const remaining = maxRows - accumulated;
+    if (table.numRows <= remaining) {
+      tables.push(table);
+      accumulated += table.numRows;
+    } else {
+      tables.push(table.slice(0, remaining));
+      break;
+    }
+    if (accumulated >= maxRows) {
+      break;
+    }
+  }
+  if (tables.length === 0) {
+    throw new Error('No parquet row groups to decode');
+  }
+  return tables.slice(1).reduce((merged, part) => merged.concat(part), tables[0]);
+}
+
+export type ParquetWorkerPayloadInput = {
+  parts?: Uint8Array[];
+  rowGroups?: ParquetRowGroupBytesChunk[];
+};
+
+export async function decodeParquetPayloadToTable(
+  readParquet: ParquetModule['readParquet'],
+  readParquetRowGroup: ReadParquetRowGroup | undefined,
+  payload: ParquetWorkerPayloadInput,
+  columns: string[] | undefined,
+  maxRows?: number
+): Promise<Table> {
+  if (payload.rowGroups?.length) {
+    if (!readParquetRowGroup) {
+      throw new Error('readParquetRowGroup is unavailable');
+    }
+    return decodeParquetRowGroupsToTable(
+      readParquetRowGroup,
+      payload.rowGroups,
+      columns,
+      maxRows
+    );
+  }
+  if (payload.parts?.length) {
+    return decodeParquetPartsToTable(readParquet, payload.parts, columns, maxRows);
+  }
+  throw new Error('No parquet parts or row groups to decode');
+}
+
+export function extractGeometryColumnar(
+  table: Table,
+  axisNames: string[]
+): { shape: number[]; xs: Float32Array; ys: Float32Array; zs?: Float32Array } {
+  const xColumn = table.getChild(axisNames[0]);
+  const yColumn = table.getChild(axisNames[1]);
+  if (!xColumn || !yColumn) {
+    throw new Error(`Geometry columns not found in parquet table`);
+  }
+  const xs = Float32Array.from(xColumn.toArray() as ArrayLike<number>);
+  const ys = Float32Array.from(yColumn.toArray() as ArrayLike<number>);
+  const hasZ = axisNames.includes('z');
+  const zColumn = hasZ ? table.getChild('z') : null;
+  const zs = zColumn ? Float32Array.from(zColumn.toArray() as ArrayLike<number>) : undefined;
+  const shape = zs ? [3, xs.length] : [2, xs.length];
+  return { shape, xs, ys, ...(zs ? { zs } : {}) };
+}
+
+export async function scanFeatureCatalogFromPayload(
+  readParquet: ParquetModule['readParquet'],
+  readParquetRowGroup: ReadParquetRowGroup | undefined,
+  input: {
+    rowGroups?: ParquetRowGroupBytesChunk[];
+    parts: Uint8Array[];
+    columns: string[];
+    featureKey: string;
+    featureCodeColumnName?: string;
+    skipMortonSentinels?: boolean;
+  }
+): Promise<PointsFeatureCatalog | null> {
+  const codeToName = new Map<number, string>();
+  const nameToCode = new Map<string, number>();
+  const catalogOptions = { skipMortonSentinels: input.skipMortonSentinels === true };
+
+  if (input.featureCodeColumnName && input.rowGroups?.length && readParquetRowGroup) {
+    const readOptions = { columns: input.columns };
+    for (const chunk of input.rowGroups) {
+      const table = tableFromIPC(
+        readParquetRowGroup(
+          chunk.schemaBytes,
+          chunk.rowGroupBytes,
+          chunk.rowGroupIndex,
+          readOptions
+        ).intoIPCStream()
+      );
+      if (table.numRows === 0) {
+        continue;
+      }
+      accumulateFeatureCatalogFromTable(
+        codeToName,
+        nameToCode,
+        table,
+        input.featureKey,
+        input.featureCodeColumnName,
+        catalogOptions
+      );
+    }
+  }
+
+  if (featureCatalogNeedsParquetFallback(codeToName)) {
+    codeToName.clear();
+    nameToCode.clear();
+    const table = await decodeParquetPartsToTable(readParquet, input.parts, input.columns);
+    accumulateFeatureCatalogFromTable(
+      codeToName,
+      nameToCode,
+      table,
+      input.featureKey,
+      input.featureCodeColumnName,
+      catalogOptions
+    );
+  }
+
+  if (codeToName.size === 0) {
+    return null;
+  }
+  return featureCatalogFromCodeMap(input.featureKey, codeToName);
+}
+
+export function scanMortonTableInBounds(input: {
+  table: Table;
+  rowGroupIndex: number;
+  bounds: { minX: number; maxX: number; minY: number; maxY: number };
+  axisNames: string[];
+  mortonCodeColumnName: string;
+  featureCodeColumnName?: string;
+  featureCodes?: readonly number[];
+  xs: number[];
+  ys: number[];
+  zs: number[];
+}): void {
+  const allowedFeatureCodes = featureCodeAllowSet(input.featureCodes);
+  const filterByFeature = allowedFeatureCodes !== null;
+  const hasZ = input.axisNames.includes('z');
+  const xColumn = input.table.getChild('x');
+  const yColumn = input.table.getChild('y');
+  const zColumn = hasZ ? input.table.getChild('z') : null;
+  const mortonColumn = input.table.getChild(input.mortonCodeColumnName);
+  const featureCodeColumn = input.featureCodeColumnName
+    ? input.table.getChild(input.featureCodeColumnName)
+    : null;
+  if (!xColumn || !yColumn) {
+    return;
+  }
+  for (let rowIndex = 0; rowIndex < input.table.numRows; rowIndex += 1) {
+    if (
+      input.rowGroupIndex === 0 &&
+      rowIndex < 4 &&
+      isMortonSentinelValue(mortonColumn?.get(rowIndex))
+    ) {
+      continue;
+    }
+    if (
+      filterByFeature &&
+      featureCodeColumn &&
+      !rowMatchesFeatureCode(featureCodeColumn.get(rowIndex), allowedFeatureCodes)
+    ) {
+      continue;
+    }
+    const x = xColumn.get(rowIndex);
+    const y = yColumn.get(rowIndex);
+    if (typeof x !== 'number' || typeof y !== 'number') {
+      continue;
+    }
+    if (
+      x < input.bounds.minX ||
+      x > input.bounds.maxX ||
+      y < input.bounds.minY ||
+      y > input.bounds.maxY
+    ) {
+      continue;
+    }
+    input.xs.push(x);
+    input.ys.push(y);
+    if (zColumn) {
+      const z = zColumn.get(rowIndex);
+      input.zs.push(typeof z === 'number' ? z : 0);
+    }
+  }
+}
+
+export function extractRowFeatureCodesFromTable(
+  table: Table,
+  featureKey: string,
+  featureCodeColumnName?: string,
+  featureCodeByName?: ReadonlyMap<string, number>
+): Int32Array {
+  const resolved = resolveRowFeatureCodesFromTable(
+    table,
+    featureKey,
+    featureCodeColumnName,
+    featureCodeByName
+  );
+  if (!resolved) {
+    return new Int32Array(0);
+  }
+  if (resolved instanceof Int32Array) {
+    return resolved;
+  }
+  return Int32Array.from(resolved);
+}
+
+export function histogramToSortedArrays(counts: Map<number, number>): {
+  codes: Int32Array;
+  countValues: Uint32Array;
+} {
+  const sorted = [...counts.entries()].sort((left, right) => left[0] - right[0]);
+  return {
+    codes: Int32Array.from(sorted.map(([code]) => code)),
+    countValues: Uint32Array.from(sorted.map(([, count]) => count)),
+  };
+}
+
+export function scanTableFeatureCounts(
+  table: Table,
+  featureKey: string,
+  featureCodeColumnName: string | undefined,
+  counts: Map<number, number>
+): void {
+  const rowCodes = extractRowFeatureCodesFromTable(table, featureKey, featureCodeColumnName);
+  for (let index = 0; index < rowCodes.length; index += 1) {
+    const code = rowCodes[index];
+    counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+}
+
+export function scanTableByFeatureCodes(input: {
+  table: Table;
+  axisNames: string[];
+  featureKey: string;
+  featureCodeColumnName?: string;
+  featureCodes: readonly number[];
+  memoryCap: number;
+  matchedRows: number;
+  xs: number[];
+  ys: number[];
+  zs: number[];
+}): number {
+  const allowed = featureCodeAllowSet(input.featureCodes);
+  if (allowed !== null && allowed.size === 0) {
+    return input.matchedRows;
+  }
+  const rowCodes = extractRowFeatureCodesFromTable(
+    input.table,
+    input.featureKey,
+    input.featureCodeColumnName
+  );
+  const xColumn = input.axisNames.includes('x') ? input.table.getChild('x') : null;
+  const yColumn = input.axisNames.includes('y') ? input.table.getChild('y') : null;
+  const zColumn = input.axisNames.includes('z') ? input.table.getChild('z') : null;
+  if (!xColumn || !yColumn) {
+    return input.matchedRows;
+  }
+  let matchedRows = input.matchedRows;
+  for (let rowIndex = 0; rowIndex < input.table.numRows; rowIndex += 1) {
+    if (matchedRows >= input.memoryCap) {
+      break;
+    }
+    if (allowed !== null && !rowMatchesFeatureCode(rowCodes[rowIndex], allowed)) {
+      continue;
+    }
+    const x = xColumn.get(rowIndex);
+    const y = yColumn.get(rowIndex);
+    if (typeof x !== 'number' || typeof y !== 'number') {
+      continue;
+    }
+    input.xs.push(x);
+    input.ys.push(y);
+    if (zColumn) {
+      const z = zColumn.get(rowIndex);
+      input.zs.push(typeof z === 'number' ? z : 0);
+    }
+    matchedRows += 1;
+  }
+  return matchedRows;
+}
+
+export function countFeatureCodesFromArray(sourceFeatureCodes: ArrayLike<number>): {
+  codes: Int32Array;
+  countValues: Uint32Array;
+} {
+  return histogramToSortedArrays(countFeatureCodesHistogram(sourceFeatureCodes));
+}

--- a/packages/core/tests/mortonPointsTiling.spec.ts
+++ b/packages/core/tests/mortonPointsTiling.spec.ts
@@ -1,0 +1,283 @@
+import { execSync } from 'node:child_process';
+import { mkdtemp, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import SpatialDataPointsSource from '../src/models/VPointsSource.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '../../..');
+const writerRoot = join(projectRoot, 'python/spatialdata-experimental-writer');
+
+async function writeSyntheticPointsZarr(root: string) {
+  const elementDir = join(root, 'points', 'transcripts');
+  await mkdir(elementDir, { recursive: true });
+  await writeFile(
+    join(root, 'zarr.json'),
+    JSON.stringify({ zarr_format: 3, node_type: 'group' })
+  );
+  await writeFile(
+    join(elementDir, 'zarr.json'),
+    JSON.stringify({
+      attributes: {
+        'encoding-type': 'ngff:points',
+        axes: ['x', 'y'],
+        spatialdata_attrs: {
+          feature_key: 'feature_name',
+          version: '0.2',
+        },
+      },
+      zarr_format: 3,
+      node_type: 'group',
+    })
+  );
+
+  execSync(
+    `uv run python - <<'PY'
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+rows = 500
+df = pd.DataFrame(
+    {
+        "x": [float(i % 100) for i in range(rows)],
+        "y": [float((i * 3) % 100) for i in range(rows)],
+        "feature_name": (["gene_a", "gene_b", "gene_c"] * rows)[:rows],
+    }
+)
+pq.write_table(pa.Table.from_pandas(df, preserve_index=False), root / "points.parquet")
+PY`,
+    { cwd: writerRoot, stdio: 'pipe' }
+  );
+
+  execSync(
+    `uv run spatialdata-experimental-writer morton-points-from-zarr ${JSON.stringify(root)} --points-key transcripts --row-group-size 100`,
+    { cwd: writerRoot, stdio: 'pipe' }
+  );
+}
+
+async function writeBadSentinelMortonPointsZarr(root: string) {
+  const elementDir = join(root, 'points', 'transcripts');
+  await mkdir(elementDir, { recursive: true });
+  await writeFile(
+    join(root, 'zarr.json'),
+    JSON.stringify({ zarr_format: 3, node_type: 'group' })
+  );
+  await writeFile(
+    join(elementDir, 'zarr.json'),
+    JSON.stringify({
+      attributes: {
+        'encoding-type': 'ngff:points',
+        axes: ['x', 'y'],
+        spatialdata_attrs: {
+          feature_key: 'feature_name',
+          version: '0.2',
+        },
+      },
+      zarr_format: 3,
+      node_type: 'group',
+    })
+  );
+
+  execSync(
+    `uv run python - <<'PY'
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+df = pd.DataFrame(
+    {
+        "x": [0.0, 100.0, 0.1, 0.2, 0.3, 20.0, 40.0],
+        "y": [0.0, 100.0, 0.1, 0.2, 0.3, 20.0, 40.0],
+        "feature_name_codes": [0, 1, 0, 0, 0, 1, 1],
+        "morton_code_2d": [0, 0, 0, 0, 0, 100, 200],
+        "feature_name": ["gene_a", "gene_b", "gene_a", "gene_a", "gene_a", "gene_b", "gene_b"],
+    }
+)
+table = pa.Table.from_pandas(df, preserve_index=False)
+writer = pq.ParquetWriter(root / "points.parquet", table.schema, compression="zstd")
+try:
+    writer.write_table(table.slice(0, 5), row_group_size=5)
+    writer.write_table(table.slice(5), row_group_size=2)
+finally:
+    writer.close()
+PY`,
+    { cwd: writerRoot, stdio: 'pipe' }
+  );
+}
+
+function createStore(files: Record<string, Uint8Array>) {
+  let getRangeCalls = 0;
+  let getCalls = 0;
+  const store = {
+    getRangeCalls: () => getRangeCalls,
+    getCalls: () => getCalls,
+    resetCalls: () => {
+      getRangeCalls = 0;
+      getCalls = 0;
+    },
+    store: {
+      async get(path: string) {
+        getCalls += 1;
+        return files[path.slice(1)] ?? null;
+      },
+      async getRange(
+        path: string,
+        range: { offset?: number; length?: number; suffixLength?: number }
+      ) {
+        getRangeCalls += 1;
+        const bytes = files[path.slice(1)];
+        if (!bytes) {
+          return null;
+        }
+        if (range.suffixLength !== undefined) {
+          const start = Math.max(0, bytes.length - range.suffixLength);
+          return bytes.slice(start);
+        }
+        const offset = range.offset ?? 0;
+        const length = range.length ?? bytes.length - offset;
+        return bytes.slice(offset, offset + length);
+      },
+    },
+  };
+  return store;
+}
+
+describe('Morton points tiling (canonical parquet)', () => {
+  let fixtureRoot: string;
+  let source: SpatialDataPointsSource;
+  let mockStore: ReturnType<typeof createStore>;
+
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(join(tmpdir(), 'morton-points-'));
+    await writeSyntheticPointsZarr(fixtureRoot);
+
+    const parquetPath = join(fixtureRoot, 'points/transcripts/points.parquet');
+    const elementJsonPath = join(fixtureRoot, 'points/transcripts/zarr.json');
+    mockStore = createStore({
+      'points/transcripts/points.parquet': new Uint8Array(await readFile(parquetPath)),
+      'points/transcripts/zarr.json': new Uint8Array(await readFile(elementJsonPath)),
+    });
+
+    source = new SpatialDataPointsSource({
+      store: mockStore.store,
+      fileType: '.zarr',
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('detects morton tiling metadata on canonical points.parquet', async () => {
+    mockStore.resetCalls();
+    const metadata = await source.getPointsTilingMetadata('points/transcripts');
+    expect(metadata).toMatchObject({
+      kind: 'morton-points',
+      featureCodeColumnName: 'feature_name_codes',
+    });
+    expect(mockStore.getRangeCalls()).toBeGreaterThan(0);
+  });
+
+  it('loads a bounded viewport without returning the full table', async () => {
+    const full = await source.loadPoints('points/transcripts');
+    const xs = full.data[0];
+    const ys = full.data[1];
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const bounds = {
+      minX: minX + 5,
+      maxX: minX + 15,
+      minY: minY + 5,
+      maxY: minY + 15,
+    };
+
+    mockStore.resetCalls();
+    const loadTable = vi.spyOn(source, 'loadParquetTable');
+    const result = await source.loadPointsInBounds('points/transcripts', { bounds });
+    expect(result.shape[1]).toBeGreaterThan(0);
+    expect(result.shape[1]).toBeLessThan(full.shape[1]);
+    expect(['row-groups', 'full-filter']).toContain(result.loadMode);
+    if (result.loadMode === 'full-filter') {
+      expect(loadTable).toHaveBeenCalled();
+    }
+    loadTable.mockRestore();
+  });
+
+  it('filters loaded points by feature codes', async () => {
+    const full = await source.loadPoints('points/transcripts');
+    const xs = full.data[0];
+    const ys = full.data[1];
+    const bounds = {
+      minX: Math.min(...xs),
+      maxX: Math.max(...xs),
+      minY: Math.min(...ys),
+      maxY: Math.max(...ys),
+    };
+
+    const unfiltered = await source.loadPointsInBounds('points/transcripts', { bounds });
+    const filtered = await source.loadPointsInBounds('points/transcripts', {
+      bounds,
+      featureCodes: [0],
+    });
+    expect(filtered.shape[1]).toBeGreaterThan(0);
+    expect(filtered.shape[1]).toBeLessThan(unfiltered.shape[1] ?? Number.MAX_SAFE_INTEGER);
+  });
+
+  it('uses row-group reads when parquet-wasm exposes row-group APIs', async () => {
+    const canRowGroups = await source.canLoadParquetRowGroups();
+    if (!canRowGroups) {
+      return;
+    }
+
+    const metadata = await source.getPointsTilingMetadata('points/transcripts');
+    expect(metadata?.supportsRowGroupRangeReads).toBe(true);
+    expect(metadata?.bounds).toBeDefined();
+
+    mockStore.resetCalls();
+    const bounds = {
+      minX: metadata!.bounds!.minX + 10,
+      maxX: metadata!.bounds!.minX + 30,
+      minY: metadata!.bounds!.minY + 10,
+      maxY: metadata!.bounds!.minY + 30,
+    };
+    const result = await source.loadPointsInBounds('points/transcripts', { bounds });
+    expect(result.shape?.[1]).toBeGreaterThan(0);
+    if (result.loadMode === 'row-groups') {
+      expect(mockStore.getRangeCalls()).toBeGreaterThan(0);
+      expect(mockStore.getCalls()).toBe(0);
+    }
+  });
+
+  it('does not enable morton tiling when sentinel row group is oversized', async () => {
+    const badFixtureRoot = await mkdtemp(join(tmpdir(), 'bad-morton-points-'));
+    try {
+      await writeBadSentinelMortonPointsZarr(badFixtureRoot);
+      const parquetPath = join(badFixtureRoot, 'points/transcripts/points.parquet');
+      const elementJsonPath = join(badFixtureRoot, 'points/transcripts/zarr.json');
+      const badStore = createStore({
+        'points/transcripts/points.parquet': new Uint8Array(await readFile(parquetPath)),
+        'points/transcripts/zarr.json': new Uint8Array(await readFile(elementJsonPath)),
+      });
+      const badSource = new SpatialDataPointsSource({
+        store: badStore.store,
+        fileType: '.zarr',
+      });
+
+      const metadata = await badSource.getPointsTilingMetadata('points/transcripts');
+
+      expect(metadata?.supportsRowGroupRangeReads).toBe(false);
+      expect(metadata?.bounds).toBeUndefined();
+    } finally {
+      execSync(`rm -rf ${JSON.stringify(badFixtureRoot)}`, { stdio: 'pipe' });
+    }
+  });
+});

--- a/packages/core/tests/pointsFeatures.spec.ts
+++ b/packages/core/tests/pointsFeatures.spec.ts
@@ -1,0 +1,431 @@
+import { execSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, mkdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import SpatialDataPointsSource from '../src/models/VPointsSource.js';
+import * as pointsWorkerClient from '../src/workers/pointsWorkerClient.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const writerRoot = join(__dirname, '../../../python/spatialdata-experimental-writer');
+
+async function writePointsFeatureFixture(root: string) {
+  const elementDir = join(root, 'points', 'transcripts');
+  await mkdir(elementDir, { recursive: true });
+
+  execSync(
+    `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+(root / "points.parquet").mkdir(parents=True, exist_ok=True)
+table0 = pa.table(
+    {
+        "x": [0.0, 1.0, 2.0],
+        "y": [0.0, 1.0, 2.0],
+        "feature_name": ["gene_a", "gene_b", "gene_a"],
+        "feature_name_codes": pa.array([0, 1, 0], type=pa.int32()),
+    }
+)
+table1 = pa.table(
+    {
+        "x": [3.0, 4.0],
+        "y": [3.0, 4.0],
+        "feature_name": ["gene_c", "gene_b"],
+        "feature_name_codes": pa.array([2, 1], type=pa.int32()),
+    }
+)
+pq.write_table(table0, root / "points.parquet" / "part.0.parquet")
+pq.write_table(table1, root / "points.parquet" / "part.1.parquet")
+PY`,
+    { cwd: writerRoot, stdio: 'pipe' }
+  );
+}
+
+function createFilesystemStore(root: string) {
+  const readStoreBytes = async (relativePath: string): Promise<Uint8Array | null> => {
+    const fullPath = join(root, relativePath);
+    try {
+      const info = await stat(fullPath);
+      if (info.isDirectory()) {
+        return null;
+      }
+      return await readFile(fullPath);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    async get(path: string) {
+      const relativePath = path.startsWith('/') ? path.slice(1) : path;
+      return readStoreBytes(relativePath);
+    },
+    async getRange(
+      path: string,
+      range: { offset?: number; length?: number; suffixLength?: number }
+    ) {
+      const relativePath = path.startsWith('/') ? path.slice(1) : path;
+      const bytes = await readStoreBytes(relativePath);
+      if (!bytes) {
+        return null;
+      }
+      if (range.suffixLength != null) {
+        return bytes.subarray(bytes.length - range.suffixLength);
+      }
+      const offset = range.offset ?? 0;
+      const length = range.length ?? bytes.length - offset;
+      return bytes.subarray(offset, offset + length);
+    },
+  };
+}
+
+describe('SpatialDataPointsSource feature catalog', () => {
+  let fixtureRoot: string;
+  let source: SpatialDataPointsSource;
+
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(join(tmpdir(), 'points-features-'));
+    await writePointsFeatureFixture(fixtureRoot);
+    source = new SpatialDataPointsSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+    vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('lists distinct feature names and codes across multipart parquet', async () => {
+    const catalog = await source.listPointsFeatures('points/transcripts');
+    expect(catalog).toEqual({
+      featureKey: 'feature_name',
+      entries: [
+        { code: 0, name: 'gene_a' },
+        { code: 1, name: 'gene_b' },
+        { code: 2, name: 'gene_c' },
+      ],
+    });
+  });
+
+  it('lists features for oversized datasets via feature-column scan', async () => {
+    vi.spyOn(source, 'resolveParquetRowCount' as keyof SpatialDataPointsSource).mockResolvedValue(
+      5_000_000
+    );
+    const catalog = await source.listPointsFeatures('points/transcripts');
+    expect(catalog).toEqual({
+      featureKey: 'feature_name',
+      entries: [
+        { code: 0, name: 'gene_a' },
+        { code: 1, name: 'gene_b' },
+        { code: 2, name: 'gene_c' },
+      ],
+    });
+  });
+
+  it('lists features for oversized dictionary-encoded datasets via row-group dictionary read', async () => {
+    const elementDir = join(fixtureRoot, 'points', 'dict_large');
+    await mkdir(elementDir, { recursive: true });
+    execSync(
+      `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+(root / "points.parquet").mkdir(parents=True, exist_ok=True)
+genes = pa.array(["gene_a", "gene_b", "gene_c"], type=pa.dictionary(pa.int32(), pa.string()))
+names = (["gene_a", "gene_b", "gene_c"] * 34)[:100]
+table = pa.table(
+    {
+        "x": [float(i) for i in range(100)],
+        "y": [float(i) for i in range(100)],
+        "feature_name": pa.array(names, type=pa.dictionary(pa.int32(), pa.string())),
+    }
+)
+pq.write_table(table, root / "points.parquet" / "part.0.parquet")
+PY`,
+      { cwd: writerRoot, stdio: 'pipe' }
+    );
+
+    const dictSource = new SpatialDataPointsSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+    vi.spyOn(dictSource, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+    vi.spyOn(
+      dictSource,
+      'resolveParquetRowCount' as keyof SpatialDataPointsSource
+    ).mockResolvedValue(5_000_000);
+
+    const catalog = await dictSource.listPointsFeatures('points/dict_large');
+    expect(catalog?.entries).toEqual([
+      { code: 0, name: 'gene_a' },
+      { code: 1, name: 'gene_b' },
+      { code: 2, name: 'gene_c' },
+    ]);
+  });
+
+  it('loads feature code column with full points preload via loadPointsRowFeatureCodes', async () => {
+    const points = await source.loadPoints('points/transcripts');
+    expect(points.shape[1]).toBe(5);
+    expect(points.featureCodes).toBeUndefined();
+    const featureCodes = await source.loadPointsRowFeatureCodes('points/transcripts');
+    expect(featureCodes?.length).toBe(5);
+  });
+
+  it('uses explicit feature code columns instead of dictionary indices', async () => {
+    const elementDir = join(fixtureRoot, 'points', 'dict_with_codes');
+    await mkdir(elementDir, { recursive: true });
+    execSync(
+      `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+(root / "points.parquet").mkdir(parents=True, exist_ok=True)
+names = pa.DictionaryArray.from_arrays(
+    pa.array([0, 1, 0], type=pa.int32()),
+    pa.array(["ABCC11", "TP53"]),
+)
+table = pa.table(
+    {
+        "x": [0.0, 1.0, 2.0],
+        "y": [0.0, 1.0, 2.0],
+        "feature_name": names,
+        "feature_name_codes": pa.array([1, 0, 1], type=pa.int32()),
+    }
+)
+pq.write_table(table, root / "points.parquet" / "part.0.parquet")
+PY`,
+      { cwd: writerRoot, stdio: 'pipe' }
+    );
+
+    const dictSource = new SpatialDataPointsSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+    vi.spyOn(dictSource, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+
+    const catalog = await dictSource.listPointsFeatures('points/dict_with_codes');
+    expect(catalog?.entries).toEqual([
+      { code: 0, name: 'TP53' },
+      { code: 1, name: 'ABCC11' },
+    ]);
+
+    const featureCodes = await dictSource.loadPointsRowFeatureCodes('points/dict_with_codes');
+    expect([...featureCodes!]).toEqual([1, 0, 1]);
+  });
+
+  it('omits counts for dictionary-only feature columns without explicit code mapping', async () => {
+    const elementDir = join(fixtureRoot, 'points', 'dict_counts_untrusted');
+    await mkdir(elementDir, { recursive: true });
+    execSync(
+      `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+(root / "points.parquet").mkdir(parents=True, exist_ok=True)
+names = ["ABCC11", "TP53", "TP53", "EGFR"]
+table = pa.table(
+    {
+        "x": [0.0, 1.0, 2.0, 3.0],
+        "y": [0.0, 1.0, 2.0, 3.0],
+        "feature_name": pa.array(names, type=pa.dictionary(pa.int32(), pa.string())),
+    }
+)
+pq.write_table(table, root / "points.parquet" / "part.0.parquet")
+PY`,
+      { cwd: writerRoot, stdio: 'pipe' }
+    );
+
+    const dictSource = new SpatialDataPointsSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+    vi.spyOn(dictSource, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+
+    const counts = await dictSource.loadFeatureCounts('points/dict_counts_untrusted');
+    expect(counts.size).toBe(0);
+
+    const catalog = await dictSource.listPointsFeaturesWithCounts('points/dict_counts_untrusted');
+    expect(catalog?.entries).toEqual([
+      { code: 0, name: 'ABCC11' },
+      { code: 1, name: 'TP53' },
+      { code: 2, name: 'EGFR' },
+    ]);
+  });
+
+  it('derives row feature codes from dictionary-encoded feature names', async () => {
+    const elementDir = join(fixtureRoot, 'points', 'dict_only');
+    await mkdir(elementDir, { recursive: true });
+    execSync(
+      `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+(root / "points.parquet").mkdir(parents=True, exist_ok=True)
+genes = pa.array(["gene_a", "gene_b", "gene_a"], type=pa.dictionary(pa.int32(), pa.string()))
+table = pa.table({"x": [0.0, 1.0, 2.0], "y": [0.0, 1.0, 2.0], "feature_name": genes})
+pq.write_table(table, root / "points.parquet" / "part.0.parquet")
+PY`,
+      { cwd: writerRoot, stdio: 'pipe' }
+    );
+
+    const dictSource = new SpatialDataPointsSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+    vi.spyOn(dictSource, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+
+    const points = await dictSource.loadPoints('points/dict_only');
+    expect(points.featureCodes).toBeUndefined();
+    const featureCodes = await dictSource.loadPointsRowFeatureCodes('points/dict_only');
+    expect(featureCodes?.length).toBe(3);
+    expect([...featureCodes!]).toEqual([0, 1, 0]);
+  });
+
+  it('derives dictionary-only row codes from decoded names, not local dictionary indices', async () => {
+    const elementDir = join(fixtureRoot, 'points', 'dict_local_indices');
+    await mkdir(elementDir, { recursive: true });
+    execSync(
+      `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(elementDir)})
+(root / "points.parquet").mkdir(parents=True, exist_ok=True)
+part0_names = pa.DictionaryArray.from_arrays(
+    pa.array([0, 0, 1], type=pa.int32()),
+    pa.array(["ABCC11", "TP53"]),
+)
+part1_names = pa.DictionaryArray.from_arrays(
+    pa.array([0, 0, 1], type=pa.int32()),
+    pa.array(["TP53", "EGFR"]),
+)
+part0 = pa.table(
+    {
+        "x": [0.0, 1.0, 2.0],
+        "y": [0.0, 1.0, 2.0],
+        "feature_name": part0_names,
+    }
+)
+part1 = pa.table(
+    {
+        "x": [3.0, 4.0, 5.0],
+        "y": [3.0, 4.0, 5.0],
+        "feature_name": part1_names,
+    }
+)
+pq.write_table(part0, root / "points.parquet" / "part.0.parquet")
+pq.write_table(part1, root / "points.parquet" / "part.1.parquet")
+PY`,
+      { cwd: writerRoot, stdio: 'pipe' }
+    );
+
+    const dictSource = new SpatialDataPointsSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+    vi.spyOn(dictSource, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+
+    const catalog = await dictSource.listPointsFeatures('points/dict_local_indices');
+    expect(catalog?.entries).toEqual([
+      { code: 0, name: 'ABCC11' },
+      { code: 1, name: 'TP53' },
+      { code: 2, name: 'EGFR' },
+    ]);
+
+    const featureCodes = await dictSource.loadPointsRowFeatureCodes('points/dict_local_indices');
+    expect([...featureCodes!]).toEqual([0, 0, 1, 1, 1, 2]);
+  });
+
+  it('delegates row feature code decode to the points worker when enabled', async () => {
+    const workerCodes = Int32Array.from([0, 1, 0, 1, 2]);
+    vi.spyOn(pointsWorkerClient, 'ensurePointsWorker').mockImplementation(() => {});
+    vi.spyOn(pointsWorkerClient, 'isPointsWorkerEnabled').mockReturnValue(true);
+    const decodeSpy = vi
+      .spyOn(pointsWorkerClient, 'decodeParquetRowFeatureCodesInWorker')
+      .mockResolvedValue(workerCodes);
+    vi.spyOn(source, 'canLoadParquetRowGroups').mockResolvedValue(false);
+
+    const featureCodes = await source.loadPointsRowFeatureCodes('points/transcripts');
+    expect(decodeSpy).toHaveBeenCalled();
+    expect([...featureCodes!]).toEqual([...workerCodes]);
+  });
+
+  it('delegates oversized feature catalog scan to the points worker when enabled', async () => {
+    const workerCatalog = {
+      featureKey: 'feature_name',
+      entries: [
+        { code: 0, name: 'gene_a' },
+        { code: 1, name: 'gene_b' },
+      ],
+    };
+    vi.spyOn(pointsWorkerClient, 'ensurePointsWorker').mockImplementation(() => {});
+    vi.spyOn(pointsWorkerClient, 'isPointsWorkerEnabled').mockReturnValue(true);
+    const catalogSpy = vi
+      .spyOn(pointsWorkerClient, 'scanParquetFeatureCatalogInWorker')
+      .mockResolvedValue(workerCatalog);
+    vi.spyOn(source, 'resolveParquetRowCount' as keyof SpatialDataPointsSource).mockResolvedValue(
+      5_000_000
+    );
+
+    const catalog = await source.listPointsFeatures('points/transcripts');
+    expect(catalogSpy).toHaveBeenCalled();
+    expect(catalog).toEqual(workerCatalog);
+  });
+});

--- a/packages/core/tests/pointsLoader.spec.ts
+++ b/packages/core/tests/pointsLoader.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMortonTiledPointsLoader, resolvePointsEncoding } from '../src/pointsLoader.js';
+import type { PointsElement } from '../src/models/index.js';
+
+describe('resolvePointsEncoding', () => {
+  it('prefers preloaded data when present', () => {
+    expect(
+      resolvePointsEncoding({ shape: [1], data: [[0], [0]] }, null, true)
+    ).toBe('preloaded-columnar');
+  });
+
+  it('selects morton tiling when metadata supports row-group reads', () => {
+    expect(
+      resolvePointsEncoding(null, {
+        kind: 'morton-points',
+        parquetPath: 'points/a/points.parquet',
+        axisNames: ['x', 'y'],
+        featureCodeColumnName: 'feature_name_codes',
+        mortonCodeColumnName: 'morton_code_2d',
+        totalRows: 10,
+        totalRowGroups: 1,
+        maxRowsPerGroup: 10,
+        supportsRowGroupRangeReads: true,
+        bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+      }, true)
+    ).toBe('morton-tiled');
+  });
+});
+
+describe('createMortonTiledPointsLoader', () => {
+  it('uses columnar shape[1] as point count, not shape[0] axis count', async () => {
+    const element = {
+      async loadPointsInBounds() {
+        return {
+          shape: [2, 1_000],
+          data: [new Float64Array(1_000), new Float64Array(1_000)],
+          bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+          loadMode: 'row-groups',
+        };
+      },
+    } as unknown as PointsElement;
+
+    const loader = createMortonTiledPointsLoader(element, {
+      kind: 'morton-points',
+      parquetPath: 'points/a/points.parquet',
+      axisNames: ['x', 'y'],
+      featureCodeColumnName: 'feature_name_codes',
+      mortonCodeColumnName: 'morton_code_2d',
+      totalRows: 1_000,
+      totalRowGroups: 1,
+      maxRowsPerGroup: 1_000,
+      supportsRowGroupRangeReads: true,
+      bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+    });
+
+    const batch = await loader.loadInBounds({
+      bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+    });
+    expect(batch?.pointCount).toBe(1_000);
+  });
+});

--- a/packages/core/tests/pointsPreloadGuard.spec.ts
+++ b/packages/core/tests/pointsPreloadGuard.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { tableFromArrays } from 'apache-arrow';
+import SpatialDataPointsSource from '../src/models/VPointsSource.js';
+import {
+  POINTS_PRELOAD_MAX_ROWS,
+  preloadedColumnarPointCount,
+} from '../src/pointsLimits.js';
+
+describe('points preload cap', () => {
+  it('loads a capped subset when parquet row count exceeds the cap', async () => {
+    const source = new SpatialDataPointsSource({
+      store: { get: async () => null },
+      fileType: '.zarr',
+    });
+
+    vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+    vi.spyOn(source, 'loadParquetDatasetMetadata').mockResolvedValue({
+      totalNumRows: POINTS_PRELOAD_MAX_ROWS + 1,
+      totalNumRowGroups: 1,
+      numRowsByPart: [POINTS_PRELOAD_MAX_ROWS + 1],
+      numRowGroupsByPart: [1],
+      numRowsPerGroupByPart: [POINTS_PRELOAD_MAX_ROWS + 1],
+      rowGroupRows: [POINTS_PRELOAD_MAX_ROWS + 1],
+      schema: null,
+      parts: [],
+    });
+    vi.spyOn(source, 'resolveParquetRowCount').mockResolvedValue(POINTS_PRELOAD_MAX_ROWS + 1);
+
+    const cappedTable = tableFromArrays({
+      x: new Float32Array(POINTS_PRELOAD_MAX_ROWS),
+      y: new Float32Array(POINTS_PRELOAD_MAX_ROWS),
+      feature_name: new Array(POINTS_PRELOAD_MAX_ROWS).fill('gene'),
+    });
+    vi.spyOn(source, 'loadParquetTableCapped').mockResolvedValue({
+      table: cappedTable,
+      totalRows: POINTS_PRELOAD_MAX_ROWS + 1,
+      truncated: true,
+    });
+
+    const result = await source.loadPoints('points/transcripts');
+    expect(preloadedColumnarPointCount(result.shape, result.data)).toBe(POINTS_PRELOAD_MAX_ROWS);
+    expect(result.totalRowCount).toBe(POINTS_PRELOAD_MAX_ROWS + 1);
+    expect(result.preloadTruncated).toBe(true);
+  });
+});

--- a/packages/core/tests/pointsPreloadReadStrategy.spec.ts
+++ b/packages/core/tests/pointsPreloadReadStrategy.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { tableFromArrays } from 'apache-arrow';
+import SpatialDataPointsSource from '../src/models/VPointsSource.js';
+import * as pointsWorkerClient from '../src/workers/pointsWorkerClient.js';
+
+describe('points preload read strategy', () => {
+  it('does not prefetch row-group bytes for geometry preload', async () => {
+    const source = new SpatialDataPointsSource({
+      store: { get: async () => null },
+      fileType: '.zarr',
+    });
+
+    vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+    vi.spyOn(source, 'resolveParquetRowCount').mockResolvedValue(100);
+    vi.spyOn(source, 'canLoadParquetRowGroups').mockResolvedValue(true);
+
+    const rowGroupBytesSpy = vi.spyOn(source, 'readParquetRowGroupsBytesCapped');
+    const payloadSpy = vi.spyOn(source, 'readParquetWorkerPayload');
+
+    vi.spyOn(pointsWorkerClient, 'isPointsWorkerEnabled').mockReturnValue(true);
+    vi.spyOn(pointsWorkerClient, 'decodeParquetGeometryCappedInWorker').mockResolvedValue({
+      shape: [2, 100],
+      data: [new Float32Array(100), new Float32Array(100)],
+    });
+
+    await source.loadPoints('points/transcripts');
+
+    expect(rowGroupBytesSpy).not.toHaveBeenCalled();
+    expect(payloadSpy).toHaveBeenCalledWith('points/transcripts/points.parquet', { maxRows: 100 });
+    expect(payloadSpy.mock.calls[0]?.[1]?.includeRowGroups).not.toBe(true);
+  });
+
+  it('uses full-file capped decode for preload fallback, not row groups', async () => {
+    const source = new SpatialDataPointsSource({
+      store: { get: async () => null },
+      fileType: '.zarr',
+    });
+
+    vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+      'encoding-type': 'ngff:points',
+      axes: ['x', 'y'],
+      spatialdata_attrs: {
+        feature_key: 'feature_name',
+        version: '0.2',
+      },
+    });
+    vi.spyOn(source, 'resolveParquetRowCount').mockResolvedValue(100);
+    vi.spyOn(source, 'canLoadParquetRowGroups').mockResolvedValue(true);
+    vi.spyOn(pointsWorkerClient, 'isPointsWorkerEnabled').mockReturnValue(false);
+
+    const cappedSpy = vi.spyOn(source, 'loadParquetTableCapped').mockResolvedValue({
+      table: tableFromArrays({
+        x: new Float32Array(100),
+        y: new Float32Array(100),
+      }),
+      totalRows: 100,
+      truncated: false,
+    });
+
+    await source.loadPoints('points/transcripts');
+
+    expect(cappedSpy).toHaveBeenCalledWith(
+      'points/transcripts/points.parquet',
+      ['x', 'y'],
+      100
+    );
+  });
+});

--- a/packages/core/tests/pointsTiling.spec.ts
+++ b/packages/core/tests/pointsTiling.spec.ts
@@ -1,0 +1,151 @@
+import type { Table as ArrowTable } from 'apache-arrow';
+import { describe, expect, it } from 'vitest';
+import {
+  extractSentinelBoundingBox,
+  filterColumnarByFeatureCodes,
+  filterPointsToBounds,
+  mergeAdjacentIntervals,
+  mortonIntervalsForBounds,
+  zcoverRectangle,
+} from '../src/pointsTiling.js';
+
+function vector(values: unknown[]) {
+  return {
+    length: values.length,
+    get: (index: number) => values[index],
+  };
+}
+
+function table(columns: Record<string, unknown[]>): ArrowTable {
+  const first = Object.values(columns)[0] ?? [];
+  return {
+    numRows: first.length,
+    getChild: (name: string) => {
+      const values = columns[name];
+      return values ? vector(values) : null;
+    },
+  } as unknown as ArrowTable;
+}
+
+describe('points tiling helpers', () => {
+  it('extracts the Vitessce sentinel bounding box from the leading rows', () => {
+    const arrowTable = table({
+      x: [10, 20, 15, 17, 99],
+      y: [5, 8, 40, 12, 99],
+      morton_code_2d: [0, 0, 0, 0, 123],
+    });
+
+    expect(extractSentinelBoundingBox(arrowTable)).toEqual({
+      minX: 10,
+      minY: 5,
+      maxX: 20,
+      maxY: 40,
+    });
+  });
+
+  it('accepts bigint morton sentinel values', () => {
+    const arrowTable = table({
+      x: [10, 20, 15, 17],
+      y: [5, 8, 40, 12],
+      morton_code_2d: [0n, 0n, 0n, 0n],
+    });
+
+    expect(extractSentinelBoundingBox(arrowTable)).toEqual({
+      minX: 10,
+      minY: 5,
+      maxX: 20,
+      maxY: 40,
+    });
+  });
+
+  it('rejects missing or incomplete sentinel bounds', () => {
+    expect(
+      extractSentinelBoundingBox(
+        table({
+          x: [10, 20],
+          y: [5, 8],
+          morton_code_2d: [7, 8],
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('merges adjacent Morton intervals', () => {
+    expect(
+      mergeAdjacentIntervals([
+        [10, 12],
+        [13, 15],
+        [20, 21],
+      ])
+    ).toEqual([
+      [10, 15],
+      [20, 21],
+    ]);
+  });
+
+  it('covers a full rectangle with the full Morton range', () => {
+    expect(zcoverRectangle(0, 0, 65535, 65535)).toEqual([[0, 4294967295]]);
+  });
+
+  it('produces intervals for a query rectangle inside a stored bbox', () => {
+    const intervals = mortonIntervalsForBounds(
+      { minX: 0, minY: 0, maxX: 100, maxY: 100 },
+      { minX: 10, minY: 10, maxX: 20, maxY: 20 }
+    );
+    expect(intervals.length).toBeGreaterThan(0);
+    expect(intervals.every(([lo, hi]) => lo <= hi)).toBe(true);
+  });
+
+  it('filters columnar points to bounds without changing source arrays', () => {
+    const xs = new Float32Array([0, 5, 10]);
+    const ys = new Float32Array([0, 5, 20]);
+    const filtered = filterPointsToBounds(
+      { data: [xs, ys], shape: [2, 3] },
+      { minX: 1, minY: 1, maxX: 10, maxY: 10 }
+    );
+    expect(Array.from(filtered.data[0])).toEqual([5]);
+    expect(Array.from(filtered.data[1])).toEqual([5]);
+    expect(filtered.shape).toEqual([2, 1]);
+  });
+
+  it('filters columnar points by feature codes after spatial bounds', () => {
+    const xs = new Float32Array([5, 5, 5]);
+    const ys = new Float32Array([5, 5, 5]);
+    const featureCodes = new Int32Array([0, 1, 2]);
+    const filtered = filterPointsToBounds(
+      { data: [xs, ys], shape: [2, 3] },
+      { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+      undefined,
+      [1],
+      featureCodes
+    );
+    expect(Array.from(filtered.data[0])).toEqual([5]);
+    expect(filtered.shape).toEqual([2, 1]);
+  });
+
+  it('filters columnar points by feature codes without bounds', () => {
+    const xs = new Float32Array([0, 1, 2]);
+    const ys = new Float32Array([0, 1, 2]);
+    const sourceFeatureCodes = new Int32Array([0, 1, 0]);
+    const filtered = filterColumnarByFeatureCodes(
+      { data: [xs, ys], shape: [2, 3] },
+      [0],
+      sourceFeatureCodes
+    );
+    expect(Array.from(filtered.data[0])).toEqual([0, 2]);
+    expect(filtered.shape).toEqual([2, 2]);
+  });
+
+  it('returns no rows when feature filter is an empty selection', () => {
+    const xs = new Float32Array([0, 1, 2]);
+    const ys = new Float32Array([0, 1, 2]);
+    const sourceFeatureCodes = new Int32Array([0, 1, 0]);
+    const filtered = filterColumnarByFeatureCodes(
+      { data: [xs, ys], shape: [2, 3] },
+      [],
+      sourceFeatureCodes
+    );
+    expect(filtered.data[0].length).toBe(0);
+    expect(filtered.shape).toEqual([2, 0]);
+  });
+});

--- a/packages/core/tests/pointsWorker.spec.ts
+++ b/packages/core/tests/pointsWorker.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  decodeParquetRowFeatureCodesInWorker,
+  disablePointsWorker,
+  filterColumnarByFeatureCodesInWorker,
+  scanParquetFeatureCatalogInWorker,
+  setPointsWorkerDefaultEnabled,
+} from '../src/workers/pointsWorkerClient.js';
+import { filterColumnarByFeatureCodes as filterSync } from '../src/pointsTiling.js';
+
+describe('points worker client', () => {
+  it('falls back to main-thread filtering when the worker is disabled', async () => {
+    setPointsWorkerDefaultEnabled(false);
+    const data = {
+      shape: [2, 4] as [number, number],
+      data: [
+        Float32Array.from([0, 1, 2, 3]),
+        Float32Array.from([0, 1, 2, 3]),
+      ],
+    };
+    const sourceFeatureCodes = Int32Array.from([0, 1, 0, 2]);
+    const filtered = await filterColumnarByFeatureCodesInWorker(data, [1], sourceFeatureCodes);
+    const expected = filterSync(data, [1], sourceFeatureCodes);
+    expect(filtered.shape).toEqual(expected.shape);
+    expect(Array.from(filtered.data[0])).toEqual(Array.from(expected.data[0]));
+    expect(Array.from(filtered.data[1])).toEqual(Array.from(expected.data[1]));
+  });
+
+  it('returns null for row feature code decode when the worker is disabled', async () => {
+    disablePointsWorker();
+    setPointsWorkerDefaultEnabled(false);
+    const result = await decodeParquetRowFeatureCodesInWorker({
+      parts: [new Uint8Array([1, 2, 3])],
+      columns: ['feature_name'],
+      featureKey: 'feature_name',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null for feature catalog scan when the worker is disabled', async () => {
+    disablePointsWorker();
+    setPointsWorkerDefaultEnabled(false);
+    const result = await scanParquetFeatureCatalogInWorker({
+      parts: [new Uint8Array([1, 2, 3])],
+      columns: ['feature_name'],
+      featureKey: 'feature_name',
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/tests/pointsWorkerScan.spec.ts
+++ b/packages/core/tests/pointsWorkerScan.spec.ts
@@ -1,0 +1,122 @@
+import { tableFromArrays, tableToIPC } from 'apache-arrow';
+import { describe, expect, it } from 'vitest';
+import {
+  decodeParquetRowGroupsToTable,
+  extractGeometryColumnar,
+  extractRowFeatureCodesFromTable,
+  scanFeatureCatalogFromPayload,
+} from '../src/workers/pointsWorkerScan.js';
+
+function mockReadParquetRowGroup(
+  chunks: Array<Array<{ name: string; code: number }>>
+): (
+  schemaBytes: Uint8Array,
+  rowGroupBytes: Uint8Array,
+  rowGroupIndex: number,
+  options?: { columns?: string[] }
+) => { intoIPCStream(): Uint8Array } {
+  return (_schemaBytes, _rowGroupBytes, rowGroupIndex) => {
+    const rows = chunks[rowGroupIndex] ?? [];
+    const table = tableFromArrays({
+      feature_name: rows.map((row) => row.name),
+      feature_name_codes: Int32Array.from(rows.map((row) => row.code)),
+    });
+    return { intoIPCStream: () => tableToIPC(table) };
+  };
+}
+
+describe('decodeParquetRowGroupsToTable', () => {
+  it('merges row groups and respects maxRows', async () => {
+    const table = await decodeParquetRowGroupsToTable(
+      mockReadParquetRowGroup([
+        [
+          { name: 'a', code: 0 },
+          { name: 'b', code: 1 },
+        ],
+        [
+          { name: 'c', code: 2 },
+          { name: 'd', code: 3 },
+        ],
+      ]),
+      [
+        { schemaBytes: new Uint8Array(0), rowGroupBytes: new Uint8Array(0), rowGroupIndex: 0 },
+        { schemaBytes: new Uint8Array(0), rowGroupBytes: new Uint8Array(0), rowGroupIndex: 1 },
+      ],
+      ['feature_name', 'feature_name_codes'],
+      3
+    );
+    expect(table.numRows).toBe(3);
+  });
+});
+
+describe('extractRowFeatureCodesFromTable with featureCodeByName', () => {
+  it('maps dictionary feature names to catalog codes', () => {
+    const names = ['gene_a', 'gene_b', 'gene_a'];
+    const table = tableFromArrays({
+      feature_name: names,
+    });
+    const featureCodeByName = new Map([
+      ['gene_a', 0],
+      ['gene_b', 1],
+    ]);
+    const codes = extractRowFeatureCodesFromTable(
+      table,
+      'feature_name',
+      undefined,
+      featureCodeByName
+    );
+    expect([...codes]).toEqual([0, 1, 0]);
+  });
+});
+
+describe('extractGeometryColumnar', () => {
+  it('returns float32 axis columns', () => {
+    const table = tableFromArrays({
+      x: [0, 1],
+      y: [2, 3],
+    });
+    const geometry = extractGeometryColumnar(table, ['x', 'y']);
+    expect(geometry.shape).toEqual([2, 2]);
+    expect([...geometry.xs]).toEqual([0, 1]);
+    expect([...geometry.ys]).toEqual([2, 3]);
+  });
+});
+
+function mockReadParquet(
+  rows: Array<{ name: string; code: number }>
+): (bytes: Uint8Array, options?: { columns?: string[] }) => { intoIPCStream(): Uint8Array } {
+  return () => {
+    const table = tableFromArrays({
+      feature_name: rows.map((row) => row.name),
+      feature_name_codes: Int32Array.from(rows.map((row) => row.code)),
+    });
+    return { intoIPCStream: () => tableToIPC(table) };
+  };
+}
+
+describe('scanFeatureCatalogFromPayload', () => {
+  it('accumulates catalog entries from row groups', async () => {
+    const catalog = await scanFeatureCatalogFromPayload(
+      mockReadParquet([]),
+      mockReadParquetRowGroup([
+        [
+          { name: 'gene_a', code: 0 },
+          { name: 'gene_b', code: 1 },
+        ],
+      ]),
+      {
+        rowGroups: [
+          { schemaBytes: new Uint8Array(0), rowGroupBytes: new Uint8Array(0), rowGroupIndex: 0 },
+        ],
+        parts: [new Uint8Array(0)],
+        columns: ['feature_name', 'feature_name_codes'],
+        featureKey: 'feature_name',
+        featureCodeColumnName: 'feature_name_codes',
+      }
+    );
+    expect(catalog?.entries).toEqual([
+      { code: 0, name: 'gene_a' },
+      { code: 1, name: 'gene_b' },
+    ]);
+  });
+});

--- a/packages/core/tests/vtableMultipart.spec.ts
+++ b/packages/core/tests/vtableMultipart.spec.ts
@@ -1,0 +1,121 @@
+import { execSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import SpatialDataTableSource from '../src/models/VTableSource.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const writerRoot = join(__dirname, '../../../python/spatialdata-experimental-writer');
+
+async function writeMultipartParquetFixture(root: string, partRows: [number, number]) {
+  execSync(
+    `uv run python - <<'PY'
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+root.mkdir(parents=True, exist_ok=True)
+
+def write_part(path: Path, start: int, count: int) -> None:
+    table = pa.table(
+        {
+            "x": [float(start + i) for i in range(count)],
+            "y": [float(i) for i in range(count)],
+            "feature_name": [f"gene_{i % 3}" for i in range(count)],
+            "feature_name_codes": pa.array([(i % 3) for i in range(count)], type=pa.int32()),
+        }
+    )
+    pq.write_table(table, path)
+
+write_part(root / "part.0.parquet", 0, ${partRows[0]})
+write_part(root / "part.1.parquet", ${partRows[0]}, ${partRows[1]})
+PY`,
+    { cwd: writerRoot, stdio: 'pipe' }
+  );
+}
+
+function createFilesystemStore(root: string) {
+  const readStoreBytes = async (relativePath: string): Promise<Uint8Array | null> => {
+    const fullPath = join(root, relativePath);
+    try {
+      const info = await stat(fullPath);
+      if (info.isDirectory()) {
+        return null;
+      }
+      return await readFile(fullPath);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    async get(path: string) {
+      const relativePath = path.startsWith('/') ? path.slice(1) : path;
+      return readStoreBytes(relativePath);
+    },
+    async getRange(path: string, range: { offset?: number; length?: number; suffixLength?: number }) {
+      const relativePath = path.startsWith('/') ? path.slice(1) : path;
+      const bytes = await readStoreBytes(relativePath);
+      if (!bytes) {
+        return null;
+      }
+      if (range.suffixLength != null) {
+        return bytes.subarray(bytes.length - range.suffixLength);
+      }
+      const offset = range.offset ?? 0;
+      const length = range.length ?? bytes.length - offset;
+      return bytes.subarray(offset, offset + length);
+    },
+  };
+}
+
+describe('SpatialDataTableSource multipart parquet reads', () => {
+  let fixtureRoot: string;
+  let source: SpatialDataTableSource;
+  const parquetPath = 'points/transcripts/points.parquet';
+
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(join(tmpdir(), 'multipart-parquet-'));
+    await writeMultipartParquetFixture(join(fixtureRoot, parquetPath), [100, 50]);
+    source = new SpatialDataTableSource({
+      store: createFilesystemStore(fixtureRoot),
+      fileType: '.zarr',
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('concatenates all multipart parquet files for full-table reads', async () => {
+    const table = await source.loadParquetTable(parquetPath);
+    expect(table.numRows).toBe(150);
+  });
+
+  it('loads feature columns across all parts for catalog-style reads', async () => {
+    const table = await source.loadParquetTable(parquetPath, [
+      'feature_name',
+      'feature_name_codes',
+    ]);
+    expect(table.numRows).toBe(150);
+    const codes = table.getChild('feature_name_codes')?.toArray();
+    expect(codes?.length).toBe(150);
+  });
+
+  it('loads capped column subset via row-group range reads', async () => {
+    const { table, truncated, totalRows } = await source.loadParquetTableCapped(
+      parquetPath,
+      ['x', 'y'],
+      120,
+      { useRowGroupReads: true }
+    );
+    expect(totalRows).toBe(150);
+    expect(truncated).toBe(true);
+    expect(table.numRows).toBe(120);
+    expect(table.getChild('x')?.length).toBe(120);
+    expect(table.getChild('y')?.length).toBe(120);
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "WebWorker", "DOM"],
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "paths": {

--- a/packages/core/vendor/parquet-wasm/README.md
+++ b/packages/core/vendor/parquet-wasm/README.md
@@ -1,0 +1,17 @@
+# Vendored parquet-wasm (browser ESM build)
+
+
+Copied from the Vitessce CDN build:
+
+- `https://cdn.vitessce.io/parquet-wasm@2c23652/esm/parquet_wasm.js`
+- `https://cdn.vitessce.io/parquet-wasm@2c23652/esm/parquet_wasm_bg.wasm`
+
+This build includes row-group APIs (`readMetadata`, `readParquetRowGroup`) that are
+not present in the published `parquet-wasm@0.6.1` npm package.
+
+https://github.com/kylebarron/parquet-wasm/issues/804
+
+Loaded by `packages/core/src/parquetWasmLoader.ts`.
+
+Upstream: [kylebarron/parquet-wasm](https://github.com/kylebarron/parquet-wasm)
+(MIT OR Apache-2.0).

--- a/packages/core/vendor/parquet-wasm/parquet_wasm.d.ts
+++ b/packages/core/vendor/parquet-wasm/parquet_wasm.d.ts
@@ -1,0 +1,15 @@
+declare const init: (moduleOrPath?: unknown) => Promise<unknown>;
+export function initSync(module?: unknown): unknown;
+export function readParquet(
+  bytes: Uint8Array,
+  options?: { columns?: string[]; limit?: number; offset?: number }
+): { intoIPCStream(): Uint8Array };
+export function readSchema(bytes: Uint8Array): { intoIPCStream(): Uint8Array };
+export function readMetadata(bytes: Uint8Array): unknown;
+export function readParquetRowGroup(
+  footerBytes: Uint8Array,
+  rowGroupBytes: Uint8Array,
+  rowGroupIndex: number,
+  options?: { columns?: string[]; limit?: number; offset?: number }
+): { intoIPCStream(): Uint8Array };
+export default init;

--- a/packages/core/vendor/parquet-wasm/parquet_wasm.js
+++ b/packages/core/vendor/parquet-wasm/parquet_wasm.js
@@ -1,0 +1,2983 @@
+let wasm;
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return decodeText(ptr, len);
+}
+
+let WASM_VECTOR_LEN = 0;
+
+const cachedTextEncoder = new TextEncoder();
+
+if (!('encodeInto' in cachedTextEncoder)) {
+    cachedTextEncoder.encodeInto = function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+            read: arg.length,
+            written: buf.length
+        };
+    }
+}
+
+function passStringToWasm0(arg, malloc, realloc) {
+
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = cachedTextEncoder.encodeInto(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+let cachedDataViewMemory0 = null;
+
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+function addToExternrefTable0(obj) {
+    const idx = wasm.__externref_table_alloc();
+    wasm.__wbindgen_export_4.set(idx, obj);
+    return idx;
+}
+
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store(idx);
+    }
+}
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
+}
+
+function getArrayU8FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
+}
+
+function debugString(val) {
+    // primitive types
+    const type = typeof val;
+    if (type == 'number' || type == 'boolean' || val == null) {
+        return  `${val}`;
+    }
+    if (type == 'string') {
+        return `"${val}"`;
+    }
+    if (type == 'symbol') {
+        const description = val.description;
+        if (description == null) {
+            return 'Symbol';
+        } else {
+            return `Symbol(${description})`;
+        }
+    }
+    if (type == 'function') {
+        const name = val.name;
+        if (typeof name == 'string' && name.length > 0) {
+            return `Function(${name})`;
+        } else {
+            return 'Function';
+        }
+    }
+    // objects
+    if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = '[';
+        if (length > 0) {
+            debug += debugString(val[0]);
+        }
+        for(let i = 1; i < length; i++) {
+            debug += ', ' + debugString(val[i]);
+        }
+        debug += ']';
+        return debug;
+    }
+    // Test for built-in
+    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+    let className;
+    if (builtInMatches && builtInMatches.length > 1) {
+        className = builtInMatches[1];
+    } else {
+        // Failed to match the standard '[object ClassName]'
+        return toString.call(val);
+    }
+    if (className == 'Object') {
+        // we're a user defined class or Object
+        // JSON.stringify avoids problems with cycles, and is generally much
+        // easier than looping through ownProperties of `val`.
+        try {
+            return 'Object(' + JSON.stringify(val) + ')';
+        } catch (_) {
+            return 'Object';
+        }
+    }
+    // errors
+    if (val instanceof Error) {
+        return `${val.name}: ${val.message}\n${val.stack}`;
+    }
+    // TODO we could test for more things here, like `Set`s and `Map`s.
+    return className;
+}
+
+const CLOSURE_DTORS = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(
+state => {
+    wasm.__wbindgen_export_5.get(state.dtor)(state.a, state.b);
+}
+);
+
+function makeMutClosure(arg0, arg1, dtor, f) {
+    const state = { a: arg0, b: arg1, cnt: 1, dtor };
+    const real = (...args) => {
+
+        // First up with a closure we increment the internal reference
+        // count. This ensures that the Rust closure environment won't
+        // be deallocated while we're invoking it.
+        state.cnt++;
+        const a = state.a;
+        state.a = 0;
+        try {
+            return f(a, state.b, ...args);
+        } finally {
+            if (--state.cnt === 0) {
+                wasm.__wbindgen_export_5.get(state.dtor)(a, state.b);
+                CLOSURE_DTORS.unregister(state);
+            } else {
+                state.a = a;
+            }
+        }
+    };
+    real.original = state;
+    CLOSURE_DTORS.register(real, state, state);
+    return real;
+}
+
+function takeFromExternrefTable0(idx) {
+    const value = wasm.__wbindgen_export_4.get(idx);
+    wasm.__externref_table_dealloc(idx);
+    return value;
+}
+
+function passArray8ToWasm0(arg, malloc) {
+    const ptr = malloc(arg.length * 1, 1) >>> 0;
+    getUint8ArrayMemory0().set(arg, ptr / 1);
+    WASM_VECTOR_LEN = arg.length;
+    return ptr;
+}
+/**
+ * Read a Parquet file into Arrow data.
+ *
+ * This returns an Arrow table in WebAssembly memory. To transfer the Arrow table to JavaScript
+ * memory you have two options:
+ *
+ * - (Easier): Call {@linkcode Table.intoIPCStream} to construct a buffer that can be parsed with
+ *   Arrow JS's `tableFromIPC` function.
+ * - (More performant but bleeding edge): Call {@linkcode Table.intoFFI} to construct a data
+ *   representation that can be parsed zero-copy from WebAssembly with
+ *   [arrow-js-ffi](https://github.com/kylebarron/arrow-js-ffi) using `parseTable`.
+ *
+ * Example with IPC stream:
+ *
+ * ```js
+ * import { tableFromIPC } from "apache-arrow";
+ * import initWasm, {readParquet} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ *
+ * const resp = await fetch("https://example.com/file.parquet");
+ * const parquetUint8Array = new Uint8Array(await resp.arrayBuffer());
+ * const arrowWasmTable = readParquet(parquetUint8Array);
+ * const arrowTable = tableFromIPC(arrowWasmTable.intoIPCStream());
+ * ```
+ *
+ * Example with `arrow-js-ffi`:
+ *
+ * ```js
+ * import { parseTable } from "arrow-js-ffi";
+ * import initWasm, {readParquet, wasmMemory} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ * const WASM_MEMORY = wasmMemory();
+ *
+ * const resp = await fetch("https://example.com/file.parquet");
+ * const parquetUint8Array = new Uint8Array(await resp.arrayBuffer());
+ * const arrowWasmTable = readParquet(parquetUint8Array);
+ * const ffiTable = arrowWasmTable.intoFFI();
+ * const arrowTable = parseTable(
+ *   WASM_MEMORY.buffer,
+ *   ffiTable.arrayAddrs(),
+ *   ffiTable.schemaAddr()
+ * );
+ * ```
+ *
+ * @param parquet_file Uint8Array containing Parquet data
+ * @param options
+ *
+ *    Options for reading Parquet data. Optional keys include:
+ *
+ *    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
+ *           default is 1024.
+ *    - `rowGroups`: Only read data from the provided row group indexes.
+ *    - `limit`: Provide a limit to the number of rows to be read.
+ *    - `offset`: Provide an offset to skip over the given number of rows.
+ *    - `columns`: The column names from the file to read.
+ * @param {Uint8Array} parquet_file
+ * @param {ReaderOptions | null} [options]
+ * @returns {Table}
+ */
+export function readParquet(parquet_file, options) {
+    const ptr0 = passArray8ToWasm0(parquet_file, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.readParquet(ptr0, len0, isLikeNone(options) ? 0 : addToExternrefTable0(options));
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return Table.__wrap(ret[0]);
+}
+
+/**
+ * @param {Uint8Array} footer_bytes
+ * @param {Uint8Array} row_group_bytes
+ * @param {number} row_group_index
+ * @param {ReaderOptions | null} [options]
+ * @returns {Table}
+ */
+export function readParquetRowGroup(footer_bytes, row_group_bytes, row_group_index, options) {
+    const ptr0 = passArray8ToWasm0(footer_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ptr1 = passArray8ToWasm0(row_group_bytes, wasm.__wbindgen_malloc);
+    const len1 = WASM_VECTOR_LEN;
+    const ret = wasm.readParquetRowGroup(ptr0, len0, ptr1, len1, row_group_index, isLikeNone(options) ? 0 : addToExternrefTable0(options));
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return Table.__wrap(ret[0]);
+}
+
+/**
+ * Read an Arrow schema from a Parquet file in memory.
+ *
+ * This returns an Arrow schema in WebAssembly memory. To transfer the Arrow schema to JavaScript
+ * memory you have two options:
+ *
+ * - (Easier): Call {@linkcode Schema.intoIPCStream} to construct a buffer that can be parsed with
+ *   Arrow JS's `tableFromIPC` function. This results in an Arrow JS Table with zero rows but a
+ *   valid schema.
+ * - (More performant but bleeding edge): Call {@linkcode Schema.intoFFI} to construct a data
+ *   representation that can be parsed zero-copy from WebAssembly with
+ *   [arrow-js-ffi](https://github.com/kylebarron/arrow-js-ffi) using `parseSchema`.
+ *
+ * Example with IPC Stream:
+ *
+ * ```js
+ * import { tableFromIPC } from "apache-arrow";
+ * import initWasm, {readSchema} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ *
+ * const resp = await fetch("https://example.com/file.parquet");
+ * const parquetUint8Array = new Uint8Array(await resp.arrayBuffer());
+ * const arrowWasmSchema = readSchema(parquetUint8Array);
+ * const arrowTable = tableFromIPC(arrowWasmSchema.intoIPCStream());
+ * const arrowSchema = arrowTable.schema;
+ * ```
+ *
+ * Example with `arrow-js-ffi`:
+ *
+ * ```js
+ * import { parseSchema } from "arrow-js-ffi";
+ * import initWasm, {readSchema, wasmMemory} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ * const WASM_MEMORY = wasmMemory();
+ *
+ * const resp = await fetch("https://example.com/file.parquet");
+ * const parquetUint8Array = new Uint8Array(await resp.arrayBuffer());
+ * const arrowWasmSchema = readSchema(parquetUint8Array);
+ * const ffiSchema = arrowWasmSchema.intoFFI();
+ * const arrowTable = parseSchema(WASM_MEMORY.buffer, ffiSchema.addr());
+ * const arrowSchema = arrowTable.schema;
+ * ```
+ *
+ * @param parquet_file Uint8Array containing Parquet data
+ * @param {Uint8Array} parquet_file
+ * @returns {Schema}
+ */
+export function readSchema(parquet_file) {
+    const ptr0 = passArray8ToWasm0(parquet_file, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.readSchema(ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return Schema.__wrap(ret[0]);
+}
+
+/**
+ * Read Parquet metadata from a Parquet file (or footer-only) bytes in memory.
+ * @param {Uint8Array} parquet_file
+ * @returns {ParquetMetaData}
+ */
+export function readMetadata(parquet_file) {
+    const ptr0 = passArray8ToWasm0(parquet_file, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.readMetadata(ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ParquetMetaData.__wrap(ret[0]);
+}
+
+function _assertClass(instance, klass) {
+    if (!(instance instanceof klass)) {
+        throw new Error(`expected instance of ${klass.name}`);
+    }
+}
+/**
+ * Write Arrow data to a Parquet file.
+ *
+ * For example, to create a Parquet file with Snappy compression:
+ *
+ * ```js
+ * import { tableToIPC } from "apache-arrow";
+ * // Edit the `parquet-wasm` import as necessary
+ * import initWasm, {
+ *   Table,
+ *   WriterPropertiesBuilder,
+ *   Compression,
+ *   writeParquet,
+ * } from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ *
+ * // Given an existing arrow JS table under `table`
+ * const wasmTable = Table.fromIPCStream(tableToIPC(table, "stream"));
+ * const writerProperties = new WriterPropertiesBuilder()
+ *   .setCompression(Compression.SNAPPY)
+ *   .build();
+ * const parquetUint8Array = writeParquet(wasmTable, writerProperties);
+ * ```
+ *
+ * If `writerProperties` is not provided or is `null`, the default writer properties will be used.
+ * This is equivalent to `new WriterPropertiesBuilder().build()`.
+ *
+ * @param table A {@linkcode Table} representation in WebAssembly memory.
+ * @param writer_properties (optional) Configuration for writing to Parquet. Use the {@linkcode
+ * WriterPropertiesBuilder} to build a writing configuration, then call `.build()` to create an
+ * immutable writer properties to pass in here.
+ * @returns Uint8Array containing written Parquet data.
+ * @param {Table} table
+ * @param {WriterProperties | null} [writer_properties]
+ * @returns {Uint8Array}
+ */
+export function writeParquet(table, writer_properties) {
+    _assertClass(table, Table);
+    var ptr0 = table.__destroy_into_raw();
+    let ptr1 = 0;
+    if (!isLikeNone(writer_properties)) {
+        _assertClass(writer_properties, WriterProperties);
+        ptr1 = writer_properties.__destroy_into_raw();
+    }
+    const ret = wasm.writeParquet(ptr0, ptr1);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v3 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v3;
+}
+
+/**
+ * Read a Parquet file into a stream of Arrow `RecordBatch`es.
+ *
+ * This returns a ReadableStream containing RecordBatches in WebAssembly memory. To transfer the
+ * Arrow table to JavaScript memory you have two options:
+ *
+ * - (Easier): Call {@linkcode RecordBatch.intoIPCStream} to construct a buffer that can be parsed
+ *   with Arrow JS's `tableFromIPC` function. (The table will have a single internal record
+ *   batch).
+ * - (More performant but bleeding edge): Call {@linkcode RecordBatch.intoFFI} to construct a data
+ *   representation that can be parsed zero-copy from WebAssembly with
+ *   [arrow-js-ffi](https://github.com/kylebarron/arrow-js-ffi) using `parseRecordBatch`.
+ *
+ * Example with IPC stream:
+ *
+ * ```js
+ * import { tableFromIPC, Table } from "apache-arrow";
+ * import initWasm, {readParquetStream} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ *
+ * const stream = await readParquetStream(url);
+ *
+ * const batches = [];
+ * for await (const wasmRecordBatch of stream) {
+ *   const arrowTable = tableFromIPC(wasmRecordBatch.intoIPCStream());
+ *   batches.push(...arrowTable.batches);
+ * }
+ * const table = new Table(batches);
+ * ```
+ *
+ * Example with `arrow-js-ffi`:
+ *
+ * ```js
+ * import { Table } from "apache-arrow";
+ * import { parseRecordBatch } from "arrow-js-ffi";
+ * import initWasm, {readParquetStream, wasmMemory} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ * const WASM_MEMORY = wasmMemory();
+ *
+ * const stream = await readParquetStream(url);
+ *
+ * const batches = [];
+ * for await (const wasmRecordBatch of stream) {
+ *   const ffiRecordBatch = wasmRecordBatch.intoFFI();
+ *   const recordBatch = parseRecordBatch(
+ *     WASM_MEMORY.buffer,
+ *     ffiRecordBatch.arrayAddr(),
+ *     ffiRecordBatch.schemaAddr(),
+ *     true
+ *   );
+ *   batches.push(recordBatch);
+ * }
+ * const table = new Table(batches);
+ * ```
+ *
+ * @param url URL to Parquet file
+ * @param {string} url
+ * @param {number | null} [content_length]
+ * @returns {Promise<ReadableStream>}
+ */
+export function readParquetStream(url, content_length) {
+    const ptr0 = passStringToWasm0(url, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.readParquetStream(ptr0, len0, isLikeNone(content_length) ? 0x100000001 : (content_length) >>> 0);
+    return ret;
+}
+
+/**
+ * Transform a ReadableStream of RecordBatches to a ReadableStream of bytes
+ *
+ * Browser example with piping to a file via the File System API:
+ *
+ * ```js
+ * import initWasm, {ParquetFile, transformParquetStream} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ *
+ * const fileInstance = await ParquetFile.fromUrl("https://example.com/file.parquet");
+ * const recordBatchStream = await fileInstance.stream();
+ * const serializedParquetStream = await transformParquetStream(recordBatchStream);
+ * // NB: requires transient user activation - you would typically do this before ☝️
+ * const handle = await window.showSaveFilePicker();
+ * const writable = await handle.createWritable();
+ * await serializedParquetStream.pipeTo(writable);
+ * ```
+ *
+ * NodeJS (ESM) example with piping to a file:
+ * ```js
+ * import { open } from "node:fs/promises";
+ * import { Writable } from "node:stream";
+ * import initWasm, {ParquetFile, transformParquetStream} from "parquet-wasm";
+ *
+ * // Instantiate the WebAssembly context
+ * await initWasm();
+ *
+ * const fileInstance = await ParquetFile.fromUrl("https://example.com/file.parquet");
+ * const recordBatchStream = await fileInstance.stream();
+ * const serializedParquetStream = await transformParquetStream(recordBatchStream);
+ *
+ * // grab a file handle via fsPromises
+ * const handle = await open("file.parquet");
+ * const destinationStream = Writable.toWeb(handle.createWriteStream());
+ * await serializedParquetStream.pipeTo(destinationStream);
+ *
+ * ```
+ * NB: the above is a little contrived - `await writeFile("file.parquet", serializedParquetStream)`
+ * is enough for most use cases.
+ *
+ * Browser kitchen sink example - teeing to the Cache API, using as a streaming post body, transferring
+ * to a Web Worker:
+ * ```js
+ * // prelude elided - see above
+ * const serializedParquetStream = await transformParquetStream(recordBatchStream);
+ * const [cacheStream, bodyStream] = serializedParquetStream.tee();
+ * const postProm = fetch(targetUrl, {
+ *     method: "POST",
+ *     duplex: "half",
+ *     body: bodyStream
+ * });
+ * const targetCache = await caches.open("foobar");
+ * await targetCache.put("https://example.com/file.parquet", new Response(cacheStream));
+ * // this could have been done with another tee, but beware of buffering
+ * const workerStream = await targetCache.get("https://example.com/file.parquet").body;
+ * const worker = new Worker("worker.js");
+ * worker.postMessage(workerStream, [workerStream]);
+ * await postProm;
+ * ```
+ *
+ * @param stream A {@linkcode ReadableStream} of {@linkcode RecordBatch} instances
+ * @param writer_properties (optional) Configuration for writing to Parquet. Use the {@linkcode
+ * WriterPropertiesBuilder} to build a writing configuration, then call `.build()` to create an
+ * immutable writer properties to pass in here.
+ * @returns ReadableStream containing serialized Parquet data.
+ * @param {ReadableStream} stream
+ * @param {WriterProperties | null} [writer_properties]
+ * @returns {Promise<ReadableStream>}
+ */
+export function transformParquetStream(stream, writer_properties) {
+    let ptr0 = 0;
+    if (!isLikeNone(writer_properties)) {
+        _assertClass(writer_properties, WriterProperties);
+        ptr0 = writer_properties.__destroy_into_raw();
+    }
+    const ret = wasm.transformParquetStream(stream, ptr0);
+    return ret;
+}
+
+function getArrayJsValueFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    const mem = getDataViewMemory0();
+    const result = [];
+    for (let i = ptr; i < ptr + 4 * len; i += 4) {
+        result.push(wasm.__wbindgen_export_4.get(mem.getUint32(i, true)));
+    }
+    wasm.__externref_drop_slice(ptr, len);
+    return result;
+}
+
+let cachedUint32ArrayMemory0 = null;
+
+function getUint32ArrayMemory0() {
+    if (cachedUint32ArrayMemory0 === null || cachedUint32ArrayMemory0.byteLength === 0) {
+        cachedUint32ArrayMemory0 = new Uint32Array(wasm.memory.buffer);
+    }
+    return cachedUint32ArrayMemory0;
+}
+
+function getArrayU32FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint32ArrayMemory0().subarray(ptr / 4, ptr / 4 + len);
+}
+/**
+ * Returns a handle to this wasm instance's `WebAssembly.Memory`
+ * @returns {Memory}
+ */
+export function wasmMemory() {
+    const ret = wasm.wasmMemory();
+    return ret;
+}
+
+/**
+ * Returns a handle to this wasm instance's `WebAssembly.Table` which is the indirect function
+ * table used by Rust
+ * @returns {FunctionTable}
+ */
+export function _functionTable() {
+    const ret = wasm._functionTable();
+    return ret;
+}
+
+function __wbg_adapter_6(arg0, arg1) {
+    wasm.wasm_bindgen__convert__closures_____invoke__ha714fc933ee2ad72(arg0, arg1);
+}
+
+function __wbg_adapter_11(arg0, arg1, arg2) {
+    wasm.closure3814_externref_shim(arg0, arg1, arg2);
+}
+
+function __wbg_adapter_271(arg0, arg1, arg2, arg3) {
+    wasm.closure3828_externref_shim(arg0, arg1, arg2, arg3);
+}
+
+/**
+ * Supported compression algorithms.
+ *
+ * Codecs added in format version X.Y can be read by readers based on X.Y and later.
+ * Codec support may vary between readers based on the format version and
+ * libraries available at runtime.
+ * @enum {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7}
+ */
+export const Compression = Object.freeze({
+    UNCOMPRESSED: 0, "0": "UNCOMPRESSED",
+    SNAPPY: 1, "1": "SNAPPY",
+    GZIP: 2, "2": "GZIP",
+    BROTLI: 3, "3": "BROTLI",
+    /**
+     * @deprecated as of Parquet 2.9.0.
+     * Switch to LZ4_RAW
+     */
+    LZ4: 4, "4": "LZ4",
+    ZSTD: 5, "5": "ZSTD",
+    LZ4_RAW: 6, "6": "LZ4_RAW",
+    LZO: 7, "7": "LZO",
+});
+/**
+ * Controls the level of statistics to be computed by the writer
+ * @enum {0 | 1 | 2}
+ */
+export const EnabledStatistics = Object.freeze({
+    /**
+     * Compute no statistics
+     */
+    None: 0, "0": "None",
+    /**
+     * Compute chunk-level statistics but not page-level
+     */
+    Chunk: 1, "1": "Chunk",
+    /**
+     * Compute page-level and chunk-level statistics
+     */
+    Page: 2, "2": "Page",
+});
+/**
+ * Encodings supported by Parquet.
+ * Not all encodings are valid for all types. These enums are also used to specify the
+ * encoding of definition and repetition levels.
+ * @enum {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}
+ */
+export const Encoding = Object.freeze({
+    /**
+     * Default byte encoding.
+     * - BOOLEAN - 1 bit per value, 0 is false; 1 is true.
+     * - INT32 - 4 bytes per value, stored as little-endian.
+     * - INT64 - 8 bytes per value, stored as little-endian.
+     * - FLOAT - 4 bytes per value, stored as little-endian.
+     * - DOUBLE - 8 bytes per value, stored as little-endian.
+     * - BYTE_ARRAY - 4 byte length stored as little endian, followed by bytes.
+     * - FIXED_LEN_BYTE_ARRAY - just the bytes are stored.
+     */
+    PLAIN: 0, "0": "PLAIN",
+    /**
+     * **Deprecated** dictionary encoding.
+     *
+     * The values in the dictionary are encoded using PLAIN encoding.
+     * Since it is deprecated, RLE_DICTIONARY encoding is used for a data page, and
+     * PLAIN encoding is used for dictionary page.
+     */
+    PLAIN_DICTIONARY: 1, "1": "PLAIN_DICTIONARY",
+    /**
+     * Group packed run length encoding.
+     *
+     * Usable for definition/repetition levels encoding and boolean values.
+     */
+    RLE: 2, "2": "RLE",
+    /**
+     * Bit packed encoding.
+     *
+     * This can only be used if the data has a known max width.
+     * Usable for definition/repetition levels encoding.
+     */
+    BIT_PACKED: 3, "3": "BIT_PACKED",
+    /**
+     * Delta encoding for integers, either INT32 or INT64.
+     *
+     * Works best on sorted data.
+     */
+    DELTA_BINARY_PACKED: 4, "4": "DELTA_BINARY_PACKED",
+    /**
+     * Encoding for byte arrays to separate the length values and the data.
+     *
+     * The lengths are encoded using DELTA_BINARY_PACKED encoding.
+     */
+    DELTA_LENGTH_BYTE_ARRAY: 5, "5": "DELTA_LENGTH_BYTE_ARRAY",
+    /**
+     * Incremental encoding for byte arrays.
+     *
+     * Prefix lengths are encoded using DELTA_BINARY_PACKED encoding.
+     * Suffixes are stored using DELTA_LENGTH_BYTE_ARRAY encoding.
+     */
+    DELTA_BYTE_ARRAY: 6, "6": "DELTA_BYTE_ARRAY",
+    /**
+     * Dictionary encoding.
+     *
+     * The ids are encoded using the RLE encoding.
+     */
+    RLE_DICTIONARY: 7, "7": "RLE_DICTIONARY",
+    /**
+     * Encoding for floating-point data.
+     *
+     * K byte-streams are created where K is the size in bytes of the data type.
+     * The individual bytes of an FP value are scattered to the corresponding stream and
+     * the streams are concatenated.
+     * This itself does not reduce the size of the data but can lead to better compression
+     * afterwards.
+     */
+    BYTE_STREAM_SPLIT: 8, "8": "BYTE_STREAM_SPLIT",
+});
+/**
+ * The Parquet version to use when writing
+ * @enum {0 | 1}
+ */
+export const WriterVersion = Object.freeze({
+    V1: 0, "0": "V1",
+    V2: 1, "1": "V2",
+});
+
+const __wbindgen_enum_ReadableStreamType = ["bytes"];
+
+const __wbindgen_enum_RequestCache = ["default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached"];
+
+const __wbindgen_enum_RequestCredentials = ["omit", "same-origin", "include"];
+
+const __wbindgen_enum_RequestMode = ["same-origin", "no-cors", "cors", "navigate"];
+
+const ColumnChunkMetaDataFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_columnchunkmetadata_free(ptr >>> 0, 1));
+/**
+ * Metadata for a Parquet column chunk.
+ */
+export class ColumnChunkMetaData {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(ColumnChunkMetaData.prototype);
+        obj.__wbg_ptr = ptr;
+        ColumnChunkMetaDataFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        ColumnChunkMetaDataFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_columnchunkmetadata_free(ptr, 0);
+    }
+    /**
+     * File where the column chunk is stored.
+     *
+     * If not set, assumed to belong to the same file as the metadata.
+     * This path is relative to the current file.
+     * @returns {string | undefined}
+     */
+    filePath() {
+        const ret = wasm.columnchunkmetadata_filePath(this.__wbg_ptr);
+        let v1;
+        if (ret[0] !== 0) {
+            v1 = getStringFromWasm0(ret[0], ret[1]).slice();
+            wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+        }
+        return v1;
+    }
+    /**
+     * Byte offset in `file_path()`.
+     * @returns {bigint}
+     */
+    fileOffset() {
+        const ret = wasm.columnchunkmetadata_fileOffset(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Path (or identifier) of this column.
+     * @returns {string[]}
+     */
+    columnPath() {
+        const ret = wasm.columnchunkmetadata_columnPath(this.__wbg_ptr);
+        var v1 = getArrayJsValueFromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+        return v1;
+    }
+    /**
+     * All encodings used for this column.
+     * @returns {any[]}
+     */
+    encodings() {
+        const ret = wasm.columnchunkmetadata_encodings(this.__wbg_ptr);
+        var v1 = getArrayJsValueFromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+        return v1;
+    }
+    /**
+     * Total number of values in this column chunk.
+     * @returns {number}
+     */
+    numValues() {
+        const ret = wasm.columnchunkmetadata_numValues(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Compression for this column.
+     * @returns {Compression}
+     */
+    compression() {
+        const ret = wasm.columnchunkmetadata_compression(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Returns the total compressed data size of this column chunk.
+     * @returns {number}
+     */
+    compressedSize() {
+        const ret = wasm.columnchunkmetadata_compressedSize(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Returns the total uncompressed data size of this column chunk.
+     * @returns {number}
+     */
+    uncompressedSize() {
+        const ret = wasm.columnchunkmetadata_uncompressedSize(this.__wbg_ptr);
+        return ret;
+    }
+}
+if (Symbol.dispose) ColumnChunkMetaData.prototype[Symbol.dispose] = ColumnChunkMetaData.prototype.free;
+
+const FFIDataFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_ffidata_free(ptr >>> 0, 1));
+/**
+ * An Arrow array exported to FFI.
+ *
+ * Using [`arrow-js-ffi`](https://github.com/kylebarron/arrow-js-ffi), you can view or copy Arrow
+ * these objects to JavaScript.
+ *
+ * Note that this also includes an ArrowSchema C struct as well, so that extension type
+ * information can be maintained.
+ * ## Memory management
+ *
+ * Note that this array will not be released automatically. You need to manually call `.free()` to
+ * release memory.
+ */
+export class FFIData {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(FFIData.prototype);
+        obj.__wbg_ptr = ptr;
+        FFIDataFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        FFIDataFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_ffidata_free(ptr, 0);
+    }
+    /**
+     * Access the pointer to the
+     * [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions)
+     * struct. This can be viewed or copied (without serialization) to an Arrow JS `RecordBatch` by
+     * using [`arrow-js-ffi`](https://github.com/kylebarron/arrow-js-ffi). You can access the
+     * [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory)
+     * instance by using {@linkcode wasmMemory}.
+     *
+     * **Example**:
+     *
+     * ```ts
+     * import { parseRecordBatch } from "arrow-js-ffi";
+     *
+     * const wasmRecordBatch: FFIRecordBatch = ...
+     * const wasmMemory: WebAssembly.Memory = wasmMemory();
+     *
+     * // Pass `true` to copy arrays across the boundary instead of creating views.
+     * const jsRecordBatch = parseRecordBatch(
+     *   wasmMemory.buffer,
+     *   wasmRecordBatch.arrayAddr(),
+     *   wasmRecordBatch.schemaAddr(),
+     *   true
+     * );
+     * ```
+     * @returns {number}
+     */
+    arrayAddr() {
+        const ret = wasm.ffidata_arrayAddr(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * Access the pointer to the
+     * [`ArrowSchema`](https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions)
+     * struct. This can be viewed or copied (without serialization) to an Arrow JS `Field` by
+     * using [`arrow-js-ffi`](https://github.com/kylebarron/arrow-js-ffi). You can access the
+     * [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory)
+     * instance by using {@linkcode wasmMemory}.
+     *
+     * **Example**:
+     *
+     * ```ts
+     * import { parseRecordBatch } from "arrow-js-ffi";
+     *
+     * const wasmRecordBatch: FFIRecordBatch = ...
+     * const wasmMemory: WebAssembly.Memory = wasmMemory();
+     *
+     * // Pass `true` to copy arrays across the boundary instead of creating views.
+     * const jsRecordBatch = parseRecordBatch(
+     *   wasmMemory.buffer,
+     *   wasmRecordBatch.arrayAddr(),
+     *   wasmRecordBatch.schemaAddr(),
+     *   true
+     * );
+     * ```
+     * @returns {number}
+     */
+    schemaAddr() {
+        const ret = wasm.ffidata_schemaAddr(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+}
+if (Symbol.dispose) FFIData.prototype[Symbol.dispose] = FFIData.prototype.free;
+
+const FFISchemaFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_ffischema_free(ptr >>> 0, 1));
+
+export class FFISchema {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(FFISchema.prototype);
+        obj.__wbg_ptr = ptr;
+        FFISchemaFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        FFISchemaFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_ffischema_free(ptr, 0);
+    }
+    /**
+     * Access the pointer to the
+     * [`ArrowSchema`](https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions)
+     * struct. This can be viewed or copied (without serialization) to an Arrow JS `Field` by
+     * using [`arrow-js-ffi`](https://github.com/kylebarron/arrow-js-ffi). You can access the
+     * [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory)
+     * instance by using {@linkcode wasmMemory}.
+     *
+     * **Example**:
+     *
+     * ```ts
+     * import { parseRecordBatch } from "arrow-js-ffi";
+     *
+     * const wasmRecordBatch: FFIRecordBatch = ...
+     * const wasmMemory: WebAssembly.Memory = wasmMemory();
+     *
+     * // Pass `true` to copy arrays across the boundary instead of creating views.
+     * const jsRecordBatch = parseRecordBatch(
+     *   wasmMemory.buffer,
+     *   wasmRecordBatch.arrayAddr(),
+     *   wasmRecordBatch.schemaAddr(),
+     *   true
+     * );
+     * ```
+     * @returns {number}
+     */
+    addr() {
+        const ret = wasm.ffischema_addr(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+}
+if (Symbol.dispose) FFISchema.prototype[Symbol.dispose] = FFISchema.prototype.free;
+
+const FFIStreamFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_ffistream_free(ptr >>> 0, 1));
+/**
+ * A representation of an Arrow C Stream in WebAssembly memory exposed as FFI-compatible
+ * structs through the Arrow C Data Interface.
+ *
+ * Unlike other Arrow implementations outside of JS, this always stores the "stream" fully
+ * materialized as a sequence of Arrow chunks.
+ */
+export class FFIStream {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(FFIStream.prototype);
+        obj.__wbg_ptr = ptr;
+        FFIStreamFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        FFIStreamFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_ffistream_free(ptr, 0);
+    }
+    /**
+     * Get the total number of elements in this stream
+     * @returns {number}
+     */
+    numArrays() {
+        const ret = wasm.ffistream_numArrays(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * Get the pointer to the ArrowSchema FFI struct
+     * @returns {number}
+     */
+    schemaAddr() {
+        const ret = wasm.ffistream_schemaAddr(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * Get the pointer to one ArrowArray FFI struct for a given chunk index and column index
+     *
+     * Access the pointer to one
+     * [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions)
+     * struct representing one of the internal `RecordBatch`es. This can be viewed or copied (without serialization) to an Arrow JS `RecordBatch` by
+     * using [`arrow-js-ffi`](https://github.com/kylebarron/arrow-js-ffi). You can access the
+     * [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory)
+     * instance by using {@linkcode wasmMemory}.
+     *
+     * **Example**:
+     *
+     * ```ts
+     * import * as arrow from "apache-arrow";
+     * import { parseRecordBatch } from "arrow-js-ffi";
+     *
+     * const wasmTable: FFITable = ...
+     * const wasmMemory: WebAssembly.Memory = wasmMemory();
+     *
+     * const jsBatches: arrow.RecordBatch[] = []
+     * for (let i = 0; i < wasmTable.numBatches(); i++) {
+     *   // Pass `true` to copy arrays across the boundary instead of creating views.
+     *   const jsRecordBatch = parseRecordBatch(
+     *     wasmMemory.buffer,
+     *     wasmTable.arrayAddr(i),
+     *     wasmTable.schemaAddr(),
+     *     true
+     *   );
+     *   jsBatches.push(jsRecordBatch);
+     * }
+     * const jsTable = new arrow.Table(jsBatches);
+     * ```
+     *
+     * @param chunk number The chunk index to use
+     * @returns number pointer to an ArrowArray FFI struct in Wasm memory
+     * @param {number} chunk
+     * @returns {number}
+     */
+    arrayAddr(chunk) {
+        const ret = wasm.ffistream_arrayAddr(this.__wbg_ptr, chunk);
+        return ret >>> 0;
+    }
+    /**
+     * @returns {Uint32Array}
+     */
+    arrayAddrs() {
+        const ret = wasm.ffistream_arrayAddrs(this.__wbg_ptr);
+        var v1 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+        return v1;
+    }
+    drop() {
+        const ptr = this.__destroy_into_raw();
+        wasm.ffistream_drop(ptr);
+    }
+}
+if (Symbol.dispose) FFIStream.prototype[Symbol.dispose] = FFIStream.prototype.free;
+
+const FileMetaDataFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_filemetadata_free(ptr >>> 0, 1));
+/**
+ * Metadata for a Parquet file.
+ */
+export class FileMetaData {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(FileMetaData.prototype);
+        obj.__wbg_ptr = ptr;
+        FileMetaDataFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        FileMetaDataFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_filemetadata_free(ptr, 0);
+    }
+    /**
+     * Returns version of this file.
+     * @returns {number}
+     */
+    version() {
+        const ret = wasm.filemetadata_version(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Returns number of rows in the file.
+     * @returns {number}
+     */
+    numRows() {
+        const ret = wasm.filemetadata_numRows(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * String message for application that wrote this file.
+     *
+     * This should have the following format:
+     * `<application> version <application version> (build <application build hash>)`.
+     *
+     * ```shell
+     * parquet-mr version 1.8.0 (build 0fda28af84b9746396014ad6a415b90592a98b3b)
+     * ```
+     * @returns {string | undefined}
+     */
+    createdBy() {
+        const ret = wasm.filemetadata_createdBy(this.__wbg_ptr);
+        let v1;
+        if (ret[0] !== 0) {
+            v1 = getStringFromWasm0(ret[0], ret[1]).slice();
+            wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+        }
+        return v1;
+    }
+    /**
+     * Returns key_value_metadata of this file.
+     * @returns {Map<any, any>}
+     */
+    keyValueMetadata() {
+        const ret = wasm.filemetadata_keyValueMetadata(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return takeFromExternrefTable0(ret[0]);
+    }
+}
+if (Symbol.dispose) FileMetaData.prototype[Symbol.dispose] = FileMetaData.prototype.free;
+
+const IntoUnderlyingByteSourceFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_intounderlyingbytesource_free(ptr >>> 0, 1));
+
+export class IntoUnderlyingByteSource {
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        IntoUnderlyingByteSourceFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_intounderlyingbytesource_free(ptr, 0);
+    }
+    /**
+     * @returns {ReadableStreamType}
+     */
+    get type() {
+        const ret = wasm.intounderlyingbytesource_type(this.__wbg_ptr);
+        return __wbindgen_enum_ReadableStreamType[ret];
+    }
+    /**
+     * @returns {number}
+     */
+    get autoAllocateChunkSize() {
+        const ret = wasm.intounderlyingbytesource_autoAllocateChunkSize(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * @param {ReadableByteStreamController} controller
+     */
+    start(controller) {
+        wasm.intounderlyingbytesource_start(this.__wbg_ptr, controller);
+    }
+    /**
+     * @param {ReadableByteStreamController} controller
+     * @returns {Promise<any>}
+     */
+    pull(controller) {
+        const ret = wasm.intounderlyingbytesource_pull(this.__wbg_ptr, controller);
+        return ret;
+    }
+    cancel() {
+        const ptr = this.__destroy_into_raw();
+        wasm.intounderlyingbytesource_cancel(ptr);
+    }
+}
+if (Symbol.dispose) IntoUnderlyingByteSource.prototype[Symbol.dispose] = IntoUnderlyingByteSource.prototype.free;
+
+const IntoUnderlyingSinkFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_intounderlyingsink_free(ptr >>> 0, 1));
+
+export class IntoUnderlyingSink {
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        IntoUnderlyingSinkFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_intounderlyingsink_free(ptr, 0);
+    }
+    /**
+     * @param {any} chunk
+     * @returns {Promise<any>}
+     */
+    write(chunk) {
+        const ret = wasm.intounderlyingsink_write(this.__wbg_ptr, chunk);
+        return ret;
+    }
+    /**
+     * @returns {Promise<any>}
+     */
+    close() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.intounderlyingsink_close(ptr);
+        return ret;
+    }
+    /**
+     * @param {any} reason
+     * @returns {Promise<any>}
+     */
+    abort(reason) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.intounderlyingsink_abort(ptr, reason);
+        return ret;
+    }
+}
+if (Symbol.dispose) IntoUnderlyingSink.prototype[Symbol.dispose] = IntoUnderlyingSink.prototype.free;
+
+const IntoUnderlyingSourceFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_intounderlyingsource_free(ptr >>> 0, 1));
+
+export class IntoUnderlyingSource {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(IntoUnderlyingSource.prototype);
+        obj.__wbg_ptr = ptr;
+        IntoUnderlyingSourceFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        IntoUnderlyingSourceFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_intounderlyingsource_free(ptr, 0);
+    }
+    /**
+     * @param {ReadableStreamDefaultController} controller
+     * @returns {Promise<any>}
+     */
+    pull(controller) {
+        const ret = wasm.intounderlyingsource_pull(this.__wbg_ptr, controller);
+        return ret;
+    }
+    cancel() {
+        const ptr = this.__destroy_into_raw();
+        wasm.intounderlyingsource_cancel(ptr);
+    }
+}
+if (Symbol.dispose) IntoUnderlyingSource.prototype[Symbol.dispose] = IntoUnderlyingSource.prototype.free;
+
+const ParquetFileFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_parquetfile_free(ptr >>> 0, 1));
+
+export class ParquetFile {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(ParquetFile.prototype);
+        obj.__wbg_ptr = ptr;
+        ParquetFileFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        ParquetFileFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_parquetfile_free(ptr, 0);
+    }
+    /**
+     * Construct a ParquetFile from a new URL.
+     * @param {string} url
+     * @returns {Promise<ParquetFile>}
+     */
+    static fromUrl(url) {
+        const ptr0 = passStringToWasm0(url, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.parquetfile_fromUrl(ptr0, len0);
+        return ret;
+    }
+    /**
+     * Construct a ParquetFile from a new [Blob] or [File] handle.
+     *
+     * [Blob]: https://developer.mozilla.org/en-US/docs/Web/API/Blob
+     * [File]: https://developer.mozilla.org/en-US/docs/Web/API/File
+     *
+     * Safety: Do not use this in a multi-threaded environment,
+     * (transitively depends on `!Send` `web_sys::Blob`)
+     * @param {Blob} handle
+     * @returns {Promise<ParquetFile>}
+     */
+    static fromFile(handle) {
+        const ret = wasm.parquetfile_fromFile(handle);
+        return ret;
+    }
+    /**
+     * @returns {ParquetMetaData}
+     */
+    metadata() {
+        const ret = wasm.parquetfile_metadata(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return ParquetMetaData.__wrap(ret[0]);
+    }
+    /**
+     * @returns {Schema}
+     */
+    schema() {
+        const ret = wasm.parquetfile_schema(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return Schema.__wrap(ret[0]);
+    }
+    /**
+     * Read from the Parquet file in an async fashion.
+     *
+     * @param options
+     *
+     *    Options for reading Parquet data. Optional keys include:
+     *
+     *    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
+     *           default is 1024.
+     *    - `rowGroups`: Only read data from the provided row group indexes.
+     *    - `limit`: Provide a limit to the number of rows to be read.
+     *    - `offset`: Provide an offset to skip over the given number of rows.
+     *    - `columns`: The column names from the file to read.
+     * @param {ReaderOptions | null} [options]
+     * @returns {Promise<Table>}
+     */
+    read(options) {
+        const ret = wasm.parquetfile_read(this.__wbg_ptr, isLikeNone(options) ? 0 : addToExternrefTable0(options));
+        return ret;
+    }
+    /**
+     * Create a readable stream of record batches.
+     *
+     * Each item in the stream will be a {@linkcode RecordBatch}.
+     *
+     * @param options
+     *
+     *    Options for reading Parquet data. Optional keys include:
+     *
+     *    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
+     *           default is 1024.
+     *    - `rowGroups`: Only read data from the provided row group indexes.
+     *    - `limit`: Provide a limit to the number of rows to be read.
+     *    - `offset`: Provide an offset to skip over the given number of rows.
+     *    - `columns`: The column names from the file to read.
+     *    - `concurrency`: The number of concurrent requests to make
+     * @param {ReaderOptions | null} [options]
+     * @returns {Promise<ReadableStream>}
+     */
+    stream(options) {
+        const ret = wasm.parquetfile_stream(this.__wbg_ptr, isLikeNone(options) ? 0 : addToExternrefTable0(options));
+        return ret;
+    }
+}
+if (Symbol.dispose) ParquetFile.prototype[Symbol.dispose] = ParquetFile.prototype.free;
+
+const ParquetMetaDataFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_parquetmetadata_free(ptr >>> 0, 1));
+/**
+ * Global Parquet metadata.
+ */
+export class ParquetMetaData {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(ParquetMetaData.prototype);
+        obj.__wbg_ptr = ptr;
+        ParquetMetaDataFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        ParquetMetaDataFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_parquetmetadata_free(ptr, 0);
+    }
+    /**
+     * Returns file metadata as reference.
+     * @returns {FileMetaData}
+     */
+    fileMetadata() {
+        const ret = wasm.parquetmetadata_fileMetadata(this.__wbg_ptr);
+        return FileMetaData.__wrap(ret);
+    }
+    /**
+     * Returns number of row groups in this file.
+     * @returns {number}
+     */
+    numRowGroups() {
+        const ret = wasm.parquetmetadata_numRowGroups(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * Returns row group metadata for `i`th position.
+     * Position should be less than number of row groups `num_row_groups`.
+     * @param {number} i
+     * @returns {RowGroupMetaData}
+     */
+    rowGroup(i) {
+        const ret = wasm.parquetmetadata_rowGroup(this.__wbg_ptr, i);
+        return RowGroupMetaData.__wrap(ret);
+    }
+    /**
+     * Returns row group metadata for all row groups
+     * @returns {RowGroupMetaData[]}
+     */
+    rowGroups() {
+        const ret = wasm.parquetmetadata_rowGroups(this.__wbg_ptr);
+        var v1 = getArrayJsValueFromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+        return v1;
+    }
+}
+if (Symbol.dispose) ParquetMetaData.prototype[Symbol.dispose] = ParquetMetaData.prototype.free;
+
+const RecordBatchFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_recordbatch_free(ptr >>> 0, 1));
+/**
+ * A group of columns of equal length in WebAssembly memory with an associated {@linkcode Schema}.
+ */
+export class RecordBatch {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(RecordBatch.prototype);
+        obj.__wbg_ptr = ptr;
+        RecordBatchFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    static __unwrap(jsValue) {
+        if (!(jsValue instanceof RecordBatch)) {
+            return 0;
+        }
+        return jsValue.__destroy_into_raw();
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        RecordBatchFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_recordbatch_free(ptr, 0);
+    }
+    /**
+     * The number of rows in this RecordBatch.
+     * @returns {number}
+     */
+    get numRows() {
+        const ret = wasm.recordbatch_numRows(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * The number of columns in this RecordBatch.
+     * @returns {number}
+     */
+    get numColumns() {
+        const ret = wasm.recordbatch_numColumns(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * The {@linkcode Schema} of this RecordBatch.
+     * @returns {Schema}
+     */
+    get schema() {
+        const ret = wasm.recordbatch_schema(this.__wbg_ptr);
+        return Schema.__wrap(ret);
+    }
+    /**
+     * Export this RecordBatch to FFI structs according to the Arrow C Data Interface.
+     *
+     * This method **does not consume** the RecordBatch, so you must remember to call {@linkcode
+     * RecordBatch.free} to release the resources. The underlying arrays are reference counted, so
+     * this method does not copy data, it only prevents the data from being released.
+     * @returns {FFIData}
+     */
+    toFFI() {
+        const ret = wasm.recordbatch_toFFI(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return FFIData.__wrap(ret[0]);
+    }
+    /**
+     * Export this RecordBatch to FFI structs according to the Arrow C Data Interface.
+     *
+     * This method **does consume** the RecordBatch, so the original RecordBatch will be
+     * inaccessible after this call. You must still call {@linkcode FFIRecordBatch.free} after
+     * you've finished using the FFIRecordBatch.
+     * @returns {FFIData}
+     */
+    intoFFI() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.recordbatch_intoFFI(ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return FFIData.__wrap(ret[0]);
+    }
+    /**
+     * Consume this RecordBatch and convert to an Arrow IPC Stream buffer
+     * @returns {Uint8Array}
+     */
+    intoIPCStream() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.recordbatch_intoIPCStream(ptr);
+        if (ret[3]) {
+            throw takeFromExternrefTable0(ret[2]);
+        }
+        var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+        return v1;
+    }
+    /**
+     * Override the schema of this [`RecordBatch`]
+     *
+     * Returns an error if `schema` is not a superset of the current schema
+     * as determined by [`Schema::contains`]
+     * @param {Schema} schema
+     * @returns {RecordBatch}
+     */
+    withSchema(schema) {
+        _assertClass(schema, Schema);
+        var ptr0 = schema.__destroy_into_raw();
+        const ret = wasm.recordbatch_withSchema(this.__wbg_ptr, ptr0);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return RecordBatch.__wrap(ret[0]);
+    }
+    /**
+     * Return a new RecordBatch where each column is sliced
+     * according to `offset` and `length`
+     * @param {number} offset
+     * @param {number} length
+     * @returns {RecordBatch}
+     */
+    slice(offset, length) {
+        const ret = wasm.recordbatch_slice(this.__wbg_ptr, offset, length);
+        return RecordBatch.__wrap(ret);
+    }
+    /**
+     * Returns the total number of bytes of memory occupied physically by this batch.
+     * @returns {number}
+     */
+    getArrayMemorySize() {
+        const ret = wasm.recordbatch_getArrayMemorySize(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+}
+if (Symbol.dispose) RecordBatch.prototype[Symbol.dispose] = RecordBatch.prototype.free;
+
+const RowGroupMetaDataFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_rowgroupmetadata_free(ptr >>> 0, 1));
+/**
+ * Metadata for a Parquet row group.
+ */
+export class RowGroupMetaData {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(RowGroupMetaData.prototype);
+        obj.__wbg_ptr = ptr;
+        RowGroupMetaDataFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        RowGroupMetaDataFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_rowgroupmetadata_free(ptr, 0);
+    }
+    /**
+     * Number of columns in this row group.
+     * @returns {number}
+     */
+    numColumns() {
+        const ret = wasm.rowgroupmetadata_numColumns(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * Returns column chunk metadata for `i`th column.
+     * @param {number} i
+     * @returns {ColumnChunkMetaData}
+     */
+    column(i) {
+        const ret = wasm.rowgroupmetadata_column(this.__wbg_ptr, i);
+        return ColumnChunkMetaData.__wrap(ret);
+    }
+    /**
+     * Returns column chunk metadata for all columns
+     * @returns {ColumnChunkMetaData[]}
+     */
+    columns() {
+        const ret = wasm.rowgroupmetadata_columns(this.__wbg_ptr);
+        var v1 = getArrayJsValueFromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+        return v1;
+    }
+    /**
+     * Number of rows in this row group.
+     * @returns {number}
+     */
+    numRows() {
+        const ret = wasm.rowgroupmetadata_numRows(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Total byte size of all uncompressed column data in this row group.
+     * @returns {number}
+     */
+    totalByteSize() {
+        const ret = wasm.rowgroupmetadata_totalByteSize(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * Total size of all compressed column data in this row group.
+     * @returns {number}
+     */
+    compressedSize() {
+        const ret = wasm.rowgroupmetadata_compressedSize(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * File offset of this row group in file.
+     * @returns {number | undefined}
+     */
+    fileOffset() {
+        const ret = wasm.rowgroupmetadata_fileOffset(this.__wbg_ptr);
+        return ret[0] === 0 ? undefined : ret[1];
+    }
+}
+if (Symbol.dispose) RowGroupMetaData.prototype[Symbol.dispose] = RowGroupMetaData.prototype.free;
+
+const SchemaFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_schema_free(ptr >>> 0, 1));
+/**
+ * A named collection of types that defines the column names and types in a RecordBatch or Table
+ * data structure.
+ *
+ * A Schema can also contain extra user-defined metadata either at the Table or Column level.
+ * Column-level metadata is often used to define [extension
+ * types](https://arrow.apache.org/docs/format/Columnar.html#extension-types).
+ */
+export class Schema {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(Schema.prototype);
+        obj.__wbg_ptr = ptr;
+        SchemaFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        SchemaFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_schema_free(ptr, 0);
+    }
+    /**
+     * Export this schema to an FFISchema object, which can be read with arrow-js-ffi.
+     *
+     * This method **does not consume** the Schema, so you must remember to call {@linkcode
+     * Schema.free} to release the resources. The underlying arrays are reference counted, so
+     * this method does not copy data, it only prevents the data from being released.
+     * @returns {FFISchema}
+     */
+    toFFI() {
+        const ret = wasm.schema_toFFI(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return FFISchema.__wrap(ret[0]);
+    }
+    /**
+     * Export this Table to FFI structs according to the Arrow C Data Interface.
+     *
+     * This method **does consume** the Table, so the original Table will be
+     * inaccessible after this call. You must still call {@linkcode FFITable.free} after
+     * you've finished using the FFITable.
+     * @returns {FFISchema}
+     */
+    intoFFI() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.schema_intoFFI(ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return FFISchema.__wrap(ret[0]);
+    }
+    /**
+     * Consume this schema and convert to an Arrow IPC Stream buffer
+     * @returns {Uint8Array}
+     */
+    intoIPCStream() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.schema_intoIPCStream(ptr);
+        if (ret[3]) {
+            throw takeFromExternrefTable0(ret[2]);
+        }
+        var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+        return v1;
+    }
+    /**
+     * Sets the metadata of this `Schema` to be `metadata` and returns a new object
+     * @param {SchemaMetadata} metadata
+     * @returns {Schema}
+     */
+    withMetadata(metadata) {
+        const ret = wasm.schema_withMetadata(this.__wbg_ptr, metadata);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return Schema.__wrap(ret[0]);
+    }
+    /**
+     * Find the index of the column with the given name.
+     * @param {string} name
+     * @returns {number}
+     */
+    indexOf(name) {
+        const ptr0 = passStringToWasm0(name, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.schema_indexOf(this.__wbg_ptr, ptr0, len0);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return ret[0] >>> 0;
+    }
+    /**
+     * Returns an immutable reference to the Map of custom metadata key-value pairs.
+     * @returns {SchemaMetadata}
+     */
+    metadata() {
+        const ret = wasm.schema_metadata(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return takeFromExternrefTable0(ret[0]);
+    }
+}
+if (Symbol.dispose) Schema.prototype[Symbol.dispose] = Schema.prototype.free;
+
+const TableFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_table_free(ptr >>> 0, 1));
+/**
+ * A Table in WebAssembly memory conforming to the Apache Arrow spec.
+ *
+ * A Table consists of one or more {@linkcode RecordBatch} objects plus a {@linkcode Schema} that
+ * each RecordBatch conforms to.
+ */
+export class Table {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(Table.prototype);
+        obj.__wbg_ptr = ptr;
+        TableFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        TableFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_table_free(ptr, 0);
+    }
+    /**
+     * Access the Table's {@linkcode Schema}.
+     * @returns {Schema}
+     */
+    get schema() {
+        const ret = wasm.table_schema(this.__wbg_ptr);
+        return Schema.__wrap(ret);
+    }
+    /**
+     * Access a RecordBatch from the Table by index.
+     *
+     * @param index The positional index of the RecordBatch to retrieve.
+     * @returns a RecordBatch or `null` if out of range.
+     * @param {number} index
+     * @returns {RecordBatch | undefined}
+     */
+    recordBatch(index) {
+        const ret = wasm.table_recordBatch(this.__wbg_ptr, index);
+        return ret === 0 ? undefined : RecordBatch.__wrap(ret);
+    }
+    /**
+     * @returns {RecordBatch[]}
+     */
+    recordBatches() {
+        const ret = wasm.table_recordBatches(this.__wbg_ptr);
+        var v1 = getArrayJsValueFromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+        return v1;
+    }
+    /**
+     * The number of batches in the Table
+     * @returns {number}
+     */
+    get numBatches() {
+        const ret = wasm.table_numBatches(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+    /**
+     * Export this Table to FFI structs according to the Arrow C Data Interface.
+     *
+     * This method **does not consume** the Table, so you must remember to call {@linkcode
+     * Table.free} to release the resources. The underlying arrays are reference counted, so
+     * this method does not copy data, it only prevents the data from being released.
+     * @returns {FFIStream}
+     */
+    toFFI() {
+        const ret = wasm.table_toFFI(this.__wbg_ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return FFIStream.__wrap(ret[0]);
+    }
+    /**
+     * Export this Table to FFI structs according to the Arrow C Data Interface.
+     *
+     * This method **does consume** the Table, so the original Table will be
+     * inaccessible after this call. You must still call {@linkcode FFITable.free} after
+     * you've finished using the FFITable.
+     * @returns {FFIStream}
+     */
+    intoFFI() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.table_intoFFI(ptr);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return FFIStream.__wrap(ret[0]);
+    }
+    /**
+     * Consume this table and convert to an Arrow IPC Stream buffer
+     * @returns {Uint8Array}
+     */
+    intoIPCStream() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.table_intoIPCStream(ptr);
+        if (ret[3]) {
+            throw takeFromExternrefTable0(ret[2]);
+        }
+        var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+        return v1;
+    }
+    /**
+     * Create a table from an Arrow IPC Stream buffer
+     * @param {Uint8Array} buf
+     * @returns {Table}
+     */
+    static fromIPCStream(buf) {
+        const ptr0 = passArray8ToWasm0(buf, wasm.__wbindgen_malloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.table_fromIPCStream(ptr0, len0);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return Table.__wrap(ret[0]);
+    }
+    /**
+     * Returns the total number of bytes of memory occupied physically by all batches in this
+     * table.
+     * @returns {number}
+     */
+    getArrayMemorySize() {
+        const ret = wasm.table_getArrayMemorySize(this.__wbg_ptr);
+        return ret >>> 0;
+    }
+}
+if (Symbol.dispose) Table.prototype[Symbol.dispose] = Table.prototype.free;
+
+const WriterPropertiesFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_writerproperties_free(ptr >>> 0, 1));
+/**
+ * Immutable struct to hold writing configuration for `writeParquet`.
+ *
+ * Use {@linkcode WriterPropertiesBuilder} to create a configuration, then call {@linkcode
+ * WriterPropertiesBuilder.build} to create an instance of `WriterProperties`.
+ */
+export class WriterProperties {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(WriterProperties.prototype);
+        obj.__wbg_ptr = ptr;
+        WriterPropertiesFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        WriterPropertiesFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_writerproperties_free(ptr, 0);
+    }
+}
+if (Symbol.dispose) WriterProperties.prototype[Symbol.dispose] = WriterProperties.prototype.free;
+
+const WriterPropertiesBuilderFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_writerpropertiesbuilder_free(ptr >>> 0, 1));
+/**
+ * Builder to create a writing configuration for `writeParquet`
+ *
+ * Call {@linkcode build} on the finished builder to create an immputable {@linkcode WriterProperties} to pass to `writeParquet`
+ */
+export class WriterPropertiesBuilder {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(WriterPropertiesBuilder.prototype);
+        obj.__wbg_ptr = ptr;
+        WriterPropertiesBuilderFinalization.register(obj, obj.__wbg_ptr, obj);
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        WriterPropertiesBuilderFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_writerpropertiesbuilder_free(ptr, 0);
+    }
+    /**
+     * Returns default state of the builder.
+     */
+    constructor() {
+        const ret = wasm.writerpropertiesbuilder_new();
+        this.__wbg_ptr = ret >>> 0;
+        WriterPropertiesBuilderFinalization.register(this, this.__wbg_ptr, this);
+        return this;
+    }
+    /**
+     * Finalizes the configuration and returns immutable writer properties struct.
+     * @returns {WriterProperties}
+     */
+    build() {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_build(ptr);
+        return WriterProperties.__wrap(ret);
+    }
+    /**
+     * Sets writer version.
+     * @param {WriterVersion} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setWriterVersion(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setWriterVersion(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets data page size limit.
+     * @param {number} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setDataPageSizeLimit(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setDataPageSizeLimit(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets dictionary page size limit.
+     * @param {number} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setDictionaryPageSizeLimit(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setDictionaryPageSizeLimit(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets write batch size.
+     * @param {number} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setWriteBatchSize(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setWriteBatchSize(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets maximum number of rows in a row group.
+     * @param {number} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setMaxRowGroupSize(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setMaxRowGroupSize(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets "created by" property.
+     * @param {string} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setCreatedBy(value) {
+        const ptr = this.__destroy_into_raw();
+        const ptr0 = passStringToWasm0(value, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.writerpropertiesbuilder_setCreatedBy(ptr, ptr0, len0);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets "key_value_metadata" property.
+     * @param {KeyValueMetadata} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setKeyValueMetadata(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setKeyValueMetadata(ptr, value);
+        if (ret[2]) {
+            throw takeFromExternrefTable0(ret[1]);
+        }
+        return WriterPropertiesBuilder.__wrap(ret[0]);
+    }
+    /**
+     * Sets encoding for any column.
+     *
+     * If dictionary is not enabled, this is treated as a primary encoding for all
+     * columns. In case when dictionary is enabled for any column, this value is
+     * considered to be a fallback encoding for that column.
+     *
+     * Panics if user tries to set dictionary encoding here, regardless of dictionary
+     * encoding flag being set.
+     * @param {Encoding} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setEncoding(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setEncoding(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets compression codec for any column.
+     * @param {Compression} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setCompression(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setCompression(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets flag to enable/disable dictionary encoding for any column.
+     *
+     * Use this method to set dictionary encoding, instead of explicitly specifying
+     * encoding in `set_encoding` method.
+     * @param {boolean} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setDictionaryEnabled(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setDictionaryEnabled(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets flag to enable/disable statistics for any column.
+     * @param {EnabledStatistics} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setStatisticsEnabled(value) {
+        const ptr = this.__destroy_into_raw();
+        const ret = wasm.writerpropertiesbuilder_setStatisticsEnabled(ptr, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets encoding for a column.
+     * Takes precedence over globally defined settings.
+     *
+     * If dictionary is not enabled, this is treated as a primary encoding for this
+     * column. In case when dictionary is enabled for this column, either through
+     * global defaults or explicitly, this value is considered to be a fallback
+     * encoding for this column.
+     *
+     * Panics if user tries to set dictionary encoding here, regardless of dictionary
+     * encoding flag being set.
+     * @param {string} col
+     * @param {Encoding} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setColumnEncoding(col, value) {
+        const ptr = this.__destroy_into_raw();
+        const ptr0 = passStringToWasm0(col, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.writerpropertiesbuilder_setColumnEncoding(ptr, ptr0, len0, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets compression codec for a column.
+     * Takes precedence over globally defined settings.
+     * @param {string} col
+     * @param {Compression} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setColumnCompression(col, value) {
+        const ptr = this.__destroy_into_raw();
+        const ptr0 = passStringToWasm0(col, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.writerpropertiesbuilder_setColumnCompression(ptr, ptr0, len0, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets flag to enable/disable dictionary encoding for a column.
+     * Takes precedence over globally defined settings.
+     * @param {string} col
+     * @param {boolean} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setColumnDictionaryEnabled(col, value) {
+        const ptr = this.__destroy_into_raw();
+        const ptr0 = passStringToWasm0(col, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.writerpropertiesbuilder_setColumnDictionaryEnabled(ptr, ptr0, len0, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+    /**
+     * Sets flag to enable/disable statistics for a column.
+     * Takes precedence over globally defined settings.
+     * @param {string} col
+     * @param {EnabledStatistics} value
+     * @returns {WriterPropertiesBuilder}
+     */
+    setColumnStatisticsEnabled(col, value) {
+        const ptr = this.__destroy_into_raw();
+        const ptr0 = passStringToWasm0(col, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.writerpropertiesbuilder_setColumnStatisticsEnabled(ptr, ptr0, len0, value);
+        return WriterPropertiesBuilder.__wrap(ret);
+    }
+}
+if (Symbol.dispose) WriterPropertiesBuilder.prototype[Symbol.dispose] = WriterPropertiesBuilder.prototype.free;
+
+const EXPECTED_RESPONSE_TYPES = new Set(['basic', 'cors', 'default']);
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+
+            } catch (e) {
+                const validResponse = module.ok && EXPECTED_RESPONSE_TYPES.has(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+
+        } else {
+            return instance;
+        }
+    }
+}
+
+function __wbg_get_imports() {
+    const imports = {};
+    imports.wbg = {};
+    imports.wbg.__wbg_Error_e17e777aac105295 = function(arg0, arg1) {
+        const ret = Error(getStringFromWasm0(arg0, arg1));
+        return ret;
+    };
+    imports.wbg.__wbg_Number_998bea33bd87c3e0 = function(arg0) {
+        const ret = Number(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_String_8f0eb39a4a4c2f66 = function(arg0, arg1) {
+        const ret = String(arg1);
+        const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len1 = WASM_VECTOR_LEN;
+        getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    imports.wbg.__wbg_abort_67e1b49bf6614565 = function(arg0) {
+        arg0.abort();
+    };
+    imports.wbg.__wbg_abort_d830bf2e9aa6ec5b = function(arg0, arg1) {
+        arg0.abort(arg1);
+    };
+    imports.wbg.__wbg_append_72a3c0addd2bce38 = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4) {
+        arg0.append(getStringFromWasm0(arg1, arg2), getStringFromWasm0(arg3, arg4));
+    }, arguments) };
+    imports.wbg.__wbg_arrayBuffer_2c907ed8e8ef4e35 = function(arg0) {
+        const ret = arg0.arrayBuffer();
+        return ret;
+    };
+    imports.wbg.__wbg_arrayBuffer_9c99b8e2809e8cbb = function() { return handleError(function (arg0) {
+        const ret = arg0.arrayBuffer();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_buffer_8d40b1d762fb3c66 = function(arg0) {
+        const ret = arg0.buffer;
+        return ret;
+    };
+    imports.wbg.__wbg_byobRequest_2c036bceca1e6037 = function(arg0) {
+        const ret = arg0.byobRequest;
+        return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    imports.wbg.__wbg_byteLength_331a6b5545834024 = function(arg0) {
+        const ret = arg0.byteLength;
+        return ret;
+    };
+    imports.wbg.__wbg_byteOffset_49a5b5608000358b = function(arg0) {
+        const ret = arg0.byteOffset;
+        return ret;
+    };
+    imports.wbg.__wbg_call_13410aac570ffff7 = function() { return handleError(function (arg0, arg1) {
+        const ret = arg0.call(arg1);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_call_a5400b25a865cfd8 = function() { return handleError(function (arg0, arg1, arg2) {
+        const ret = arg0.call(arg1, arg2);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_cancel_8bb5b8f4906b658a = function(arg0) {
+        const ret = arg0.cancel();
+        return ret;
+    };
+    imports.wbg.__wbg_catch_c80ecae90cb8ed4e = function(arg0, arg1) {
+        const ret = arg0.catch(arg1);
+        return ret;
+    };
+    imports.wbg.__wbg_clearTimeout_6222fede17abcb1a = function(arg0) {
+        const ret = clearTimeout(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_close_a1918cff3cac355b = function(arg0) {
+        const ret = arg0.close();
+        return ret;
+    };
+    imports.wbg.__wbg_close_cccada6053ee3a65 = function() { return handleError(function (arg0) {
+        arg0.close();
+    }, arguments) };
+    imports.wbg.__wbg_close_d71a78219dc23e91 = function() { return handleError(function (arg0) {
+        arg0.close();
+    }, arguments) };
+    imports.wbg.__wbg_columnchunkmetadata_new = function(arg0) {
+        const ret = ColumnChunkMetaData.__wrap(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_done_75ed0ee6dd243d9d = function(arg0) {
+        const ret = arg0.done;
+        return ret;
+    };
+    imports.wbg.__wbg_enqueue_452bc2343d1c2ff9 = function() { return handleError(function (arg0, arg1) {
+        arg0.enqueue(arg1);
+    }, arguments) };
+    imports.wbg.__wbg_entries_2be2f15bd5554996 = function(arg0) {
+        const ret = Object.entries(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_fetch_87aed7f306ec6d63 = function(arg0, arg1) {
+        const ret = arg0.fetch(arg1);
+        return ret;
+    };
+    imports.wbg.__wbg_fetch_f156d10be9a5c88a = function(arg0) {
+        const ret = fetch(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_getReader_48e00749fe3f6089 = function() { return handleError(function (arg0) {
+        const ret = arg0.getReader();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_getWriter_03d7689e275ac6a4 = function() { return handleError(function (arg0) {
+        const ret = arg0.getWriter();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_get_0da715ceaecea5c8 = function(arg0, arg1) {
+        const ret = arg0[arg1 >>> 0];
+        return ret;
+    };
+    imports.wbg.__wbg_get_458e874b43b18b25 = function() { return handleError(function (arg0, arg1) {
+        const ret = Reflect.get(arg0, arg1);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_getdone_f026246f6bbe58d3 = function(arg0) {
+        const ret = arg0.done;
+        return isLikeNone(ret) ? 0xFFFFFF : ret ? 1 : 0;
+    };
+    imports.wbg.__wbg_getvalue_31e5a08f61e5aa42 = function(arg0) {
+        const ret = arg0.value;
+        return ret;
+    };
+    imports.wbg.__wbg_getwithrefkey_1dc361bd10053bfe = function(arg0, arg1) {
+        const ret = arg0[arg1];
+        return ret;
+    };
+    imports.wbg.__wbg_has_b89e451f638123e3 = function() { return handleError(function (arg0, arg1) {
+        const ret = Reflect.has(arg0, arg1);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_headers_29fec3c72865cd75 = function(arg0) {
+        const ret = arg0.headers;
+        return ret;
+    };
+    imports.wbg.__wbg_instanceof_ArrayBuffer_67f3012529f6a2dd = function(arg0) {
+        let result;
+        try {
+            result = arg0 instanceof ArrayBuffer;
+        } catch (_) {
+            result = false;
+        }
+        const ret = result;
+        return ret;
+    };
+    imports.wbg.__wbg_instanceof_Response_50fde2cd696850bf = function(arg0) {
+        let result;
+        try {
+            result = arg0 instanceof Response;
+        } catch (_) {
+            result = false;
+        }
+        const ret = result;
+        return ret;
+    };
+    imports.wbg.__wbg_instanceof_Uint8Array_9a8378d955933db7 = function(arg0) {
+        let result;
+        try {
+            result = arg0 instanceof Uint8Array;
+        } catch (_) {
+            result = false;
+        }
+        const ret = result;
+        return ret;
+    };
+    imports.wbg.__wbg_isArray_030cce220591fb41 = function(arg0) {
+        const ret = Array.isArray(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_isSafeInteger_1c0d1af5542e102a = function(arg0) {
+        const ret = Number.isSafeInteger(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_iterator_f370b34483c71a1c = function() {
+        const ret = Symbol.iterator;
+        return ret;
+    };
+    imports.wbg.__wbg_length_186546c51cd61acd = function(arg0) {
+        const ret = arg0.length;
+        return ret;
+    };
+    imports.wbg.__wbg_length_6bb7e81f9d7713e4 = function(arg0) {
+        const ret = arg0.length;
+        return ret;
+    };
+    imports.wbg.__wbg_new_19c25a3f2fa63a02 = function() {
+        const ret = new Object();
+        return ret;
+    };
+    imports.wbg.__wbg_new_2e3c58a15f39f5f9 = function(arg0, arg1) {
+        try {
+            var state0 = {a: arg0, b: arg1};
+            var cb0 = (arg0, arg1) => {
+                const a = state0.a;
+                state0.a = 0;
+                try {
+                    return __wbg_adapter_271(a, state0.b, arg0, arg1);
+                } finally {
+                    state0.a = a;
+                }
+            };
+            const ret = new Promise(cb0);
+            return ret;
+        } finally {
+            state0.a = state0.b = 0;
+        }
+    };
+    imports.wbg.__wbg_new_2ff1f68f3676ea53 = function() {
+        const ret = new Map();
+        return ret;
+    };
+    imports.wbg.__wbg_new_638ebfaedbf32a5e = function(arg0) {
+        const ret = new Uint8Array(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_new_66b9434b4e59b63e = function() { return handleError(function () {
+        const ret = new AbortController();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_new_99a6a948d5b3f607 = function() { return handleError(function () {
+        const ret = new TransformStream();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_new_da9dc54c5db29dfa = function(arg0, arg1) {
+        const ret = new Error(getStringFromWasm0(arg0, arg1));
+        return ret;
+    };
+    imports.wbg.__wbg_new_f6e53210afea8e45 = function() { return handleError(function () {
+        const ret = new Headers();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_newfromslice_074c56947bd43469 = function(arg0, arg1) {
+        const ret = new Uint8Array(getArrayU8FromWasm0(arg0, arg1));
+        return ret;
+    };
+    imports.wbg.__wbg_newnoargs_254190557c45b4ec = function(arg0, arg1) {
+        const ret = new Function(getStringFromWasm0(arg0, arg1));
+        return ret;
+    };
+    imports.wbg.__wbg_newwithbyteoffset_6bd4b2a4ca518883 = function(arg0, arg1) {
+        const ret = new Uint8Array(arg0, arg1 >>> 0);
+        return ret;
+    };
+    imports.wbg.__wbg_newwithbyteoffsetandlength_e8f53910b4d42b45 = function(arg0, arg1, arg2) {
+        const ret = new Uint8Array(arg0, arg1 >>> 0, arg2 >>> 0);
+        return ret;
+    };
+    imports.wbg.__wbg_newwithintounderlyingsource_b47f6a6a596a7f24 = function(arg0, arg1) {
+        const ret = new ReadableStream(IntoUnderlyingSource.__wrap(arg0), arg1);
+        return ret;
+    };
+    imports.wbg.__wbg_newwithstrandinit_b5d168a29a3fd85f = function() { return handleError(function (arg0, arg1, arg2) {
+        const ret = new Request(getStringFromWasm0(arg0, arg1), arg2);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_next_5b3530e612fde77d = function(arg0) {
+        const ret = arg0.next;
+        return ret;
+    };
+    imports.wbg.__wbg_next_692e82279131b03c = function() { return handleError(function (arg0) {
+        const ret = arg0.next();
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_parquetfile_new = function(arg0) {
+        const ret = ParquetFile.__wrap(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_prototypesetcall_3d4a26c1ed734349 = function(arg0, arg1, arg2) {
+        Uint8Array.prototype.set.call(getArrayU8FromWasm0(arg0, arg1), arg2);
+    };
+    imports.wbg.__wbg_queueMicrotask_25d0739ac89e8c88 = function(arg0) {
+        queueMicrotask(arg0);
+    };
+    imports.wbg.__wbg_queueMicrotask_4488407636f5bf24 = function(arg0) {
+        const ret = arg0.queueMicrotask;
+        return ret;
+    };
+    imports.wbg.__wbg_read_bc925c758aa4d897 = function(arg0) {
+        const ret = arg0.read();
+        return ret;
+    };
+    imports.wbg.__wbg_readable_e82cff27b968ed1c = function(arg0) {
+        const ret = arg0.readable;
+        return ret;
+    };
+    imports.wbg.__wbg_ready_4186da3cb500ae7d = function(arg0) {
+        const ret = arg0.ready;
+        return ret;
+    };
+    imports.wbg.__wbg_recordbatch_new = function(arg0) {
+        const ret = RecordBatch.__wrap(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_recordbatch_unwrap = function(arg0) {
+        const ret = RecordBatch.__unwrap(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_releaseLock_62151472ae632176 = function(arg0) {
+        arg0.releaseLock();
+    };
+    imports.wbg.__wbg_releaseLock_ff29b586502a8221 = function(arg0) {
+        arg0.releaseLock();
+    };
+    imports.wbg.__wbg_resolve_4055c623acdd6a1b = function(arg0) {
+        const ret = Promise.resolve(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_respond_6c2c4e20ef85138e = function() { return handleError(function (arg0, arg1) {
+        arg0.respond(arg1 >>> 0);
+    }, arguments) };
+    imports.wbg.__wbg_rowgroupmetadata_new = function(arg0) {
+        const ret = RowGroupMetaData.__wrap(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_setTimeout_2b339866a2aa3789 = function(arg0, arg1) {
+        const ret = setTimeout(arg0, arg1);
+        return ret;
+    };
+    imports.wbg.__wbg_set_1353b2a5e96bc48c = function(arg0, arg1, arg2) {
+        arg0.set(getArrayU8FromWasm0(arg1, arg2));
+    };
+    imports.wbg.__wbg_set_3f1d0b984ed272ed = function(arg0, arg1, arg2) {
+        arg0[arg1] = arg2;
+    };
+    imports.wbg.__wbg_set_b7f1cf4fae26fe2a = function(arg0, arg1, arg2) {
+        const ret = arg0.set(arg1, arg2);
+        return ret;
+    };
+    imports.wbg.__wbg_setbody_c8460bdf44147df8 = function(arg0, arg1) {
+        arg0.body = arg1;
+    };
+    imports.wbg.__wbg_setcache_90ca4ad8a8ad40d3 = function(arg0, arg1) {
+        arg0.cache = __wbindgen_enum_RequestCache[arg1];
+    };
+    imports.wbg.__wbg_setcredentials_9cd60d632c9d5dfc = function(arg0, arg1) {
+        arg0.credentials = __wbindgen_enum_RequestCredentials[arg1];
+    };
+    imports.wbg.__wbg_setheaders_0052283e2f3503d1 = function(arg0, arg1) {
+        arg0.headers = arg1;
+    };
+    imports.wbg.__wbg_sethighwatermark_3d5961f834647d41 = function(arg0, arg1) {
+        arg0.highWaterMark = arg1;
+    };
+    imports.wbg.__wbg_setmethod_9b504d5b855b329c = function(arg0, arg1, arg2) {
+        arg0.method = getStringFromWasm0(arg1, arg2);
+    };
+    imports.wbg.__wbg_setmode_a23e1a2ad8b512f8 = function(arg0, arg1) {
+        arg0.mode = __wbindgen_enum_RequestMode[arg1];
+    };
+    imports.wbg.__wbg_setsignal_8c45ad1247a74809 = function(arg0, arg1) {
+        arg0.signal = arg1;
+    };
+    imports.wbg.__wbg_signal_da4d466ce86118b5 = function(arg0) {
+        const ret = arg0.signal;
+        return ret;
+    };
+    imports.wbg.__wbg_size_8f84e7768fba0589 = function(arg0) {
+        const ret = arg0.size;
+        return ret;
+    };
+    imports.wbg.__wbg_slice_224856d46230c13c = function() { return handleError(function (arg0, arg1, arg2) {
+        const ret = arg0.slice(arg1, arg2);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_static_accessor_GLOBAL_8921f820c2ce3f12 = function() {
+        const ret = typeof global === 'undefined' ? null : global;
+        return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    imports.wbg.__wbg_static_accessor_GLOBAL_THIS_f0a4409105898184 = function() {
+        const ret = typeof globalThis === 'undefined' ? null : globalThis;
+        return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    imports.wbg.__wbg_static_accessor_SELF_995b214ae681ff99 = function() {
+        const ret = typeof self === 'undefined' ? null : self;
+        return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    imports.wbg.__wbg_static_accessor_WINDOW_cde3890479c675ea = function() {
+        const ret = typeof window === 'undefined' ? null : window;
+        return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    imports.wbg.__wbg_status_3fea3036088621d6 = function(arg0) {
+        const ret = arg0.status;
+        return ret;
+    };
+    imports.wbg.__wbg_stringify_b98c93d0a190446a = function() { return handleError(function (arg0) {
+        const ret = JSON.stringify(arg0);
+        return ret;
+    }, arguments) };
+    imports.wbg.__wbg_table_new = function(arg0) {
+        const ret = Table.__wrap(arg0);
+        return ret;
+    };
+    imports.wbg.__wbg_then_b33a773d723afa3e = function(arg0, arg1, arg2) {
+        const ret = arg0.then(arg1, arg2);
+        return ret;
+    };
+    imports.wbg.__wbg_then_e22500defe16819f = function(arg0, arg1) {
+        const ret = arg0.then(arg1);
+        return ret;
+    };
+    imports.wbg.__wbg_toString_78df35411a4fd40c = function(arg0) {
+        const ret = arg0.toString();
+        return ret;
+    };
+    imports.wbg.__wbg_url_e5720dfacf77b05e = function(arg0, arg1) {
+        const ret = arg1.url;
+        const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len1 = WASM_VECTOR_LEN;
+        getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    imports.wbg.__wbg_value_dd9372230531eade = function(arg0) {
+        const ret = arg0.value;
+        return ret;
+    };
+    imports.wbg.__wbg_view_91cc97d57ab30530 = function(arg0) {
+        const ret = arg0.view;
+        return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    imports.wbg.__wbg_wbindgenbigintgetasi64_ac743ece6ab9bba1 = function(arg0, arg1) {
+        const v = arg1;
+        const ret = typeof(v) === 'bigint' ? v : undefined;
+        getDataViewMemory0().setBigInt64(arg0 + 8 * 1, isLikeNone(ret) ? BigInt(0) : ret, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
+    };
+    imports.wbg.__wbg_wbindgenbooleanget_3fe6f642c7d97746 = function(arg0) {
+        const v = arg0;
+        const ret = typeof(v) === 'boolean' ? v : undefined;
+        return isLikeNone(ret) ? 0xFFFFFF : ret ? 1 : 0;
+    };
+    imports.wbg.__wbg_wbindgencbdrop_eb10308566512b88 = function(arg0) {
+        const obj = arg0.original;
+        if (obj.cnt-- == 1) {
+            obj.a = 0;
+            return true;
+        }
+        const ret = false;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgendebugstring_99ef257a3ddda34d = function(arg0, arg1) {
+        const ret = debugString(arg1);
+        const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len1 = WASM_VECTOR_LEN;
+        getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    imports.wbg.__wbg_wbindgenfunctiontable_aa1084b2969a9cbe = function() {
+        const ret = wasm.__wbindgen_export_5;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenin_d7a1ee10933d2d55 = function(arg0, arg1) {
+        const ret = arg0 in arg1;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenisbigint_ecb90cc08a5a9154 = function(arg0) {
+        const ret = typeof(arg0) === 'bigint';
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenisfunction_8cee7dce3725ae74 = function(arg0) {
+        const ret = typeof(arg0) === 'function';
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenisobject_307a53c6bd97fbf8 = function(arg0) {
+        const val = arg0;
+        const ret = typeof(val) === 'object' && val !== null;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenisstring_d4fa939789f003b0 = function(arg0) {
+        const ret = typeof(arg0) === 'string';
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenisundefined_c4b71d073b92f3c5 = function(arg0) {
+        const ret = arg0 === undefined;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenjsvaleq_e6f2ad59ccae1b58 = function(arg0, arg1) {
+        const ret = arg0 === arg1;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenjsvallooseeq_9bec8c9be826bed1 = function(arg0, arg1) {
+        const ret = arg0 == arg1;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgenmemory_d84da70f7c42d172 = function() {
+        const ret = wasm.memory;
+        return ret;
+    };
+    imports.wbg.__wbg_wbindgennumberget_f74b4c7525ac05cb = function(arg0, arg1) {
+        const obj = arg1;
+        const ret = typeof(obj) === 'number' ? obj : undefined;
+        getDataViewMemory0().setFloat64(arg0 + 8 * 1, isLikeNone(ret) ? 0 : ret, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
+    };
+    imports.wbg.__wbg_wbindgenstringget_0f16a6ddddef376f = function(arg0, arg1) {
+        const obj = arg1;
+        const ret = typeof(obj) === 'string' ? obj : undefined;
+        var ptr1 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        var len1 = WASM_VECTOR_LEN;
+        getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    imports.wbg.__wbg_wbindgenthrow_451ec1a8469d7eb6 = function(arg0, arg1) {
+        throw new Error(getStringFromWasm0(arg0, arg1));
+    };
+    imports.wbg.__wbg_writable_e5202c9fd57615db = function(arg0) {
+        const ret = arg0.writable;
+        return ret;
+    };
+    imports.wbg.__wbg_write_2e39e04a4c8c9e9d = function(arg0, arg1) {
+        const ret = arg0.write(arg1);
+        return ret;
+    };
+    imports.wbg.__wbindgen_cast_2241b6af4c4b2941 = function(arg0, arg1) {
+        // Cast intrinsic for `Ref(String) -> Externref`.
+        const ret = getStringFromWasm0(arg0, arg1);
+        return ret;
+    };
+    imports.wbg.__wbindgen_cast_4625c577ab2ec9ee = function(arg0) {
+        // Cast intrinsic for `U64 -> Externref`.
+        const ret = BigInt.asUintN(64, arg0);
+        return ret;
+    };
+    imports.wbg.__wbindgen_cast_7cc3531aa3e3e0fe = function(arg0, arg1) {
+        // Cast intrinsic for `Closure(Closure { dtor_idx: 3803, function: Function { arguments: [Externref], shim_idx: 3814, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+        const ret = makeMutClosure(arg0, arg1, 3803, __wbg_adapter_11);
+        return ret;
+    };
+    imports.wbg.__wbindgen_cast_d6cd19b81560fd6e = function(arg0) {
+        // Cast intrinsic for `F64 -> Externref`.
+        const ret = arg0;
+        return ret;
+    };
+    imports.wbg.__wbindgen_cast_fc73a81ca98ca911 = function(arg0, arg1) {
+        // Cast intrinsic for `Closure(Closure { dtor_idx: 335, function: Function { arguments: [], shim_idx: 336, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+        const ret = makeMutClosure(arg0, arg1, 335, __wbg_adapter_6);
+        return ret;
+    };
+    imports.wbg.__wbindgen_init_externref_table = function() {
+        const table = wasm.__wbindgen_export_4;
+        const offset = table.grow(4);
+        table.set(0, undefined);
+        table.set(offset + 0, undefined);
+        table.set(offset + 1, null);
+        table.set(offset + 2, true);
+        table.set(offset + 3, false);
+        ;
+    };
+
+    return imports;
+}
+
+function __wbg_init_memory(imports, memory) {
+
+}
+
+function __wbg_finalize_init(instance, module) {
+    wasm = instance.exports;
+    __wbg_init.__wbindgen_wasm_module = module;
+    cachedDataViewMemory0 = null;
+    cachedUint32ArrayMemory0 = null;
+    cachedUint8ArrayMemory0 = null;
+
+
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module !== 'undefined') {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+
+    __wbg_init_memory(imports);
+
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+
+    const instance = new WebAssembly.Instance(module, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module_or_path !== 'undefined') {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (typeof module_or_path === 'undefined') {
+        module_or_path = new URL('parquet_wasm_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    __wbg_init_memory(imports);
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync };
+export default __wbg_init;

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,20 +1,60 @@
+import { cpSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
+
+const rollupExternals = new Set(['zarrita', 'zod', 'anndata.js', 'zarrextra', 'apache-arrow']);
 
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        workers: resolve(__dirname, 'src/workers/index.ts'),
+        'points-worker': resolve(__dirname, 'src/workers/points-worker.ts'),
+      },
       name: 'SpatialDataCore',
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`,
+      fileName: (format, entryName) => {
+        if (entryName === 'index') {
+          return `index.${format === 'es' ? 'js' : 'cjs'}`;
+        }
+        return `${entryName}.js`;
+      },
     },
     rollupOptions: {
-      external: ['zarrita', 'zod', 'anndata.js', 'parquet-wasm', 'zarrextra'],
+      external: (id) => {
+        const normalizedId = id.replace(/\\/g, '/');
+        if (normalizedId.includes('vendor/parquet-wasm/parquet_wasm.js')) {
+          return true;
+        }
+        return rollupExternals.has(id);
+      },
     },
     sourcemap: true,
     target: 'es2020',
   },
+  plugins: [
+    {
+      name: 'externalize-vendored-parquet-wasm',
+      resolveId(source) {
+        const normalizedSource = source.replace(/\\/g, '/');
+        if (normalizedSource.includes('vendor/parquet-wasm/parquet_wasm.js')) {
+          return { id: source, external: true };
+        }
+        return null;
+      },
+    },
+    {
+      name: 'copy-vendored-parquet-wasm',
+      closeBundle() {
+        cpSync(
+          resolve(__dirname, 'vendor/parquet-wasm'),
+          resolve(__dirname, 'dist/vendor/parquet-wasm'),
+          { recursive: true }
+        );
+      },
+    },
+  ],
   test: {
     globals: true,
     environment: 'node',

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -30,6 +30,7 @@
     "@deck.gl/core": "catalog:",
     "@hms-dbmi/viv": "catalog:",
     "@math.gl/core": "catalog:",
+    "@spatialdata/core": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/layers/src/PointsLayer.ts
+++ b/packages/layers/src/PointsLayer.ts
@@ -1,0 +1,213 @@
+import type { Matrix4 } from '@math.gl/core';
+import type { UpdateParameters } from '@deck.gl/core';
+import { filterColumnarByFeatureCodesInWorker } from '@spatialdata/core';
+import { CompositeLayer } from 'deck.gl';
+import type { Layer, LayersList } from 'deck.gl';
+import type { PointsRenderResource } from './pointsLoader.js';
+import type { TileDebugStore } from './pointsTiledDebugHooks.js';
+import type { ColumnarNdarrayPointsBatch } from './pointsLoader.js';
+import { filterBatchSignature, featureFilterAwaitingRowCodes, hasPreloadedRowFeatureCodes } from './pointsFeatureCodes.js';
+import { resolvePointsRenderStrategy } from './pointsRenderStrategies.js';
+import { applyRenderCapToColumnar } from '@spatialdata/core';
+import {
+  DEFAULT_POINT_RADIUS_MAX_PIXELS,
+  DEFAULT_POINT_RADIUS_MIN_PIXELS,
+  DEFAULT_POINT_SIZE,
+} from './pointsScatterLayer.js';
+
+export interface PointsLayerProps {
+  id: string;
+  resource: PointsRenderResource;
+  visible?: boolean;
+  opacity?: number;
+  modelMatrix: Matrix4;
+  pointSize?: number;
+  pointRadiusMinPixels?: number;
+  pointRadiusMaxPixels?: number;
+  pointMinSizeScale?: number;
+  viewZoom?: number | null;
+  color?: [number, number, number, number];
+  featureCodes?: readonly number[];
+  /** Source-side integer codes aligned with the preloaded table rows. */
+  preloadedFeatureCodes?: ArrayLike<number>;
+  /** Max rows to draw after feature filtering. */
+  renderCap?: number;
+  showTileDebugOverlay?: boolean;
+  tileDebugStore?: TileDebugStore;
+  /** Bumps when {@link tileDebugStore} contents change; forces debug overlay refresh. */
+  tileDebugSignature?: string;
+  use3d?: boolean;
+}
+
+interface PointsLayerState {
+  preloadedBatch?: ColumnarNdarrayPointsBatch;
+  filteredBatch?: ColumnarNdarrayPointsBatch;
+  filteredBatchSignature?: string;
+  filterGeneration?: number;
+}
+
+function emptyFilteredBatch(batch: ColumnarNdarrayPointsBatch): ColumnarNdarrayPointsBatch {
+  const axisCount = batch.shape[0] ?? batch.data.length;
+  const empty = new Float32Array(0);
+  const emptyData = axisCount >= 3 && batch.data[2] ? [empty, empty, empty] : [empty, empty];
+  return {
+    ...batch,
+    data: emptyData,
+    shape: [axisCount, 0],
+    pointCount: 0,
+  };
+}
+
+async function filterPreloadedBatch(
+  batch: ColumnarNdarrayPointsBatch,
+  featureCodes: readonly number[] | undefined,
+  preloadedFeatureCodes: ArrayLike<number> | undefined
+): Promise<ColumnarNdarrayPointsBatch> {
+  if (featureCodes === undefined) {
+    return batch;
+  }
+  if (featureCodes.length === 0) {
+    return emptyFilteredBatch(batch);
+  }
+  if (!hasPreloadedRowFeatureCodes(preloadedFeatureCodes)) {
+    return batch;
+  }
+  const filtered = await filterColumnarByFeatureCodesInWorker(
+    { shape: batch.shape, data: batch.data },
+    featureCodes,
+    preloadedFeatureCodes ?? []
+  );
+  const filteredShape = filtered.shape ?? [filtered.data.length, filtered.data[0]?.length ?? 0];
+  const pointCount = filteredShape[1] ?? filtered.data[0]?.length ?? 0;
+  return {
+    ...batch,
+    data: filtered.data,
+    shape: filteredShape,
+    pointCount,
+  };
+}
+
+export class PointsLayer extends CompositeLayer<PointsLayerProps> {
+  static layerName = 'PointsLayer';
+
+  static defaultProps = {
+    visible: true,
+    opacity: 1,
+    pointSize: DEFAULT_POINT_SIZE,
+    pointRadiusMinPixels: DEFAULT_POINT_RADIUS_MIN_PIXELS,
+    pointRadiusMaxPixels: DEFAULT_POINT_RADIUS_MAX_PIXELS,
+    showTileDebugOverlay: true,
+  } satisfies Partial<PointsLayerProps>;
+
+  initializeState(): void {
+    this.state = { filterGeneration: 0 };
+    void this.ensurePreloadedBatch();
+  }
+
+  updateState(params: UpdateParameters<this>): void {
+    const { props, oldProps } = params;
+    if (
+      props.resource.loader !== oldProps.resource?.loader ||
+      props.resource.element !== oldProps.resource?.element
+    ) {
+      this.setState({
+        preloadedBatch: undefined,
+        filteredBatch: undefined,
+        filteredBatchSignature: undefined,
+        filterGeneration: 0,
+      });
+      void this.ensurePreloadedBatch();
+      return;
+    }
+
+    const signature = filterBatchSignature(
+      props.featureCodes,
+      props.preloadedFeatureCodes,
+      props.renderCap
+    );
+    const state = this.state as PointsLayerState;
+    const preloadedBatch = state.preloadedBatch;
+    const awaitingRowCodes = featureFilterAwaitingRowCodes(
+      props.featureCodes,
+      props.preloadedFeatureCodes
+    );
+    const canFilter = !awaitingRowCodes;
+    const rowCodesBecameReady =
+      hasPreloadedRowFeatureCodes(props.preloadedFeatureCodes) &&
+      !hasPreloadedRowFeatureCodes(oldProps.preloadedFeatureCodes);
+    if (
+      preloadedBatch &&
+      canFilter &&
+      (rowCodesBecameReady ||
+        signature !== state.filteredBatchSignature ||
+        !state.filteredBatch)
+    ) {
+      void this.ensureFilteredBatch(preloadedBatch, signature);
+    }
+  }
+
+  private async ensurePreloadedBatch(): Promise<void> {
+    const { resource } = this.props;
+    if (resource.loader.capabilities.kind !== 'preloaded-columnar') {
+      return;
+    }
+    const existing = (this.state as PointsLayerState).preloadedBatch;
+    if (existing) {
+      return;
+    }
+    const batch = await resource.loader.loadAll?.();
+    if (batch?.format === 'columnar-ndarray') {
+      this.setState({ preloadedBatch: batch });
+      const awaitingRowCodes = featureFilterAwaitingRowCodes(
+        this.props.featureCodes,
+        this.props.preloadedFeatureCodes
+      );
+      if (!awaitingRowCodes) {
+        void this.ensureFilteredBatch(
+          batch,
+          filterBatchSignature(
+            this.props.featureCodes,
+            this.props.preloadedFeatureCodes,
+            this.props.renderCap
+          )
+        );
+      }
+    }
+  }
+
+  private async ensureFilteredBatch(
+    batch: ColumnarNdarrayPointsBatch,
+    signature: string
+  ): Promise<void> {
+    const generation = ((this.state as PointsLayerState).filterGeneration ?? 0) + 1;
+    this.setState({ filterGeneration: generation });
+    const { featureCodes, preloadedFeatureCodes, renderCap } = this.props;
+    let filtered = await filterPreloadedBatch(batch, featureCodes, preloadedFeatureCodes);
+    filtered = applyRenderCapToColumnar(filtered, renderCap);
+    const state = this.state as PointsLayerState;
+    if (state.filterGeneration !== generation) {
+      return;
+    }
+    this.setState({
+      filteredBatch: filtered,
+      filteredBatchSignature: signature,
+    });
+    this.setNeedsUpdate();
+  }
+
+  /** Public wrapper for strategy modules outside this class. */
+  subLayerProps<P extends Record<string, unknown>>(props: P & { id: string }): P {
+    return this.getSubLayerProps(props);
+  }
+
+  renderLayers(): Layer | null | LayersList {
+    const { visible = true, resource } = this.props;
+    if (!visible || !resource?.loader) {
+      return null;
+    }
+    return resolvePointsRenderStrategy(resource.loader).renderLayers(this);
+  }
+}
+
+export { filterPreloadedBatch };
+export { featureCodesSignature, filterBatchSignature } from './pointsFeatureCodes.js';

--- a/packages/layers/src/engine/PointsDataEngine.ts
+++ b/packages/layers/src/engine/PointsDataEngine.ts
@@ -1,0 +1,156 @@
+import type { PointsElement, PointsLoadResult } from '@spatialdata/core';
+import { pointsRenderResourceSignature, resolvePointsRenderResource } from '../resolvePointsRenderResource.js';
+import type { PointsRenderResource } from '../pointsLoader.js';
+
+/**
+ * Framework-agnostic points loading/caching/resolution engine.
+ *
+ * This is step 1b of the LayerDataEngine decomposition: the points-only
+ * sub-engine, extracted from the `@spatialdata/vis` `useLayerData` hook so the
+ * cache + orchestration live in React-free `@spatialdata/layers` and can be
+ * unit-tested headlessly. It owns exactly what the hook's points path used to
+ * hold as `useRef` state:
+ *
+ *  - the per-element preloaded batch cache (`loadedDataRef.points`),
+ *  - the stable render-resource memo (`stablePointsResourceRef`),
+ *  - the async preload orchestration (the load effect's points branch).
+ *
+ * Parity scope: this mirrors the current branch's *preloaded flat scatter* path
+ * only. Metadata probing, Morton tiling, feature catalog/codes, and tile-debug
+ * state are deliberately NOT here yet — they are the dark capabilities that MVP
+ * steps 2–4 will wire *into this engine* (see docs/plans/points-mvp-and-roadmap).
+ */
+
+export type PointsLoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface PointsLoadTarget {
+  /** Stable element key — the cache/resolver key. */
+  key: string;
+  /** Layer id, used only to report status back to the host. */
+  layerId: string;
+  element: PointsElement;
+}
+
+export interface PointsDataEngineCallbacks {
+  /** Report load-status transitions so the host can drive its load-state UI. */
+  onStatus?: (layerId: string, status: PointsLoadStatus) => void;
+}
+
+interface PointsEntry {
+  data?: PointsLoadResult;
+  status: PointsLoadStatus;
+  loading?: Promise<void>;
+  resource?: { signature: string; resource: PointsRenderResource };
+}
+
+export class PointsDataEngine {
+  private readonly entries = new Map<string, PointsEntry>();
+  private readonly listeners = new Set<() => void>();
+  private readonly callbacks: PointsDataEngineCallbacks;
+
+  constructor(callbacks: PointsDataEngineCallbacks = {}) {
+    this.callbacks = callbacks;
+  }
+
+  /** Subscribe to cache mutations (async load settled). Returns an unsubscribe. */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  hasData(key: string): boolean {
+    return this.entries.get(key)?.data !== undefined;
+  }
+
+  getData(key: string): PointsLoadResult | undefined {
+    return this.entries.get(key)?.data;
+  }
+
+  getStatus(key: string): PointsLoadStatus {
+    return this.entries.get(key)?.status ?? 'idle';
+  }
+
+  /**
+   * Resolve a **stable** render resource for an element. Memoized by signature
+   * so repeated calls (every render / pan-zoom frame) reuse the same loader
+   * identity: the `PointsLayer` composite resets its async-loaded batch whenever
+   * the loader identity changes, which would blank the layer for a frame (the
+   * pan flash) if we resolved afresh each call. Returns null until data loads.
+   */
+  getResource(element: PointsElement, key: string): PointsRenderResource | null {
+    const entry = this.entries.get(key);
+    if (!entry?.data) {
+      return null;
+    }
+    const cache = { preloaded: entry.data, metadataKnown: false };
+    const options = { experimentalOptimizations: 'off' as const };
+    const signature = pointsRenderResourceSignature(element, cache, options);
+    if (entry.resource && entry.resource.signature === signature) {
+      return entry.resource.resource;
+    }
+    const resource = resolvePointsRenderResource(element, cache, options);
+    if (resource) {
+      entry.resource = { signature, resource };
+    }
+    return resource;
+  }
+
+  /**
+   * Idempotently preload an element's points. No-op if already loaded or a load
+   * is in flight; the returned promise resolves when the (possibly already
+   * running) load settles. Status transitions are reported via `onStatus`; the
+   * cache mutation notifies subscribers.
+   */
+  ensureLoaded(target: PointsLoadTarget): Promise<void> {
+    const { key, layerId, element } = target;
+    const existing = this.entries.get(key);
+    if (existing?.data !== undefined) {
+      return Promise.resolve();
+    }
+    if (existing?.loading) {
+      return existing.loading;
+    }
+
+    const entry: PointsEntry = existing ?? { status: 'idle' };
+    entry.status = 'loading';
+    this.entries.set(key, entry);
+    this.callbacks.onStatus?.(layerId, 'loading');
+
+    const loading = (async () => {
+      try {
+        const data = await element.loadPoints();
+        entry.data = data;
+        entry.status = 'ready';
+        this.callbacks.onStatus?.(layerId, 'ready');
+      } catch (error) {
+        entry.status = 'error';
+        this.callbacks.onStatus?.(layerId, 'error');
+        console.error(`Failed to load points for ${layerId}:`, error);
+      } finally {
+        entry.loading = undefined;
+        this.notify();
+      }
+    })();
+    entry.loading = loading;
+    return loading;
+  }
+
+  /** Drop an element from the cache (on unload / dataset switch). */
+  evict(key: string): void {
+    this.entries.delete(key);
+  }
+
+  /** Release all cached data and listeners. */
+  dispose(): void {
+    this.entries.clear();
+    this.listeners.clear();
+  }
+}

--- a/packages/layers/src/geoArrowStrategies.ts
+++ b/packages/layers/src/geoArrowStrategies.ts
@@ -1,0 +1,24 @@
+import type { Layer, LayersList } from 'deck.gl';
+import type { PointsLayer } from './PointsLayer.js';
+import type { PointsRenderStrategy } from './pointsRenderStrategies.js';
+
+export const geoArrowBinaryStrategy: PointsRenderStrategy = {
+  renderLayers(): Layer | null | LayersList {
+    return null;
+  },
+};
+
+export const geoArrowTiledStrategy: PointsRenderStrategy = {
+  renderLayers(): Layer | null | LayersList {
+    return null;
+  },
+};
+
+export const unsupportedPointsStrategy: PointsRenderStrategy = {
+  renderLayers(layer): Layer | null | LayersList {
+    console.debug(
+      `[PointsLayer] Unsupported points encoding for element "${layer.props.resource.element.key}"`
+    );
+    return null;
+  },
+};

--- a/packages/layers/src/index.ts
+++ b/packages/layers/src/index.ts
@@ -68,3 +68,58 @@ export type {
   RenderStackSpatialElementType,
   RenderStackSpatialEntry,
 } from './renderStack';
+export { PointsLayer } from './PointsLayer';
+export type { PointsLayerProps } from './PointsLayer';
+export {
+  columnarBatchFromPointData,
+  pointDataFromColumnarBatch,
+  type ArrowRecordBatchPointsBatch,
+  type ColumnarNdarrayPointsBatch,
+  type PointData,
+  type PointsBatch,
+  type PointsBatchFormat,
+  type PointsEncodingKind,
+  type PointsLoadInBoundsOptions,
+  type PointsLoader,
+  type PointsLoaderCapabilities,
+  type PointsRenderResource,
+} from './pointsLoader.js';
+export {
+  createPointsRenderResource,
+  coreLoaderToPointsLoader,
+} from './pointsLoaderAdapter.js';
+export {
+  DEFAULT_POINT_RADIUS_MAX_PIXELS,
+  DEFAULT_POINT_RADIUS_MIN_PIXELS,
+  DEFAULT_POINT_SIZE,
+  MIN_POINT_SIZE_SCALE,
+  POINT_SIZE_ZOOM_REFERENCE,
+  zoomScaledPointSize,
+} from './pointsScatterLayer.js';
+export type { PointsTileHandle, PointsTileLoadResult } from './pointsTileLoadCallbacks.js';
+export {
+  createTileDebugStore,
+  createTiledPointsDebugHooks,
+  type TileDebugStore,
+  type TiledPointsDebugState,
+} from './pointsTiledDebugHooks.js';
+export {
+  POINTS_TILE_DEBUG_PICK_KIND,
+  formatPointsTileDebugTooltip,
+  isPointsTileDebugPickObject,
+  reduceTileDebugEntries,
+  tileDebugEntriesSignature,
+  tileDebugStatusFillColor,
+  tileDebugStatusLineColor,
+  type PointsTileDebugEntry,
+  type PointsTileDebugPickObject,
+  type PointsTileLoadProgress,
+  type PointsTileStatus,
+} from './pointsTileDebug.js';
+
+// Points render-resource resolution and load planning.
+// Relocated from @spatialdata/vis (SpatialCanvas) per
+// docs/plans/layer-data-engine-decomposition.md — these are framework-agnostic
+// (no React) and belong in layers. Re-exported from vis for MDV compatibility.
+export * from './pointsLoadPlan.js';
+export * from './resolvePointsRenderResource.js';

--- a/packages/layers/src/index.ts
+++ b/packages/layers/src/index.ts
@@ -123,3 +123,11 @@ export {
 // (no React) and belong in layers. Re-exported from vis for MDV compatibility.
 export * from './pointsLoadPlan.js';
 export * from './resolvePointsRenderResource.js';
+
+// Framework-agnostic points loading/caching engine (LayerDataEngine step 1b).
+export {
+  PointsDataEngine,
+  type PointsDataEngineCallbacks,
+  type PointsLoadStatus,
+  type PointsLoadTarget,
+} from './engine/PointsDataEngine.js';

--- a/packages/layers/src/mortonTiledStrategy.ts
+++ b/packages/layers/src/mortonTiledStrategy.ts
@@ -1,0 +1,255 @@
+import { COORDINATE_SYSTEM } from '@deck.gl/core';
+import { PolygonLayer, TileLayer } from 'deck.gl';
+import type { Layer, LayersList } from 'deck.gl';
+import type { PointsLayer } from './PointsLayer.js';
+import {
+  boundsFromTileBbox,
+  intersectBounds,
+  isPointTileBbox,
+  scatterBoundsFromTileBbox,
+  tileHandleFromDeckTile,
+} from './pointsBbox.js';
+import type { ColumnarNdarrayPointsBatch } from './pointsLoader.js';
+import {
+  DEFAULT_POINT_RADIUS_MAX_PIXELS,
+  DEFAULT_POINT_RADIUS_MIN_PIXELS,
+  DEFAULT_POINT_SIZE,
+  renderColumnarScatterLayer,
+} from './pointsScatterLayer.js';
+import type { PointsRenderStrategy } from './pointsRenderStrategies.js';
+import { featureCodesSignature } from './pointsFeatureCodes.js';
+import { createTiledPointsDebugHooks } from './pointsTiledDebugHooks.js';
+import {
+  POINTS_TILE_DEBUG_PICK_KIND,
+  pointsTileDebugPolygonData,
+  tileDebugStatusFillColor,
+  tileDebugStatusLineColor,
+} from './pointsTileDebug.js';
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+function isColumnarBatch(value: unknown): value is ColumnarNdarrayPointsBatch {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as ColumnarNdarrayPointsBatch).format === 'columnar-ndarray'
+  );
+}
+
+function renderedPointCount(batch: ColumnarNdarrayPointsBatch): number {
+  if (batch.pointCount !== undefined) {
+    return batch.pointCount;
+  }
+  if (batch.shape.length >= 2 && Number.isFinite(batch.shape[1])) {
+    return batch.shape[1];
+  }
+  return batch.data[0]?.length ?? 0;
+}
+
+export const mortonTiledStrategy: PointsRenderStrategy = {
+  renderLayers(layer: PointsLayer): Layer | null | LayersList {
+    const {
+      resource,
+      featureCodes,
+      showTileDebugOverlay,
+      opacity = 1,
+      visible = true,
+      pointSize = DEFAULT_POINT_SIZE,
+      pointRadiusMinPixels,
+      pointRadiusMaxPixels,
+      color = [255, 100, 100, 200],
+      use3d,
+    } = layer.props;
+
+    const localBounds = resource.loader.capabilities.bounds;
+    if (!localBounds) {
+      return null;
+    }
+
+    const debugHooks = createTiledPointsDebugHooks(layer.props.tileDebugStore);
+    const scatterStyleProps = {
+      color,
+      pointSize,
+      pointRadiusMinPixels,
+      pointRadiusMaxPixels,
+      opacity,
+      modelMatrix: layer.props.modelMatrix,
+      use3d,
+    };
+
+    const layers: LayersList = [
+      new TileLayer(
+        layer.subLayerProps({
+          id: 'tiles',
+          coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+          modelMatrix: layer.props.modelMatrix,
+          extent: [localBounds.minX, localBounds.minY, localBounds.maxX, localBounds.maxY],
+          opacity,
+          visible,
+          tileSize: 512,
+          minZoom: -1,
+          maxZoom: -1,
+          refinementStrategy: 'best-available',
+          updateTriggers: {
+            getTileData: [resource.element.key, featureCodesSignature(featureCodes)],
+            renderSubLayers: [
+              pointSize,
+              pointRadiusMinPixels,
+              pointRadiusMaxPixels,
+              color,
+              opacity,
+              layer.props.modelMatrix,
+              use3d,
+            ],
+          },
+          onViewportLoad(
+            tiles: Array<{
+              index?: { x: number; y: number; z: number };
+              id?: string;
+              bbox?: unknown;
+            }> | null
+          ) {
+            const handles = (tiles ?? [])
+              .map(
+                (tile: {
+                  index?: { x: number; y: number; z: number };
+                  id?: string;
+                  bbox?: unknown;
+                }) => tileHandleFromDeckTile(tile)
+              )
+              .filter(
+                (handle): handle is NonNullable<ReturnType<typeof tileHandleFromDeckTile>> =>
+                  handle != null
+              );
+            debugHooks.onViewportTilesRequested(handles);
+          },
+          async getTileData(tileProps: {
+            index?: { x: number; y: number; z: number };
+            id?: string;
+            bbox?: unknown;
+            signal?: AbortSignal;
+          }) {
+            const tile = tileHandleFromDeckTile(tileProps);
+            if (!tile || !isPointTileBbox(tileProps.bbox)) {
+              return null;
+            }
+            debugHooks.onTileLoadStart(tile);
+            const rawBounds = boundsFromTileBbox(tile.bbox);
+            const bounds = intersectBounds(rawBounds, localBounds);
+            if (!bounds) {
+              debugHooks.onTileLoadEnd(
+                tile,
+                { success: true, clippedBounds: null, pointCount: 0, loadMode: 'clipped' },
+                rawBounds
+              );
+              return null;
+            }
+            try {
+              const batch = await resource.loader.loadInBounds({
+                bounds,
+                featureCodes,
+                signal: tileProps.signal,
+              });
+              if (!batch || !isColumnarBatch(batch)) {
+                debugHooks.onTileLoadEnd(
+                  tile,
+                  { success: true, clippedBounds: bounds, pointCount: 0 },
+                  rawBounds
+                );
+                return null;
+              }
+              debugHooks.onTileLoadEnd(
+                tile,
+                {
+                  success: true,
+                  clippedBounds: bounds,
+                  pointCount: renderedPointCount(batch),
+                  loadMode: batch.loadMode,
+                },
+                rawBounds
+              );
+              return batch;
+            } catch (error) {
+              const aborted = Boolean(tileProps.signal?.aborted) || isAbortError(error);
+              debugHooks.onTileLoadEnd(
+                tile,
+                {
+                  success: false,
+                  aborted,
+                  clippedBounds: bounds,
+                  errorMessage: aborted ? 'aborted' : String(error),
+                },
+                rawBounds
+              );
+              if (aborted) {
+                return null;
+              }
+              throw error;
+            }
+          },
+          renderSubLayers: (props: {
+            id: string;
+            data?: ColumnarNdarrayPointsBatch | null;
+            tile?: { bbox?: unknown };
+          }) => {
+            if (!props.data || !isColumnarBatch(props.data)) {
+              return null;
+            }
+            const tileBbox = isPointTileBbox(props.tile?.bbox) ? props.tile.bbox : null;
+            return renderColumnarScatterLayer(`${props.id}-scatter`, props.data, {
+              ...scatterStyleProps,
+              tileBounds: tileBbox ? scatterBoundsFromTileBbox(tileBbox) : undefined,
+              tileSubLayer: true,
+            });
+          },
+        })
+      ),
+    ];
+
+    if (showTileDebugOverlay) {
+      const entries = debugHooks.getTileDebugEntries();
+      const debugSignature = layer.props.tileDebugSignature ?? debugHooks.getTileDebugSignature();
+      const polygonData = pointsTileDebugPolygonData(entries).map(({ polygon, entry }) => ({
+        polygon,
+        entry,
+        kind: POINTS_TILE_DEBUG_PICK_KIND as typeof POINTS_TILE_DEBUG_PICK_KIND,
+      }));
+      layers.push(
+        new PolygonLayer(
+          layer.subLayerProps({
+            id: 'tile-debug',
+            coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+            modelMatrix: layer.props.modelMatrix,
+            data: polygonData,
+            pickable: true,
+            autoHighlight: true,
+            highlightColor: [255, 255, 255, 120],
+            getPolygon: (d: { polygon: [number, number][] }) => d.polygon,
+            getFillColor: (d: {
+              entry: { status: import('./pointsTileDebug.js').PointsTileStatus };
+            }) => tileDebugStatusFillColor(d.entry.status),
+            getLineColor: (d: {
+              entry: { status: import('./pointsTileDebug.js').PointsTileStatus };
+            }) => tileDebugStatusLineColor(d.entry.status),
+            getLineWidth: 2,
+            lineWidthUnits: 'pixels',
+            filled: true,
+            stroked: true,
+            opacity: Math.min(1, opacity + 0.15),
+            visible,
+            updateTriggers: {
+              data: [debugSignature],
+              getFillColor: [debugSignature],
+              getLineColor: [debugSignature],
+              getPolygon: [debugSignature],
+            },
+          })
+        )
+      );
+    }
+
+    return layers;
+  },
+};

--- a/packages/layers/src/pointsBbox.ts
+++ b/packages/layers/src/pointsBbox.ts
@@ -1,0 +1,67 @@
+import type { SpatialBounds } from '@spatialdata/core';
+import type { PointsTileHandle } from './pointsTileLoadCallbacks.js';
+
+export type PointTileBbox = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+export function isPointTileBbox(value: unknown): value is PointTileBbox {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.left === 'number' &&
+    typeof candidate.right === 'number' &&
+    typeof candidate.top === 'number' &&
+    typeof candidate.bottom === 'number'
+  );
+}
+
+export function intersectBounds(
+  query: SpatialBounds,
+  clip: SpatialBounds
+): SpatialBounds | null {
+  const minX = Math.max(query.minX, clip.minX);
+  const maxX = Math.min(query.maxX, clip.maxX);
+  const minY = Math.max(query.minY, clip.minY);
+  const maxY = Math.min(query.maxY, clip.maxY);
+  if (minX > maxX || minY > maxY) {
+    return null;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+export function boundsFromTileBbox(bbox: PointTileBbox): SpatialBounds {
+  return {
+    minX: Math.min(bbox.left, bbox.right),
+    maxX: Math.max(bbox.left, bbox.right),
+    minY: Math.min(bbox.top, bbox.bottom),
+    maxY: Math.max(bbox.top, bbox.bottom),
+  };
+}
+
+export function scatterBoundsFromTileBbox(
+  bbox: PointTileBbox
+): [number, number, number, number] {
+  return [bbox.left, bbox.top, bbox.right, bbox.bottom];
+}
+
+export function tileHandleFromDeckTile(tile: {
+  index?: { x: number; y: number; z: number };
+  id?: string;
+  bbox?: unknown;
+}): PointsTileHandle | null {
+  if (!tile.index || !isPointTileBbox(tile.bbox)) {
+    return null;
+  }
+  const { x, y, z } = tile.index;
+  return {
+    tileId: tile.id ?? `${x}-${y}-${z}`,
+    index: { x, y, z },
+    bbox: tile.bbox,
+  };
+}

--- a/packages/layers/src/pointsFeatureCodes.ts
+++ b/packages/layers/src/pointsFeatureCodes.ts
@@ -1,0 +1,49 @@
+export function hasPreloadedRowFeatureCodes(
+  preloadedFeatureCodes: ArrayLike<number> | undefined
+): boolean {
+  return preloadedFeatureCodes !== undefined && preloadedFeatureCodes.length > 0;
+}
+
+export function featureFilterAwaitingRowCodes(
+  featureCodes: readonly number[] | undefined,
+  preloadedFeatureCodes: ArrayLike<number> | undefined
+): boolean {
+  return (
+    featureCodes !== undefined &&
+    featureCodes.length > 0 &&
+    !hasPreloadedRowFeatureCodes(preloadedFeatureCodes)
+  );
+}
+
+export function featureCodesSignature(featureCodes: readonly number[] | undefined): string {
+  if (featureCodes === undefined) {
+    return 'all';
+  }
+  if (featureCodes.length === 0) {
+    return 'none';
+  }
+  return featureCodes.slice().sort((left, right) => left - right).join(',');
+}
+
+export function preloadedFeatureCodesSignature(
+  featureCodes: ArrayLike<number> | undefined
+): string {
+  if (!featureCodes) {
+    return 'nocodes';
+  }
+  const length = featureCodes.length;
+  if (length === 0) {
+    return 'len:0';
+  }
+  return `len:${length}:${featureCodes[0]}:${featureCodes[length - 1]}`;
+}
+
+export function filterBatchSignature(
+  featureCodes: readonly number[] | undefined,
+  preloadedFeatureCodes: ArrayLike<number> | undefined,
+  renderCap?: number
+): string {
+  const renderPart =
+    renderCap === undefined ? 'default' : renderCap <= 0 ? 'none' : String(renderCap);
+  return `${featureCodesSignature(featureCodes)}|${preloadedFeatureCodesSignature(preloadedFeatureCodes)}|r:${renderPart}`;
+}

--- a/packages/layers/src/pointsLoadPlan.ts
+++ b/packages/layers/src/pointsLoadPlan.ts
@@ -1,0 +1,122 @@
+import { resolvePointsMemoryCap, type PointsTilingMetadata } from '@spatialdata/core';
+
+export interface PointsPreloadCacheKeyInput {
+  pointsMemoryCap?: number;
+}
+
+/** Cache key for preloaded scatter data (per element + memory cap). */
+export function pointsPreloadCacheKey(
+  elementKey: string,
+  config: PointsPreloadCacheKeyInput
+): string {
+  const memoryCap = resolvePointsMemoryCap(config.pointsMemoryCap);
+  return `${elementKey}|m${memoryCap}`;
+}
+
+export function deletePointsPreloadCacheForElement(
+  cache: Map<string, unknown>,
+  elementKey: string
+): void {
+  for (const key of [...cache.keys()]) {
+    if (key === elementKey || key.startsWith(`${elementKey}|`)) {
+      cache.delete(key);
+    }
+  }
+}
+
+export function hasPointsPreloadForElement(
+  cache: Map<string, unknown>,
+  elementKey: string
+): boolean {
+  for (const key of cache.keys()) {
+    if (key === elementKey || key.startsWith(`${elementKey}|`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolvePointsPreloadData<T>(
+  cache: Map<string, T>,
+  elementKey: string,
+  preloadCacheKey: string
+): T | undefined {
+  return cache.get(preloadCacheKey) ?? cache.get(elementKey);
+}
+
+export interface PointsLoadPlanInput {
+  wantsOptimized: boolean;
+  metadataKnown: boolean;
+  tiledMetadata: PointsTilingMetadata | null | undefined;
+  hasPreloaded: boolean;
+  /** Known row count from parquet metadata, when available. */
+  totalRows?: number;
+}
+
+export interface PointsLoadPlan {
+  probeMetadata: boolean;
+  preloadFullTable: boolean;
+}
+
+/** Decide which points loads to schedule at the start of a load pass. */
+export function planPointsLoads(input: PointsLoadPlanInput): PointsLoadPlan {
+  const { wantsOptimized, metadataKnown, tiledMetadata, hasPreloaded } = input;
+  const probeMetadata = wantsOptimized && !metadataKnown;
+  const preloadFullTable =
+    !hasPreloaded && (!wantsOptimized || (metadataKnown && tiledMetadata === null));
+  return { probeMetadata, preloadFullTable };
+}
+
+export interface ShouldPreloadAfterMetadataProbeInput {
+  probeRan: boolean;
+  renderableMetadata: boolean;
+  hasPreloaded: boolean;
+  totalRows?: number;
+}
+
+/**
+ * After a metadata probe completes, preload may still be required even when
+ * `planPointsLoads` did not schedule it (metadata was unknown at plan time).
+ */
+export function shouldPreloadAfterMetadataProbe(
+  input: ShouldPreloadAfterMetadataProbeInput | boolean,
+  renderableMetadata?: boolean,
+  hasPreloaded?: boolean,
+  totalRows?: number
+): boolean {
+  const normalized: ShouldPreloadAfterMetadataProbeInput =
+    typeof input === 'boolean'
+      ? {
+          probeRan: input,
+          renderableMetadata: renderableMetadata ?? false,
+          hasPreloaded: hasPreloaded ?? false,
+          totalRows,
+        }
+      : input;
+
+  if (!normalized.probeRan || normalized.renderableMetadata || normalized.hasPreloaded) {
+    return false;
+  }
+  return true;
+}
+
+export interface ShouldLoadPointsRowFeatureCodesInput {
+  hasPreloaded: boolean;
+  hasCached: boolean;
+  inFlight: boolean;
+  featureCodes?: readonly number[];
+}
+
+export function shouldLoadPointsRowFeatureCodes(
+  input: ShouldLoadPointsRowFeatureCodesInput
+): boolean {
+  return input.hasPreloaded && !input.hasCached && !input.inFlight;
+}
+
+export function pointsPreloadBlockedMessage(totalRows: number): string {
+  return `${totalRows.toLocaleString()} points exceeds the preload limit — use a Morton-sorted element or tiled path`;
+}
+
+export function pointsTilingUnavailableMessage(totalRows: number): string {
+  return `${totalRows.toLocaleString()} points cannot be tiled with this store (range reads unavailable) and exceeds the preload limit`;
+}

--- a/packages/layers/src/pointsLoader.ts
+++ b/packages/layers/src/pointsLoader.ts
@@ -1,0 +1,92 @@
+import type { SpatialBounds, PointsElement, PointsLoadMode } from '@spatialdata/core';
+
+export type PointsEncodingKind =
+  | 'preloaded-columnar'
+  | 'morton-tiled'
+  | 'geoarrow-binary'
+  | 'geoarrow-tiled';
+
+export type PointsBatchFormat = 'columnar-ndarray' | 'arrow-record-batch';
+
+export interface PointsLoaderCapabilities {
+  kind: PointsEncodingKind;
+  batchFormat: PointsBatchFormat;
+  bounds?: SpatialBounds;
+  supportsViewportTiles: boolean;
+  supportsFeatureCodes?: boolean;
+}
+
+export interface ColumnarNdarrayPointsBatch {
+  format: 'columnar-ndarray';
+  data: ArrayLike<number>[];
+  shape: number[];
+  bounds?: SpatialBounds;
+  loadMode?: PointsLoadMode;
+  pointCount?: number;
+}
+
+/** Placeholder for future GeoArrow strategies. */
+export interface ArrowRecordBatchPointsBatch {
+  format: 'arrow-record-batch';
+  batch: unknown;
+  bounds?: SpatialBounds;
+  loadMode?: string;
+  pointCount?: number;
+}
+
+export type PointsBatch = ColumnarNdarrayPointsBatch | ArrowRecordBatchPointsBatch;
+
+export interface PointsLoadInBoundsOptions {
+  bounds: SpatialBounds;
+  featureCodes?: readonly number[];
+  signal?: AbortSignal;
+}
+
+export interface PointsLoader {
+  readonly capabilities: PointsLoaderCapabilities;
+  loadInBounds(options: PointsLoadInBoundsOptions): Promise<PointsBatch | null>;
+  loadAll?(options?: { signal?: AbortSignal }): Promise<PointsBatch>;
+}
+
+export interface PointsRenderResource {
+  element: PointsElement;
+  loader: PointsLoader;
+}
+
+export interface PointData {
+  shape: number[];
+  data: ArrayLike<number>[];
+  featureCodes?: ArrayLike<number>;
+  /** Full dataset row count when preload was truncated. */
+  totalRowCount?: number;
+  preloadTruncated?: boolean;
+  /** Rows scanned when loading with an active feature filter. */
+  scannedRowCount?: number;
+  /** Data was loaded with a source-side feature filter. */
+  filterActive?: boolean;
+}
+
+export function columnarBatchFromPointData(
+  data: PointData,
+  options?: { loadMode?: PointsLoadMode; bounds?: SpatialBounds }
+): ColumnarNdarrayPointsBatch {
+  const pointCount =
+    data.shape.length >= 2 && Number.isFinite(data.shape[1])
+      ? data.shape[1]
+      : (data.data[0]?.length ?? data.shape[0] ?? 0);
+  return {
+    format: 'columnar-ndarray',
+    data: data.data,
+    shape: data.shape,
+    bounds: options?.bounds,
+    loadMode: options?.loadMode,
+    pointCount,
+  };
+}
+
+export function pointDataFromColumnarBatch(batch: ColumnarNdarrayPointsBatch): PointData {
+  return {
+    data: batch.data,
+    shape: batch.shape,
+  };
+}

--- a/packages/layers/src/pointsLoaderAdapter.ts
+++ b/packages/layers/src/pointsLoaderAdapter.ts
@@ -1,0 +1,46 @@
+import type { PointsElement } from '@spatialdata/core';
+import type {
+  PointsBatch,
+  PointsLoader,
+  PointsLoaderCapabilities,
+  PointsLoadInBoundsOptions,
+  PointsRenderResource,
+} from './pointsLoader.js';
+
+type CorePointsLoader = {
+  readonly capabilities: PointsLoaderCapabilities;
+  loadInBounds(options: PointsLoadInBoundsOptions): Promise<PointsBatch | null>;
+  loadAll?(options?: { signal?: AbortSignal }): Promise<PointsBatch>;
+};
+
+export type {
+  ArrowRecordBatchPointsBatch,
+  ColumnarNdarrayPointsBatch,
+  PointData,
+  PointsBatch,
+  PointsBatchFormat,
+  PointsEncodingKind,
+  PointsLoadInBoundsOptions,
+  PointsLoader,
+  PointsLoaderCapabilities,
+  PointsRenderResource,
+} from './pointsLoader.js';
+
+export {
+  columnarBatchFromPointData,
+  pointDataFromColumnarBatch,
+} from './pointsLoader.js';
+
+export function coreLoaderToPointsLoader(loader: CorePointsLoader): PointsLoader {
+  return loader;
+}
+
+export function createPointsRenderResource(
+  element: PointsElement,
+  loader: CorePointsLoader
+): PointsRenderResource {
+  return {
+    element,
+    loader: coreLoaderToPointsLoader(loader),
+  };
+}

--- a/packages/layers/src/pointsRenderStrategies.ts
+++ b/packages/layers/src/pointsRenderStrategies.ts
@@ -1,0 +1,21 @@
+import type { Layer, LayersList } from 'deck.gl';
+import type { PointsEncodingKind, PointsLoader } from './pointsLoader.js';
+import type { PointsLayer } from './PointsLayer.js';
+import { geoArrowBinaryStrategy, geoArrowTiledStrategy, unsupportedPointsStrategy } from './geoArrowStrategies.js';
+import { mortonTiledStrategy } from './mortonTiledStrategy.js';
+import { preloadedScatterStrategy } from './preloadedScatterStrategy.js';
+
+export interface PointsRenderStrategy {
+  renderLayers(layer: PointsLayer): Layer | null | LayersList;
+}
+
+const STRATEGIES: Record<PointsEncodingKind, PointsRenderStrategy> = {
+  'preloaded-columnar': preloadedScatterStrategy,
+  'morton-tiled': mortonTiledStrategy,
+  'geoarrow-binary': geoArrowBinaryStrategy,
+  'geoarrow-tiled': geoArrowTiledStrategy,
+};
+
+export function resolvePointsRenderStrategy(loader: PointsLoader): PointsRenderStrategy {
+  return STRATEGIES[loader.capabilities.kind] ?? unsupportedPointsStrategy;
+}

--- a/packages/layers/src/pointsScatterLayer.ts
+++ b/packages/layers/src/pointsScatterLayer.ts
@@ -46,14 +46,16 @@ export function renderColumnarScatterLayer(
 ) {
   const pointData = pointDataFromColumnarBatch(batch);
   const d = pointData.data;
-  const effectivePointSize = props.tileSubLayer
-    ? props.pointSize
-    : zoomScaledPointSize(
-        props.pointSize,
-        props.viewZoom,
-        POINT_SIZE_ZOOM_REFERENCE,
-        props.pointMinSizeScale ?? MIN_POINT_SIZE_SCALE
-      );
+
+  // Preloaded scatter sizes points in WORLD (common) units so the GPU scales
+  // them with zoom — points shrink when you zoom out, which is exactly where
+  // scatter overdraw is worst — while `radiusMinPixels`/`radiusMaxPixels` clamp
+  // the projected radius so points never vanish or bloat. The Morton tile path
+  // keeps fixed pixel sizing (tiles are already viewport-bounded).
+  const isTile = props.tileSubLayer === true;
+  const radiusUnits: 'common' | 'pixels' = isTile ? 'pixels' : 'common';
+  const radiusMinPixels = props.pointRadiusMinPixels ?? DEFAULT_POINT_RADIUS_MIN_PIXELS;
+  const radiusMaxPixels = props.pointRadiusMaxPixels ?? DEFAULT_POINT_RADIUS_MAX_PIXELS;
 
   const pointCount = batch.pointCount ?? batch.shape[1] ?? d[0]?.length ?? 0;
 
@@ -67,14 +69,10 @@ export function renderColumnarScatterLayer(
       d[1][index],
       props.use3d ? d[2]?.[index] || 0 : 0,
     ],
-    getRadius: effectivePointSize,
-    ...(props.tileSubLayer
-      ? {
-          radiusMinPixels: props.pointRadiusMinPixels ?? DEFAULT_POINT_RADIUS_MIN_PIXELS,
-          radiusMaxPixels: props.pointRadiusMaxPixels ?? DEFAULT_POINT_RADIUS_MAX_PIXELS,
-        }
-      : {}),
-    radiusUnits: 'pixels',
+    getRadius: props.pointSize,
+    radiusUnits,
+    radiusMinPixels,
+    radiusMaxPixels,
     getFillColor: props.color,
     opacity: props.opacity,
     modelMatrix: props.modelMatrix,
@@ -83,13 +81,7 @@ export function renderColumnarScatterLayer(
     highlightColor: [255, 255, 0, 200],
     updateTriggers: {
       getPosition: [pointCount, d[0], d[1], d[2]],
-      getRadius: [
-        props.pointSize,
-        props.viewZoom,
-        props.pointRadiusMinPixels,
-        props.pointRadiusMaxPixels,
-        props.pointMinSizeScale,
-      ],
+      getRadius: [props.pointSize],
     },
   });
 }

--- a/packages/layers/src/pointsScatterLayer.ts
+++ b/packages/layers/src/pointsScatterLayer.ts
@@ -1,0 +1,95 @@
+import type { Matrix4 } from '@math.gl/core';
+import { COORDINATE_SYSTEM } from '@deck.gl/core';
+import { ScatterplotLayer } from 'deck.gl';
+import type { ColumnarNdarrayPointsBatch } from './pointsLoader.js';
+import { pointDataFromColumnarBatch } from './pointsLoader.js';
+
+/** Orthographic zoom at which configured pointSize applies at full scale. */
+export const POINT_SIZE_ZOOM_REFERENCE = 0;
+/** Minimum radius multiplier when zoomed out (reduces fragment overdraw). */
+export const MIN_POINT_SIZE_SCALE = 0.15;
+export const DEFAULT_POINT_SIZE = 0.1;
+export const DEFAULT_POINT_RADIUS_MIN_PIXELS = 0.1;
+export const DEFAULT_POINT_RADIUS_MAX_PIXELS = 3;
+
+export function zoomScaledPointSize(
+  pointSize: number,
+  zoom: number | null | undefined,
+  zoomReference = POINT_SIZE_ZOOM_REFERENCE,
+  minScale = MIN_POINT_SIZE_SCALE
+): number {
+  if (zoom === null || zoom === undefined || !Number.isFinite(zoom)) {
+    return pointSize;
+  }
+  const scale = 2 ** (zoom - zoomReference);
+  return pointSize * Math.min(1, Math.max(minScale, scale));
+}
+
+export interface PointsScatterStyleProps {
+  color: [number, number, number, number];
+  pointSize: number;
+  pointRadiusMinPixels?: number;
+  pointRadiusMaxPixels?: number;
+  pointMinSizeScale?: number;
+  viewZoom?: number | null;
+  opacity: number;
+  modelMatrix: Matrix4;
+  use3d?: boolean;
+  tileBounds?: [number, number, number, number];
+  tileSubLayer?: boolean;
+}
+
+export function renderColumnarScatterLayer(
+  id: string,
+  batch: ColumnarNdarrayPointsBatch,
+  props: PointsScatterStyleProps
+) {
+  const pointData = pointDataFromColumnarBatch(batch);
+  const d = pointData.data;
+  const effectivePointSize = props.tileSubLayer
+    ? props.pointSize
+    : zoomScaledPointSize(
+        props.pointSize,
+        props.viewZoom,
+        POINT_SIZE_ZOOM_REFERENCE,
+        props.pointMinSizeScale ?? MIN_POINT_SIZE_SCALE
+      );
+
+  const pointCount = batch.pointCount ?? batch.shape[1] ?? d[0]?.length ?? 0;
+
+  return new ScatterplotLayer({
+    id,
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+    data: d[0],
+    ...(props.tileBounds ? { bounds: props.tileBounds } : {}),
+    getPosition: (_d, { index, target }) => [
+      d[0][index],
+      d[1][index],
+      props.use3d ? d[2]?.[index] || 0 : 0,
+    ],
+    getRadius: effectivePointSize,
+    ...(props.tileSubLayer
+      ? {
+          radiusMinPixels: props.pointRadiusMinPixels ?? DEFAULT_POINT_RADIUS_MIN_PIXELS,
+          radiusMaxPixels: props.pointRadiusMaxPixels ?? DEFAULT_POINT_RADIUS_MAX_PIXELS,
+        }
+      : {}),
+    radiusUnits: 'pixels',
+    getFillColor: props.color,
+    opacity: props.opacity,
+    modelMatrix: props.modelMatrix,
+    pickable: true,
+    autoHighlight: true,
+    highlightColor: [255, 255, 0, 200],
+    updateTriggers: {
+      getPosition: [pointCount, d[0], d[1], d[2]],
+      getRadius: [
+        props.pointSize,
+        props.viewZoom,
+        props.pointRadiusMinPixels,
+        props.pointRadiusMaxPixels,
+        props.pointMinSizeScale,
+      ],
+    },
+  });
+}

--- a/packages/layers/src/pointsTileDebug.ts
+++ b/packages/layers/src/pointsTileDebug.ts
@@ -1,0 +1,368 @@
+import type { SpatialBounds } from '@spatialdata/core';
+import type { PointsTileHandle, PointsTileLoadResult } from './pointsTileLoadCallbacks.js';
+
+export type PointsTileStatus =
+  | 'pending'
+  | 'loading'
+  | 'loaded'
+  | 'empty'
+  | 'error'
+  | 'aborted';
+
+export interface PointsTileLoadProgress {
+  inFlight: number;
+  loaded: number;
+  loadedPoints: number;
+  viewportTotal: number;
+}
+
+export interface PointsTileDebugEntry {
+  tileId: string;
+  index: { x: number; y: number; z: number };
+  bbox: SpatialBounds;
+  clippedBounds: SpatialBounds | null;
+  status: PointsTileStatus;
+  requestedAt: number;
+  startedAt?: number;
+  completedAt?: number;
+  pointCount?: number;
+  loadMode?: string;
+  errorMessage?: string;
+}
+
+export const POINTS_TILE_DEBUG_PICK_KIND = 'spatialdata-points-tile-debug' as const;
+
+export interface PointsTileDebugPickObject {
+  kind: typeof POINTS_TILE_DEBUG_PICK_KIND;
+  entry: PointsTileDebugEntry;
+}
+
+export function isPointsTileDebugPickObject(
+  value: unknown
+): value is PointsTileDebugPickObject {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<PointsTileDebugPickObject>;
+  return candidate.kind === POINTS_TILE_DEBUG_PICK_KIND && candidate.entry != null;
+}
+
+export interface PointsTileCompletedSnapshot {
+  status: PointsTileStatus;
+  pointCount?: number;
+  loadMode?: string;
+  clippedBounds: SpatialBounds | null;
+  errorMessage?: string;
+  startedAt?: number;
+  completedAt: number;
+}
+
+export interface PointsTileDebugViewportContext {
+  loadingTileIds: ReadonlySet<string>;
+  completedTilesById: ReadonlyMap<string, PointsTileCompletedSnapshot>;
+  tileHandlesById: ReadonlyMap<string, PointsTileHandle>;
+}
+
+export type PointsTileDebugEvent =
+  | {
+      type: 'viewport';
+      tiles: readonly PointsTileHandle[];
+      at: number;
+      context: PointsTileDebugViewportContext;
+    }
+  | { type: 'start'; tile: PointsTileHandle; at: number }
+  | {
+      type: 'end';
+      tile: PointsTileHandle;
+      result: PointsTileLoadResult;
+      at: number;
+      clipBounds: SpatialBounds;
+    };
+
+export function completedSnapshotFromLoadResult(
+  result: PointsTileLoadResult,
+  clipBounds: SpatialBounds,
+  completedAt: number,
+  startedAt?: number
+): PointsTileCompletedSnapshot {
+  let status: PointsTileStatus = 'error';
+  if (result.aborted) {
+    status = 'aborted';
+  } else if (result.success) {
+    status = (result.pointCount ?? 0) > 0 ? 'loaded' : 'empty';
+  }
+
+  return {
+    status,
+    pointCount: result.pointCount,
+    loadMode: result.loadMode,
+    clippedBounds: result.clippedBounds ?? clipBounds,
+    errorMessage: result.errorMessage,
+    startedAt,
+    completedAt,
+  };
+}
+
+function resolveViewportTileStatus(
+  tileId: string,
+  existing: PointsTileDebugEntry | undefined,
+  context: PointsTileDebugViewportContext
+): PointsTileStatus {
+  if (context.loadingTileIds.has(tileId)) {
+    return 'loading';
+  }
+  const completed = context.completedTilesById.get(tileId);
+  if (completed) {
+    return completed.status;
+  }
+  if (existing?.status === 'loaded' || existing?.status === 'empty') {
+    return existing.status;
+  }
+  return 'pending';
+}
+
+function applyCompletedSnapshot(
+  entry: PointsTileDebugEntry,
+  completed: PointsTileCompletedSnapshot
+): PointsTileDebugEntry {
+  return {
+    ...entry,
+    status: completed.status,
+    clippedBounds: completed.clippedBounds,
+    pointCount: completed.pointCount,
+    loadMode: completed.loadMode,
+    errorMessage: completed.errorMessage,
+    startedAt: completed.startedAt ?? entry.startedAt,
+    completedAt: completed.completedAt,
+  };
+}
+
+export function reduceTileDebugEntries(
+  previous: readonly PointsTileDebugEntry[],
+  event: PointsTileDebugEvent
+): PointsTileDebugEntry[] {
+  const byId = new Map(previous.map((entry) => [entry.tileId, entry]));
+
+  if (event.type === 'viewport') {
+    const tileHandlesById = new Map(event.context.tileHandlesById);
+    for (const tile of event.tiles) {
+      tileHandlesById.set(tile.tileId, tile);
+    }
+    const activeTileIds = new Set<string>([
+      ...event.tiles.map((tile) => tile.tileId),
+      ...event.context.loadingTileIds,
+      ...event.context.completedTilesById.keys(),
+    ]);
+    const next = new Map<string, PointsTileDebugEntry>();
+    for (const tileId of activeTileIds) {
+      const tile = tileHandlesById.get(tileId);
+      if (!tile) {
+        continue;
+      }
+      const rawBounds = boundsFromHandle(tile);
+      const existing = byId.get(tile.tileId);
+      const completed = event.context.completedTilesById.get(tile.tileId);
+      const status = resolveViewportTileStatus(tile.tileId, existing, event.context);
+      let entry: PointsTileDebugEntry = {
+        tileId: tile.tileId,
+        index: tile.index,
+        bbox: rawBounds,
+        clippedBounds: existing?.clippedBounds ?? completed?.clippedBounds ?? null,
+        status,
+        requestedAt: existing?.requestedAt ?? event.at,
+        startedAt: existing?.startedAt ?? completed?.startedAt,
+        completedAt: existing?.completedAt ?? completed?.completedAt,
+        pointCount: existing?.pointCount ?? completed?.pointCount,
+        loadMode: existing?.loadMode ?? completed?.loadMode,
+        errorMessage: existing?.errorMessage ?? completed?.errorMessage,
+      };
+      if (completed && (status === 'loaded' || status === 'empty' || status === 'error' || status === 'aborted')) {
+        entry = applyCompletedSnapshot(entry, completed);
+      }
+      next.set(tile.tileId, entry);
+    }
+    return [...next.values()];
+  }
+
+  if (event.type === 'start') {
+    const rawBounds = boundsFromHandle(event.tile);
+    const existing = byId.get(event.tile.tileId);
+    byId.set(event.tile.tileId, {
+      tileId: event.tile.tileId,
+      index: event.tile.index,
+      bbox: rawBounds,
+      clippedBounds: existing?.clippedBounds ?? null,
+      status: 'loading',
+      requestedAt: existing?.requestedAt ?? event.at,
+      startedAt: event.at,
+      completedAt: undefined,
+      pointCount: undefined,
+      loadMode: undefined,
+      errorMessage: undefined,
+    });
+    return [...byId.values()];
+  }
+
+  const rawBounds = boundsFromHandle(event.tile);
+  const { result } = event;
+  const snapshot = completedSnapshotFromLoadResult(
+    result,
+    event.clipBounds,
+    event.at,
+    byId.get(event.tile.tileId)?.startedAt ?? event.at
+  );
+
+  byId.set(event.tile.tileId, {
+    tileId: event.tile.tileId,
+    index: event.tile.index,
+    bbox: rawBounds,
+    clippedBounds: snapshot.clippedBounds,
+    status: snapshot.status,
+    requestedAt: byId.get(event.tile.tileId)?.requestedAt ?? event.at,
+    startedAt: snapshot.startedAt,
+    completedAt: snapshot.completedAt,
+    pointCount: snapshot.pointCount,
+    loadMode: snapshot.loadMode,
+    errorMessage: snapshot.errorMessage,
+  });
+  return [...byId.values()];
+}
+
+function boundsFromHandle(tile: PointsTileHandle): SpatialBounds {
+  const { bbox } = tile;
+  return {
+    minX: Math.min(bbox.left, bbox.right),
+    maxX: Math.max(bbox.left, bbox.right),
+    minY: Math.min(bbox.top, bbox.bottom),
+    maxY: Math.max(bbox.top, bbox.bottom),
+  };
+}
+
+export interface PointsTileDebugPolygonDatum {
+  polygon: [number, number][];
+  entry: PointsTileDebugEntry;
+}
+
+export function pointsTileDebugPolygonData(
+  entries: readonly PointsTileDebugEntry[]
+): PointsTileDebugPolygonDatum[] {
+  return entries.map((entry) => {
+    const bounds = entry.clippedBounds ?? entry.bbox;
+    const { minX, minY, maxX, maxY } = bounds;
+    return {
+      entry,
+      polygon: [
+        [minX, minY],
+        [maxX, minY],
+        [maxX, maxY],
+        [minX, maxY],
+      ],
+    };
+  });
+}
+
+function formatBounds(bounds: SpatialBounds): string {
+  return `[${bounds.minX.toFixed(1)}, ${bounds.minY.toFixed(1)}]–[${bounds.maxX.toFixed(1)}, ${bounds.maxY.toFixed(1)}]`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function formatPointsTileDebugTooltip(
+  entry: PointsTileDebugEntry,
+  batchProgress: PointsTileLoadProgress,
+  now = Date.now()
+): { title: string; items: Array<{ label: string; value: string }> } {
+  const items: Array<{ label: string; value: string }> = [
+    { label: 'tile', value: entry.tileId },
+    { label: 'status', value: entry.status },
+    {
+      label: 'batch',
+      value:
+        batchProgress.loadedPoints > 0
+          ? `${batchProgress.loaded}/${batchProgress.viewportTotal} (${batchProgress.inFlight} in flight, ${batchProgress.loadedPoints.toLocaleString()} points)`
+          : `${batchProgress.loaded}/${batchProgress.viewportTotal} (${batchProgress.inFlight} in flight)`,
+    },
+    { label: 'index', value: `x=${entry.index.x} y=${entry.index.y} z=${entry.index.z}` },
+    { label: 'bbox', value: formatBounds(entry.bbox) },
+  ];
+
+  if (entry.clippedBounds) {
+    items.push({ label: 'clipped', value: formatBounds(entry.clippedBounds) });
+  }
+  if (entry.startedAt !== undefined) {
+    if (entry.completedAt !== undefined) {
+      items.push({
+        label: 'duration',
+        value: formatDuration(entry.completedAt - entry.startedAt),
+      });
+    } else {
+      items.push({
+        label: 'elapsed',
+        value: formatDuration(now - entry.startedAt),
+      });
+    }
+  }
+  if (entry.pointCount !== undefined) {
+    items.push({ label: 'points', value: String(entry.pointCount) });
+  }
+  if (entry.loadMode) {
+    items.push({ label: 'load mode', value: entry.loadMode });
+  }
+  if (entry.errorMessage) {
+    items.push({ label: 'error', value: entry.errorMessage });
+  }
+
+  return {
+    title: `Tile ${entry.tileId}`,
+    items,
+  };
+}
+
+export function tileDebugStatusFillColor(
+  status: PointsTileStatus
+): [number, number, number, number] {
+  switch (status) {
+    case 'pending':
+      return [120, 120, 120, 30];
+    case 'loading':
+      return [255, 180, 0, 80];
+    case 'loaded':
+      return [80, 200, 80, 25];
+    case 'empty':
+      return [120, 160, 200, 35];
+    case 'error':
+      return [220, 60, 60, 70];
+    case 'aborted':
+      return [180, 80, 80, 45];
+  }
+}
+
+export function tileDebugStatusLineColor(
+  status: PointsTileStatus
+): [number, number, number, number] {
+  switch (status) {
+    case 'pending':
+      return [180, 180, 180, 180];
+    case 'loading':
+      return [255, 200, 0, 255];
+    case 'loaded':
+      return [80, 220, 80, 220];
+    case 'empty':
+      return [140, 180, 220, 220];
+    case 'error':
+      return [255, 80, 80, 255];
+    case 'aborted':
+      return [220, 120, 120, 220];
+  }
+}
+
+export function tileDebugEntriesSignature(entries: readonly PointsTileDebugEntry[]): string {
+  return entries
+    .map((entry) => `${entry.tileId}:${entry.status}:${entry.pointCount ?? ''}`)
+    .join('|');
+}

--- a/packages/layers/src/pointsTileLoadCallbacks.ts
+++ b/packages/layers/src/pointsTileLoadCallbacks.ts
@@ -1,0 +1,17 @@
+import type { SpatialBounds, PointsLoadMode } from '@spatialdata/core';
+import type { PointTileBbox } from './pointsBbox.js';
+
+export interface PointsTileHandle {
+  tileId: string;
+  index: { x: number; y: number; z: number };
+  bbox: PointTileBbox;
+}
+
+export interface PointsTileLoadResult {
+  success: boolean;
+  aborted?: boolean;
+  clippedBounds?: SpatialBounds | null;
+  pointCount?: number;
+  loadMode?: PointsLoadMode;
+  errorMessage?: string;
+}

--- a/packages/layers/src/pointsTiledDebugHooks.ts
+++ b/packages/layers/src/pointsTiledDebugHooks.ts
@@ -1,0 +1,179 @@
+import type { PointsTileHandle, PointsTileLoadResult } from './pointsTileLoadCallbacks.js';
+import {
+  completedSnapshotFromLoadResult,
+  reduceTileDebugEntries,
+  tileDebugEntriesSignature,
+  type PointsTileCompletedSnapshot,
+  type PointsTileDebugEntry,
+} from './pointsTileDebug.js';
+
+export interface TiledPointsDebugState {
+  tileDebugEntries: PointsTileDebugEntry[];
+  completedTilesById?: Record<string, PointsTileCompletedSnapshot>;
+  loadingTileIds?: string[];
+  lastViewportTiles?: readonly PointsTileHandle[];
+  tileHandlesById?: Record<string, PointsTileHandle>;
+}
+
+function rememberTileHandle(
+  state: TiledPointsDebugState,
+  tile: PointsTileHandle
+): Record<string, PointsTileHandle> {
+  return { ...(state.tileHandlesById ?? {}), [tile.tileId]: tile };
+}
+
+function rebuildActiveDebugEntries(
+  entries: readonly PointsTileDebugEntry[],
+  state: TiledPointsDebugState,
+  at: number
+): PointsTileDebugEntry[] {
+  return reduceTileDebugEntries(entries, {
+    type: 'viewport',
+    tiles: state.lastViewportTiles ?? [],
+    at,
+    context: {
+      loadingTileIds: new Set(state.loadingTileIds ?? []),
+      completedTilesById: new Map(Object.entries(state.completedTilesById ?? {})),
+      tileHandlesById: new Map(Object.entries(state.tileHandlesById ?? {})),
+    },
+  });
+}
+
+export interface TileDebugStore {
+  getState(): TiledPointsDebugState;
+  update(updater: (state: TiledPointsDebugState) => TiledPointsDebugState): void;
+}
+
+function emptyDebugState(): TiledPointsDebugState {
+  return { tileDebugEntries: [], completedTilesById: {}, loadingTileIds: [], tileHandlesById: {} };
+}
+
+function debugStateSignature(state: TiledPointsDebugState): string {
+  const completedKeys = Object.keys(state.completedTilesById ?? {})
+    .sort()
+    .join(',');
+  const loadingKeys = [...(state.loadingTileIds ?? [])].sort().join(',');
+  const handleKeys = Object.keys(state.tileHandlesById ?? {})
+    .sort()
+    .join(',');
+  return `${tileDebugEntriesSignature(state.tileDebugEntries)}|${loadingKeys}|${completedKeys}|${handleKeys}`;
+}
+
+export function createTileDebugStore(onChange?: () => void): TileDebugStore {
+  let state = emptyDebugState();
+  return {
+    getState() {
+      return state;
+    },
+    update(updater) {
+      const next = updater(state);
+      if (debugStateSignature(state) === debugStateSignature(next)) {
+        return;
+      }
+      state = next;
+      onChange?.();
+    },
+  };
+}
+
+export function createTiledPointsDebugHooks(store: TileDebugStore | undefined) {
+  if (!store) {
+    return {
+      onViewportTilesRequested(_tiles: readonly PointsTileHandle[]) {},
+      onTileLoadStart(_tile: PointsTileHandle) {},
+      onTileLoadEnd(
+        _tile: PointsTileHandle,
+        _result: PointsTileLoadResult,
+        _clipBounds: { minX: number; minY: number; maxX: number; maxY: number }
+      ) {},
+      getTileDebugEntries(): PointsTileDebugEntry[] {
+        return [];
+      },
+      getTileDebugSignature(): string {
+        return '';
+      },
+    };
+  }
+
+  return {
+    onViewportTilesRequested(tiles: readonly PointsTileHandle[]) {
+      store.update((state) => {
+        const at = Date.now();
+        const tileHandlesById = { ...(state.tileHandlesById ?? {}) };
+        for (const tile of tiles) {
+          tileHandlesById[tile.tileId] = tile;
+        }
+        const nextState: TiledPointsDebugState = {
+          ...state,
+          lastViewportTiles: tiles,
+          tileHandlesById,
+        };
+        return {
+          ...nextState,
+          tileDebugEntries: rebuildActiveDebugEntries(state.tileDebugEntries, nextState, at),
+        };
+      });
+    },
+    onTileLoadStart(tile: PointsTileHandle) {
+      store.update((state) => {
+        const at = Date.now();
+        const nextState: TiledPointsDebugState = {
+          ...state,
+          tileHandlesById: rememberTileHandle(state, tile),
+          loadingTileIds: [...new Set([...(state.loadingTileIds ?? []), tile.tileId])],
+          completedTilesById: Object.fromEntries(
+            Object.entries(state.completedTilesById ?? {}).filter(
+              ([tileId]) => tileId !== tile.tileId
+            )
+          ),
+        };
+        const afterStart = reduceTileDebugEntries(state.tileDebugEntries, {
+          type: 'start',
+          tile,
+          at,
+        });
+        return {
+          ...nextState,
+          tileDebugEntries: rebuildActiveDebugEntries(afterStart, nextState, at),
+        };
+      });
+    },
+    onTileLoadEnd(
+      tile: PointsTileHandle,
+      result: PointsTileLoadResult,
+      clipBounds: { minX: number; minY: number; maxX: number; maxY: number }
+    ) {
+      const at = Date.now();
+      store.update((state) => {
+        const loadingTileIds = (state.loadingTileIds ?? []).filter(
+          (tileId) => tileId !== tile.tileId
+        );
+        const completedTilesById = { ...(state.completedTilesById ?? {}) };
+        const startedAt =
+          state.tileDebugEntries.find((entry) => entry.tileId === tile.tileId)?.startedAt ?? at;
+        completedTilesById[tile.tileId] = completedSnapshotFromLoadResult(
+          result,
+          clipBounds,
+          at,
+          startedAt
+        );
+        const nextState: TiledPointsDebugState = {
+          ...state,
+          tileHandlesById: rememberTileHandle(state, tile),
+          loadingTileIds,
+          completedTilesById,
+        };
+        return {
+          ...nextState,
+          tileDebugEntries: rebuildActiveDebugEntries(state.tileDebugEntries, nextState, at),
+        };
+      });
+    },
+    getTileDebugEntries(): PointsTileDebugEntry[] {
+      return store.getState().tileDebugEntries;
+    },
+    getTileDebugSignature(): string {
+      return tileDebugEntriesSignature(store.getState().tileDebugEntries);
+    },
+  };
+}

--- a/packages/layers/src/preloadedScatterStrategy.ts
+++ b/packages/layers/src/preloadedScatterStrategy.ts
@@ -57,7 +57,11 @@ export const preloadedScatterStrategy: PointsRenderStrategy = {
       return null;
     }
 
-    return renderColumnarScatterLayer(layer.props.id, batch, {
+    // Namespace the sublayer id via the composite's sublayer-props helper.
+    // Passing layer.props.id raw makes the ScatterplotLayer collide with its
+    // parent PointsLayer id (deck asserts on every frame). The morton strategy
+    // already derives `${id}-scatter`; do the same here.
+    return renderColumnarScatterLayer(`${layer.props.id}-scatter`, batch, {
       color,
       pointSize,
       pointRadiusMinPixels,

--- a/packages/layers/src/preloadedScatterStrategy.ts
+++ b/packages/layers/src/preloadedScatterStrategy.ts
@@ -1,0 +1,72 @@
+import { applyRenderCapToColumnar } from '@spatialdata/core';
+import type { Layer, LayersList } from 'deck.gl';
+import type { PointsLayer } from './PointsLayer.js';
+import type { PointsRenderStrategy } from './pointsRenderStrategies.js';
+import { featureFilterAwaitingRowCodes, filterBatchSignature } from './pointsFeatureCodes.js';
+import {
+  DEFAULT_POINT_SIZE,
+  renderColumnarScatterLayer,
+} from './pointsScatterLayer.js';
+import type { ColumnarNdarrayPointsBatch } from './pointsLoader.js';
+
+function resolveScatterBatch(layer: PointsLayer): ColumnarNdarrayPointsBatch | undefined {
+  const { featureCodes, preloadedFeatureCodes, renderCap } = layer.props;
+  const state = layer.state as {
+    preloadedBatch?: ColumnarNdarrayPointsBatch;
+    filteredBatch?: ColumnarNdarrayPointsBatch;
+    filteredBatchSignature?: string;
+  };
+  const signature = filterBatchSignature(featureCodes, preloadedFeatureCodes, renderCap);
+  const awaitingRowCodes = featureFilterAwaitingRowCodes(featureCodes, preloadedFeatureCodes);
+  if (awaitingRowCodes) {
+    if (!state.preloadedBatch) {
+      return undefined;
+    }
+    return applyRenderCapToColumnar(state.preloadedBatch, renderCap);
+  }
+  if (state.filteredBatch && state.filteredBatchSignature === signature) {
+    return state.filteredBatch;
+  }
+  if (!state.preloadedBatch) {
+    return undefined;
+  }
+  return applyRenderCapToColumnar(state.preloadedBatch, renderCap);
+}
+
+export const preloadedScatterStrategy: PointsRenderStrategy = {
+  renderLayers(layer): Layer | null | LayersList {
+    const {
+      resource,
+      opacity = 1,
+      visible = true,
+      pointSize = DEFAULT_POINT_SIZE,
+      pointRadiusMinPixels,
+      pointRadiusMaxPixels,
+      pointMinSizeScale,
+      viewZoom,
+      color = [255, 100, 100, 200],
+      use3d,
+    } = layer.props;
+
+    if (!visible) {
+      return null;
+    }
+
+    const batch = resolveScatterBatch(layer);
+    if (!batch) {
+      return null;
+    }
+
+    return renderColumnarScatterLayer(layer.props.id, batch, {
+      color,
+      pointSize,
+      pointRadiusMinPixels,
+      pointRadiusMaxPixels,
+      pointMinSizeScale,
+      viewZoom,
+      opacity,
+      modelMatrix: layer.props.modelMatrix,
+      use3d,
+    });
+  },
+};

--- a/packages/layers/src/resolvePointsRenderResource.ts
+++ b/packages/layers/src/resolvePointsRenderResource.ts
@@ -1,0 +1,62 @@
+import {
+  createPointsLoaderForElement,
+  type PointsElement,
+  type PointsTilingMetadata,
+} from '@spatialdata/core';
+import { createPointsRenderResource } from './pointsLoaderAdapter.js';
+import type { PointsRenderResource } from './pointsLoader.js';
+
+export interface ResolvePointsRenderResourceCache {
+  preloaded?: { shape: number[]; data: ArrayLike<number>[] } | null;
+  tilingMetadata?: PointsTilingMetadata | null;
+  metadataKnown?: boolean;
+}
+
+export interface ResolvePointsRenderResourceOptions {
+  experimentalOptimizations: 'auto' | 'off';
+}
+
+export function resolvePointsRenderResource(
+  element: PointsElement,
+  cache: ResolvePointsRenderResourceCache,
+  options: ResolvePointsRenderResourceOptions
+): PointsRenderResource | null {
+  const wantsOptimized = options.experimentalOptimizations !== 'off';
+  const canTile =
+    wantsOptimized &&
+    cache.metadataKnown &&
+    cache.tilingMetadata?.supportsRowGroupRangeReads &&
+    cache.tilingMetadata.bounds;
+
+  const loader = createPointsLoaderForElement(element, {
+    preloaded: cache.preloaded ?? null,
+    tilingMetadata: canTile ? cache.tilingMetadata : null,
+    wantsOptimized,
+  });
+
+  if (!loader) {
+    return null;
+  }
+
+  return createPointsRenderResource(element, loader);
+}
+
+export function pointsRenderResourceSignature(
+  element: PointsElement,
+  cache: ResolvePointsRenderResourceCache,
+  options: ResolvePointsRenderResourceOptions & { preloadCacheKey?: string }
+): string {
+  const rowCount =
+    cache.preloaded && cache.preloaded.shape.length >= 2
+      ? cache.preloaded.shape[1]
+      : cache.preloaded?.data[0]?.length ?? 0;
+  return [
+    element.key,
+    options.preloadCacheKey ?? '',
+    options.experimentalOptimizations,
+    cache.metadataKnown ? 'meta' : 'nometa',
+    cache.tilingMetadata?.parquetPath ?? '',
+    cache.tilingMetadata?.supportsRowGroupRangeReads ? 'rg' : '',
+    cache.preloaded ? `pre:${rowCount}` : 'nopre',
+  ].join('|');
+}

--- a/packages/layers/tests/pointsDataEngine.spec.ts
+++ b/packages/layers/tests/pointsDataEngine.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PointsDataEngine } from '../src/engine/PointsDataEngine.js';
+import type { PointsElement, PointsLoadResult } from '@spatialdata/core';
+
+function makeBatch(): PointsLoadResult {
+  return {
+    shape: [3, 2],
+    data: [new Float32Array([0, 1, 2]), new Float32Array([0, 1, 2])],
+  };
+}
+
+/** Minimal PointsElement stub: only `key` and `loadPoints` are exercised by the
+ * preloaded path. `loadPoints` is a spy so we can assert idempotent loading. */
+function makeElement(key: string, batch = makeBatch()) {
+  const loadPoints = vi.fn(async () => batch);
+  return { element: { key, loadPoints } as unknown as PointsElement, loadPoints };
+}
+
+describe('PointsDataEngine', () => {
+  it('loads once, reports status, and caches the batch', async () => {
+    const statuses: Array<[string, string]> = [];
+    const engine = new PointsDataEngine({
+      onStatus: (layerId, status) => statuses.push([layerId, status]),
+    });
+    const { element } = makeElement('pts:a');
+
+    expect(engine.hasData('pts:a')).toBe(false);
+    expect(engine.getStatus('pts:a')).toBe('idle');
+
+    await engine.ensureLoaded({ key: 'pts:a', layerId: 'layer-a', element });
+
+    expect(engine.hasData('pts:a')).toBe(true);
+    expect(engine.getStatus('pts:a')).toBe('ready');
+    expect(engine.getData('pts:a')?.data[0]).toHaveLength(3);
+    expect(statuses).toEqual([
+      ['layer-a', 'loading'],
+      ['layer-a', 'ready'],
+    ]);
+  });
+
+  it('is idempotent: concurrent loads trigger a single loadPoints', async () => {
+    const engine = new PointsDataEngine();
+    const { element, loadPoints } = makeElement('pts:b');
+
+    const p1 = engine.ensureLoaded({ key: 'pts:b', layerId: 'l', element });
+    const p2 = engine.ensureLoaded({ key: 'pts:b', layerId: 'l', element });
+    await Promise.all([p1, p2]);
+    // A third call after settle is a no-op too.
+    await engine.ensureLoaded({ key: 'pts:b', layerId: 'l', element });
+
+    expect(loadPoints).toHaveBeenCalledTimes(1);
+  });
+
+  it('memoizes a stable render resource (the pan-flash guard)', async () => {
+    const engine = new PointsDataEngine();
+    const { element } = makeElement('pts:c');
+
+    expect(engine.getResource(element, 'pts:c')).toBeNull(); // no data yet
+    await engine.ensureLoaded({ key: 'pts:c', layerId: 'l', element });
+
+    const r1 = engine.getResource(element, 'pts:c');
+    const r2 = engine.getResource(element, 'pts:c');
+    expect(r1).toBeTruthy();
+    // Same identity across calls: a fresh loader each render would reset the
+    // composite and blank the layer for a frame.
+    expect(r1).toBe(r2);
+    expect(r1?.loader).toBe(r2?.loader);
+  });
+
+  it('reports error status when loadPoints rejects', async () => {
+    const statuses: string[] = [];
+    const engine = new PointsDataEngine({ onStatus: (_l, s) => statuses.push(s) });
+    const element = {
+      key: 'pts:d',
+      loadPoints: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    } as unknown as PointsElement;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await engine.ensureLoaded({ key: 'pts:d', layerId: 'l', element });
+
+    expect(engine.getStatus('pts:d')).toBe('error');
+    expect(engine.hasData('pts:d')).toBe(false);
+    expect(statuses).toEqual(['loading', 'error']);
+    errSpy.mockRestore();
+  });
+
+  it('evict clears cached data and resource', async () => {
+    const engine = new PointsDataEngine();
+    const { element } = makeElement('pts:e');
+    await engine.ensureLoaded({ key: 'pts:e', layerId: 'l', element });
+    expect(engine.getResource(element, 'pts:e')).toBeTruthy();
+
+    engine.evict('pts:e');
+
+    expect(engine.hasData('pts:e')).toBe(false);
+    expect(engine.getResource(element, 'pts:e')).toBeNull();
+  });
+
+  it('notifies subscribers when a load settles', async () => {
+    const engine = new PointsDataEngine();
+    const { element } = makeElement('pts:f');
+    const listener = vi.fn();
+    const unsubscribe = engine.subscribe(listener);
+
+    await engine.ensureLoaded({ key: 'pts:f', layerId: 'l', element });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    engine.evict('pts:f');
+    await engine.ensureLoaded({ key: 'pts:f', layerId: 'l', element });
+    expect(listener).toHaveBeenCalledTimes(1); // no longer subscribed
+  });
+});

--- a/packages/layers/tests/pointsLayerFilter.spec.ts
+++ b/packages/layers/tests/pointsLayerFilter.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  featureCodesSignature,
+  featureFilterAwaitingRowCodes,
+  hasPreloadedRowFeatureCodes,
+} from '../src/pointsFeatureCodes.js';
+import { filterPreloadedBatch } from '../src/PointsLayer.js';
+import type { ColumnarNdarrayPointsBatch } from '../src/pointsLoader.js';
+
+describe('PointsLayer preloaded filtering', () => {
+  const batch: ColumnarNdarrayPointsBatch = {
+    format: 'columnar-ndarray',
+    shape: [2, 4],
+    data: [Float32Array.from([0, 1, 2, 3]), Float32Array.from([10, 11, 12, 13])],
+    pointCount: 4,
+  };
+
+  it('builds stable feature code signatures', () => {
+    expect(featureCodesSignature(undefined)).toBe('all');
+    expect(featureCodesSignature([])).toBe('none');
+    expect(featureCodesSignature([2, 0, 1])).toBe('0,1,2');
+  });
+
+  it('keeps the preloaded batch visible while row feature codes are still loading', async () => {
+    const filtered = await filterPreloadedBatch(batch, [1], undefined);
+    expect(filtered.pointCount).toBe(4);
+    expect(filtered.data[0].length).toBe(4);
+  });
+
+  it('treats empty row feature code arrays as still loading', async () => {
+    expect(hasPreloadedRowFeatureCodes(undefined)).toBe(false);
+    expect(hasPreloadedRowFeatureCodes(new Int32Array(0))).toBe(false);
+    expect(featureFilterAwaitingRowCodes([1], new Int32Array(0))).toBe(true);
+
+    const filtered = await filterPreloadedBatch(batch, [1], new Int32Array(0));
+    expect(filtered.pointCount).toBe(4);
+    expect(filtered.data[0].length).toBe(4);
+  });
+
+  it('returns an empty batch when all features are deselected without row codes', async () => {
+    const filtered = await filterPreloadedBatch(batch, [], undefined);
+    expect(filtered.pointCount).toBe(0);
+    expect(filtered.data[0].length).toBe(0);
+  });
+
+  it('returns an empty batch when all features are deselected', async () => {
+    const sourceFeatureCodes = Int32Array.from([0, 1, 0, 2]);
+    const filtered = await filterPreloadedBatch(batch, [], sourceFeatureCodes);
+    expect(filtered.pointCount).toBe(0);
+    expect(filtered.data[0].length).toBe(0);
+  });
+
+  it('filters preloaded batches by feature codes', async () => {
+    const sourceFeatureCodes = Int32Array.from([0, 1, 0, 2]);
+    const filtered = await filterPreloadedBatch(batch, [1], sourceFeatureCodes);
+    expect(filtered.pointCount).toBe(1);
+    expect(filtered.data[0][0]).toBe(1);
+    expect(filtered.data[1][0]).toBe(11);
+  });
+});

--- a/packages/layers/tests/pointsLoadPlan.spec.ts
+++ b/packages/layers/tests/pointsLoadPlan.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PointsTilingMetadata } from '@spatialdata/core';
+
+import {
+  planPointsLoads,
+  pointsPreloadCacheKey,
+  shouldLoadPointsRowFeatureCodes,
+  shouldPreloadAfterMetadataProbe,
+} from '../src/pointsLoadPlan.js';
+
+describe('planPointsLoads', () => {
+  it('schedules metadata probe only when optimized and metadata unknown', () => {
+    expect(
+      planPointsLoads({
+        wantsOptimized: true,
+        metadataKnown: false,
+        tiledMetadata: undefined,
+        hasPreloaded: false,
+      })
+    ).toEqual({ probeMetadata: true, preloadFullTable: false });
+  });
+
+  it('schedules preload when metadata known and non-tileable', () => {
+    expect(
+      planPointsLoads({
+        wantsOptimized: true,
+        metadataKnown: true,
+        tiledMetadata: null,
+        hasPreloaded: false,
+      })
+    ).toEqual({ probeMetadata: false, preloadFullTable: true });
+  });
+
+  it('schedules preload immediately when optimizations off', () => {
+    expect(
+      planPointsLoads({
+        wantsOptimized: false,
+        metadataKnown: false,
+        tiledMetadata: undefined,
+        hasPreloaded: false,
+      })
+    ).toEqual({ probeMetadata: false, preloadFullTable: true });
+  });
+
+  it('schedules probe only when Morton metadata is present', () => {
+    // planPointsLoads only checks tiledMetadata for presence; a minimal partial
+    // stands in for a full PointsTilingMetadata here.
+    const tiledMetadata = {
+      supportsRowGroupRangeReads: true,
+      bounds: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+    } as unknown as PointsTilingMetadata;
+    expect(
+      planPointsLoads({
+        wantsOptimized: true,
+        metadataKnown: true,
+        tiledMetadata,
+        hasPreloaded: false,
+      })
+    ).toEqual({ probeMetadata: false, preloadFullTable: false });
+  });
+});
+
+describe('pointsPreloadCacheKey', () => {
+  it('includes memory cap only (feature filter is runtime)', () => {
+    expect(
+      pointsPreloadCacheKey('points:transcripts', {
+        pointsMemoryCap: 1_000_000,
+      })
+    ).toBe('points:transcripts|m1000000');
+  });
+
+  it('uses default memory cap when unset', () => {
+    expect(pointsPreloadCacheKey('points:transcripts', {})).toMatch(/m\d+$/);
+  });
+});
+
+describe('shouldPreloadAfterMetadataProbe', () => {
+  it('requires preload after non-tileable probe result', () => {
+    expect(
+      shouldPreloadAfterMetadataProbe({
+        probeRan: true,
+        renderableMetadata: false,
+        hasPreloaded: false,
+      })
+    ).toBe(true);
+  });
+
+  it('skips preload when probe found renderable Morton metadata', () => {
+    expect(
+      shouldPreloadAfterMetadataProbe({
+        probeRan: true,
+        renderableMetadata: true,
+        hasPreloaded: false,
+      })
+    ).toBe(false);
+  });
+
+  it('skips preload when data already cached', () => {
+    expect(
+      shouldPreloadAfterMetadataProbe({
+        probeRan: true,
+        renderableMetadata: false,
+        hasPreloaded: true,
+      })
+    ).toBe(false);
+  });
+
+  it('skips preload when no probe ran', () => {
+    expect(
+      shouldPreloadAfterMetadataProbe({
+        probeRan: false,
+        renderableMetadata: false,
+        hasPreloaded: false,
+      })
+    ).toBe(false);
+  });
+
+  it('still requires preload after probe when row count exceeds the cap', () => {
+    expect(
+      shouldPreloadAfterMetadataProbe({
+        probeRan: true,
+        renderableMetadata: false,
+        hasPreloaded: false,
+        totalRows: 4_000_001,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('shouldLoadPointsRowFeatureCodes', () => {
+  it('does not load row codes before preloaded points exist', () => {
+    expect(
+      shouldLoadPointsRowFeatureCodes({
+        hasPreloaded: false,
+        hasCached: false,
+        inFlight: false,
+        featureCodes: [1],
+      })
+    ).toBe(false);
+  });
+
+  it('loads row codes once preload is ready, regardless of filter state', () => {
+    expect(
+      shouldLoadPointsRowFeatureCodes({
+        hasPreloaded: true,
+        hasCached: false,
+        inFlight: false,
+        featureCodes: undefined,
+      })
+    ).toBe(true);
+    expect(
+      shouldLoadPointsRowFeatureCodes({
+        hasPreloaded: true,
+        hasCached: false,
+        inFlight: false,
+        featureCodes: [],
+      })
+    ).toBe(true);
+    expect(
+      shouldLoadPointsRowFeatureCodes({
+        hasPreloaded: true,
+        hasCached: false,
+        inFlight: false,
+        featureCodes: [1, 2],
+      })
+    ).toBe(true);
+  });
+
+  it('skips row codes when cached or already in flight', () => {
+    expect(
+      shouldLoadPointsRowFeatureCodes({
+        hasPreloaded: true,
+        hasCached: true,
+        inFlight: false,
+        featureCodes: [1, 2],
+      })
+    ).toBe(false);
+    expect(
+      shouldLoadPointsRowFeatureCodes({
+        hasPreloaded: true,
+        hasCached: false,
+        inFlight: true,
+        featureCodes: [1, 2],
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/layers/tests/pointsRenderStrategies.spec.ts
+++ b/packages/layers/tests/pointsRenderStrategies.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePointsRenderStrategy } from '../src/pointsRenderStrategies.js';
+
+describe('resolvePointsRenderStrategy', () => {
+  it('selects morton and preloaded strategies by encoding kind', () => {
+    expect(
+      resolvePointsRenderStrategy({
+        capabilities: {
+          kind: 'morton-tiled',
+          batchFormat: 'columnar-ndarray',
+          supportsViewportTiles: true,
+        },
+        loadInBounds: async () => null,
+      }).renderLayers
+    ).toBeTypeOf('function');
+
+    expect(
+      resolvePointsRenderStrategy({
+        capabilities: {
+          kind: 'preloaded-columnar',
+          batchFormat: 'columnar-ndarray',
+          supportsViewportTiles: false,
+        },
+        loadAll: async () => ({
+          format: 'columnar-ndarray',
+          data: [[0], [0]],
+          shape: [1],
+          pointCount: 1,
+        }),
+        loadInBounds: async () => null,
+      }).renderLayers
+    ).toBeTypeOf('function');
+  });
+});

--- a/packages/layers/tests/pointsRenderStrategies.spec.ts
+++ b/packages/layers/tests/pointsRenderStrategies.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { resolvePointsRenderStrategy } from '../src/pointsRenderStrategies.js';
+import { preloadedScatterStrategy } from '../src/preloadedScatterStrategy.js';
+import type { PointsLayer } from '../src/PointsLayer.js';
 
 describe('resolvePointsRenderStrategy', () => {
   it('selects morton and preloaded strategies by encoding kind', () => {
@@ -31,5 +33,33 @@ describe('resolvePointsRenderStrategy', () => {
         loadInBounds: async () => null,
       }).renderLayers
     ).toBeTypeOf('function');
+  });
+});
+
+describe('preloadedScatterStrategy sublayer id', () => {
+  // Regression: the preloaded strategy used to pass the composite's own id
+  // straight to its ScatterplotLayer sublayer. A sublayer sharing its parent
+  // composite's id makes deck.gl re-initialise an already-initialised layer
+  // (`assert(!this.internalState)`), flooding the console every frame. The
+  // sublayer id must be namespaced (`<compositeId>-scatter`), matching the
+  // morton strategy.
+  it('namespaces the scatter sublayer id below the composite id', () => {
+    const compositeId = 'points:transcripts';
+    const batch = {
+      format: 'columnar-ndarray' as const,
+      data: [new Float32Array([0, 1]), new Float32Array([0, 1])],
+      shape: [2, 2],
+      pointCount: 2,
+    };
+    const fakeLayer = {
+      props: { id: compositeId, visible: true },
+      state: { preloadedBatch: batch },
+    } as unknown as PointsLayer;
+
+    const result = preloadedScatterStrategy.renderLayers(fakeLayer);
+    const layer = (Array.isArray(result) ? result[0] : result) as { id: string } | null;
+    expect(layer).toBeTruthy();
+    expect(layer?.id).toBe(`${compositeId}-scatter`);
+    expect(layer?.id).not.toBe(compositeId);
   });
 });

--- a/packages/layers/tests/pointsTileDebug.spec.ts
+++ b/packages/layers/tests/pointsTileDebug.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  completedSnapshotFromLoadResult,
+  formatPointsTileDebugTooltip,
+  reduceTileDebugEntries,
+} from '../src/pointsTileDebug.js';
+
+const sampleTile = {
+  tileId: '1-2--1',
+  index: { x: 1, y: 2, z: -1 },
+  bbox: { left: 512, top: 1024, right: 1024, bottom: 512 },
+};
+
+const emptyViewportContext = {
+  loadingTileIds: new Set<string>(),
+  completedTilesById: new Map(),
+  tileHandlesById: new Map(),
+};
+
+const sampleTile2 = {
+  tileId: '3-4--1',
+  index: { x: 3, y: 4, z: -1 },
+  bbox: { left: 1536, top: 2048, right: 2048, bottom: 1536 },
+};
+
+describe('pointsTileDebug', () => {
+  it('transitions tile status through viewport, start, and end events', () => {
+    const at = 1_000;
+    let entries = reduceTileDebugEntries([], {
+      type: 'viewport',
+      tiles: [sampleTile],
+      at,
+      context: {
+        ...emptyViewportContext,
+        tileHandlesById: new Map([[sampleTile.tileId, sampleTile]]),
+      },
+    });
+    expect(entries[0]?.status).toBe('pending');
+
+    entries = reduceTileDebugEntries(entries, { type: 'start', tile: sampleTile, at: at + 10 });
+    expect(entries[0]?.status).toBe('loading');
+    expect(entries[0]?.startedAt).toBe(at + 10);
+
+    entries = reduceTileDebugEntries(entries, {
+      type: 'end',
+      tile: sampleTile,
+      at: at + 100,
+      clipBounds: { minX: 512, minY: 512, maxX: 1024, maxY: 1024 },
+      result: { success: true, pointCount: 42, loadMode: 'row-groups' },
+    });
+    expect(entries[0]?.status).toBe('loaded');
+    expect(entries[0]?.pointCount).toBe(42);
+    expect(entries[0]?.completedAt).toBe(at + 100);
+  });
+
+  it('restores completed tiles after they re-enter the viewport', () => {
+    const at = 1_000;
+    const completedTilesById = new Map([
+      [
+        sampleTile.tileId,
+        completedSnapshotFromLoadResult(
+          { success: true, pointCount: 42, loadMode: 'row-groups' },
+          { minX: 512, minY: 512, maxX: 1024, maxY: 1024 },
+          at + 100,
+          at + 10
+        ),
+      ],
+    ]);
+
+    const entries = reduceTileDebugEntries([], {
+      type: 'viewport',
+      tiles: [sampleTile],
+      at: at + 200,
+      context: {
+        loadingTileIds: new Set(),
+        completedTilesById,
+        tileHandlesById: new Map([[sampleTile.tileId, sampleTile]]),
+      },
+    });
+
+    expect(entries[0]?.status).toBe('loaded');
+    expect(entries[0]?.pointCount).toBe(42);
+  });
+
+  it('includes loading and completed tiles not reported in the latest viewport event', () => {
+    const at = 1_000;
+    const completedTilesById = new Map([
+      [
+        sampleTile2.tileId,
+        completedSnapshotFromLoadResult(
+          { success: true, pointCount: 99, loadMode: 'row-groups' },
+          { minX: 1536, minY: 1536, maxX: 2048, maxY: 2048 },
+          at + 50,
+          at + 10
+        ),
+      ],
+    ]);
+
+    const entries = reduceTileDebugEntries([], {
+      type: 'viewport',
+      tiles: [sampleTile],
+      at: at + 100,
+      context: {
+        loadingTileIds: new Set([sampleTile.tileId]),
+        completedTilesById,
+        tileHandlesById: new Map([
+          [sampleTile.tileId, sampleTile],
+          [sampleTile2.tileId, sampleTile2],
+        ]),
+      },
+    });
+
+    expect(entries.map((entry) => entry.tileId).sort()).toEqual(
+      [sampleTile.tileId, sampleTile2.tileId].sort()
+    );
+    expect(entries.find((entry) => entry.tileId === sampleTile.tileId)?.status).toBe('loading');
+    expect(entries.find((entry) => entry.tileId === sampleTile2.tileId)?.pointCount).toBe(99);
+  });
+
+  it('formats tooltip with elapsed time for in-flight tiles', () => {
+    const tooltip = formatPointsTileDebugTooltip(
+      {
+        tileId: sampleTile.tileId,
+        index: sampleTile.index,
+        bbox: { minX: 512, minY: 512, maxX: 1024, maxY: 1024 },
+        clippedBounds: null,
+        status: 'loading',
+        requestedAt: 1_000,
+        startedAt: 1_500,
+      },
+      { inFlight: 1, loaded: 0, loadedPoints: 0, viewportTotal: 3 },
+      2_000
+    );
+    expect(tooltip.items.some((item) => item.label === 'elapsed' && item.value === '500ms')).toBe(
+      true
+    );
+  });
+});

--- a/packages/layers/tests/resolvePointsRenderResource.spec.ts
+++ b/packages/layers/tests/resolvePointsRenderResource.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { pointsRenderResourceSignature } from '../src/resolvePointsRenderResource.js';
+
+describe('pointsRenderResourceSignature', () => {
+  it('changes when preload or metadata inputs change', () => {
+    const element = { key: 'transcripts' } as { key: string };
+    const base = pointsRenderResourceSignature(
+      element as never,
+      { metadataKnown: true, tilingMetadata: null, preloaded: null },
+      { experimentalOptimizations: 'auto' }
+    );
+    const withPreload = pointsRenderResourceSignature(
+      element as never,
+      {
+        metadataKnown: true,
+        tilingMetadata: null,
+        preloaded: { shape: [2, 100], data: [new Float32Array(100), new Float32Array(100)] },
+      },
+      { experimentalOptimizations: 'auto', preloadCacheKey: 'points:transcripts|m4000000|fall' }
+    );
+    const withMoreRows = pointsRenderResourceSignature(
+      element as never,
+      {
+        metadataKnown: true,
+        tilingMetadata: null,
+        preloaded: { shape: [2, 200], data: [new Float32Array(200), new Float32Array(200)] },
+      },
+      { experimentalOptimizations: 'auto', preloadCacheKey: 'points:transcripts|m4000000|fall' }
+    );
+    expect(base).not.toEqual(withPreload);
+    expect(withPreload).not.toEqual(withMoreRows);
+  });
+});

--- a/packages/layers/vite.config.ts
+++ b/packages/layers/vite.config.ts
@@ -26,7 +26,14 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['@deck.gl/core', '@hms-dbmi/viv', '@math.gl/core', 'deck.gl', 'zod'],
+      external: [
+        '@deck.gl/core',
+        '@hms-dbmi/viv',
+        '@math.gl/core',
+        '@spatialdata/core',
+        'deck.gl',
+        'zod',
+      ],
     },
   },
   test: {

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -824,6 +824,31 @@ function SpatialCanvasInner({
                     }
                   />
                 </label>
+                {selectedConfig.type === 'points' && (
+                  <label
+                    style={{
+                      color: '#ccc',
+                      fontSize: '12px',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 4,
+                    }}
+                  >
+                    Point size ({(selectedConfig.pointSize ?? 1).toFixed(1)} px)
+                    <input
+                      type="range"
+                      min={0.1}
+                      max={12}
+                      step={0.1}
+                      value={selectedConfig.pointSize ?? 1}
+                      onChange={(e) =>
+                        actions.updateLayer(selectedConfig.id, {
+                          pointSize: Number(e.target.value),
+                        })
+                      }
+                    />
+                  </label>
+                )}
                 {selectedLayerLoadState && (
                   <div
                     style={{

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -834,7 +834,7 @@ function SpatialCanvasInner({
                       gap: 4,
                     }}
                   >
-                    Point size ({(selectedConfig.pointSize ?? 1).toFixed(1)} px)
+                    Point size ({(selectedConfig.pointSize ?? 1).toFixed(1)})
                     <input
                       type="range"
                       min={0.1}

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -529,12 +529,24 @@ function SpatialCanvasInner({
         : undefined;
   const selectedLayerLoadState = getLayerLoadState(selectedConfig?.id);
 
+  // The resource whose readiness means the layer has centerable geometry:
+  // image/labels are raster (image status); shapes/points are geometry.
+  const selectedLayerReadyResource =
+    selectedConfig?.type === 'image' || selectedConfig?.type === 'labels'
+      ? selectedLayerLoadState?.image
+      : selectedLayerLoadState?.geometry;
+
   const selectedLayerCanCenter =
     !!selectedConfig?.id &&
     selectedConfig.visible &&
     vw > 0 &&
     vh > 0 &&
-    hasRenderableLayerData(selectedConfig.id);
+    // Gate on the reactive load-state (not just `hasRenderableLayerData`, which
+    // reads an imperatively-mutated ref cache): a ref mutation does not trigger a
+    // re-render, so relying on it alone leaves this button stale-disabled until an
+    // unrelated re-render recomputes it. `selectedLayerLoadState` is real state and
+    // flips to 'ready' in lockstep with the load, so the button enables immediately.
+    (selectedLayerReadyResource === 'ready' || hasRenderableLayerData(selectedConfig.id));
 
   // TODO: include extra annotation columns carried by the shapes element itself,
   // not just associated table obs columns. Longer term, expose entries

--- a/packages/vis/src/SpatialCanvas/renderers/pointsRenderer.ts
+++ b/packages/vis/src/SpatialCanvas/renderers/pointsRenderer.ts
@@ -19,8 +19,9 @@ export interface PointDataX {
 // not that we wouldn't also want to be able to have other data & accessors
 export interface PointData {
   shape: number[];
-  // this should most definitely be TypedArray...
-  data: number[][];
+  // Columns may be plain arrays or TypedArrays; the core loader now returns
+  // ArrayLike columns (PointsLoadResult), so keep this widened to match.
+  data: ArrayLike<number>[];
 }
 
 export interface PointsLayerRenderConfig {

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -44,6 +44,7 @@ import {
 import {
   EMPTY_SHAPE_FEATURE_STATE_RUNTIME,
   PointsLayer,
+  type PointsRenderResource,
   type ShapeFeatureRenderDatum,
   type ShapeFeatureStateRuntime,
   type ShapeFillColorMode,
@@ -51,6 +52,7 @@ import {
   buildShapeFeatureStateRuntime,
   buildShapeFillColorByFeatureId,
   buildShapesPrebuiltData,
+  pointsRenderResourceSignature,
   resolvePointsRenderResource,
   resolveShapeFeatureFromPick,
   resolveShapeTooltipFromPickInfo,
@@ -486,6 +488,15 @@ export function useLayerData(
   >(new Map());
   const stableShapeFeatureStateRef = useRef<
     Map<string, { signature: string; runtime: ShapeFeatureStateRuntime }>
+  >(new Map());
+  // Stable points render resources, keyed by element. `getLayers` runs on every
+  // viewer render (including every pan/zoom frame, via the pickingEnabled gate),
+  // and the PointsLayer composite resets its async-loaded batch whenever the
+  // resource's loader identity changes. Resolving a fresh resource each call
+  // would therefore blank the layer for a frame on every pan — so we memoize by
+  // signature and only re-resolve when the structural inputs actually change.
+  const stablePointsResourceRef = useRef<
+    Map<string, { signature: string; resource: PointsRenderResource }>
   >(new Map());
 
   // Mirror the latest `layers` into a ref. This is read both by async loaders
@@ -1103,6 +1114,7 @@ export function useLayerData(
     } else if (type === 'points') {
       loaded.points.delete(key);
       loaded.worldBounds.delete(`points:${key}`);
+      stablePointsResourceRef.current.delete(key);
     } else if (type === 'image') {
       loaded.images.delete(key);
       loaded.worldBounds.delete(`image:${key}`);
@@ -1287,11 +1299,30 @@ export function useLayerData(
           // The already-cached x/y batch is handed in as the resolver's
           // `preloaded` input, so this is the same I/O and the same flat-colour
           // scatter — just via the composite that later gains filter/colour.
-          const resource = resolvePointsRenderResource(
+          //
+          // Resolve through a per-element memo so the composite sees a STABLE
+          // loader identity across renders. `getLayers` re-runs every pan/zoom
+          // frame; a fresh resource each time would reset the composite's loaded
+          // batch and blank the layer for a frame (visible flashing).
+          const resolveCache = { preloaded: pointData, metadataKnown: false };
+          const resolveOptions = { experimentalOptimizations: 'off' as const };
+          const signature = pointsRenderResourceSignature(
             elem.element as PointsElement,
-            { preloaded: pointData, metadataKnown: false },
-            { experimentalOptimizations: 'off' }
+            resolveCache,
+            resolveOptions
           );
+          const cached = stablePointsResourceRef.current.get(elem.key);
+          let resource = cached?.signature === signature ? cached.resource : null;
+          if (!resource) {
+            resource = resolvePointsRenderResource(
+              elem.element as PointsElement,
+              resolveCache,
+              resolveOptions
+            );
+            if (resource) {
+              stablePointsResourceRef.current.set(elem.key, { signature, resource });
+            }
+          }
           if (resource) {
             deckLayers.push(
               new PointsLayer({

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -43,6 +43,7 @@ import {
 } from '@spatialdata/core';
 import {
   EMPTY_SHAPE_FEATURE_STATE_RUNTIME,
+  PointsLayer,
   type ShapeFeatureRenderDatum,
   type ShapeFeatureStateRuntime,
   type ShapeFillColorMode,
@@ -50,6 +51,7 @@ import {
   buildShapeFeatureStateRuntime,
   buildShapeFillColorByFeatureId,
   buildShapesPrebuiltData,
+  resolvePointsRenderResource,
   resolveShapeFeatureFromPick,
   resolveShapeTooltipFromPickInfo,
   resolveShapeTooltipRowIndex,
@@ -63,7 +65,7 @@ import {
 } from './imageLoaderChannelDefaults';
 import { createImageLoader } from './renderers/imageRenderer';
 import { renderLabelsLayer } from './renderers/labelsRenderer';
-import { type PointData, renderPointsLayer } from './renderers/pointsRenderer';
+import { type PointData } from './renderers/pointsRenderer';
 import { loadShapesData, renderShapesLayer } from './renderers/shapesRenderer';
 import type {
   AvailableElement,
@@ -1280,17 +1282,31 @@ export function useLayerData(
       } else if (config.type === 'points') {
         const pointData = loaded.points.get(elem.key);
         if (pointData) {
-          const layer = renderPointsLayer({
-            element: elem.element as PointsElement,
-            id: layerId,
-            modelMatrix: elem.transform,
-            opacity: config.opacity,
-            visible: config.visible,
-            pointSize: config.pointSize,
-            color: config.color,
-            pointData,
-          });
-          if (layer) deckLayers.push(layer);
+          // Parity slice (step 1a): render through the @spatialdata/layers
+          // PointsLayer composite instead of the legacy flat renderPointsLayer.
+          // The already-cached x/y batch is handed in as the resolver's
+          // `preloaded` input, so this is the same I/O and the same flat-colour
+          // scatter — just via the composite that later gains filter/colour.
+          const resource = resolvePointsRenderResource(
+            elem.element as PointsElement,
+            { preloaded: pointData, metadataKnown: false },
+            { experimentalOptimizations: 'off' }
+          );
+          if (resource) {
+            deckLayers.push(
+              new PointsLayer({
+                id: layerId,
+                resource,
+                modelMatrix: elem.transform,
+                opacity: config.opacity,
+                visible: config.visible,
+                // Legacy renderPointsLayer defaulted radius to 1px; preserve that
+                // for parity (the composite's own default is smaller).
+                pointSize: config.pointSize ?? 1,
+                ...(config.color ? { color: config.color } : {}),
+              })
+            );
+          }
         }
       } else if (config.type === 'labels') {
         const labelsData = loaded.labels.get(elem.key);

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -43,8 +43,8 @@ import {
 } from '@spatialdata/core';
 import {
   EMPTY_SHAPE_FEATURE_STATE_RUNTIME,
+  PointsDataEngine,
   PointsLayer,
-  type PointsRenderResource,
   type ShapeFeatureRenderDatum,
   type ShapeFeatureStateRuntime,
   type ShapeFillColorMode,
@@ -52,8 +52,6 @@ import {
   buildShapeFeatureStateRuntime,
   buildShapeFillColorByFeatureId,
   buildShapesPrebuiltData,
-  pointsRenderResourceSignature,
-  resolvePointsRenderResource,
   resolveShapeFeatureFromPick,
   resolveShapeTooltipFromPickInfo,
   resolveShapeTooltipRowIndex,
@@ -67,7 +65,6 @@ import {
 } from './imageLoaderChannelDefaults';
 import { createImageLoader } from './renderers/imageRenderer';
 import { renderLabelsLayer } from './renderers/labelsRenderer';
-import { type PointData } from './renderers/pointsRenderer';
 import { loadShapesData, renderShapesLayer } from './renderers/shapesRenderer';
 import type {
   AvailableElement,
@@ -116,7 +113,7 @@ export interface WorldBoundsCacheEntry {
 
 interface LoadedData {
   shapes: Map<string, LoadedShapesData>;
-  points: Map<string, PointData>;
+  // Points data lives in `pointsEngine` (PointsDataEngine), not here.
   images: Map<string, ImageLoaderData>; // Viv loaders with computed channel data
   labels: Map<string, LabelsLoaderData>;
   /**
@@ -476,7 +473,6 @@ export function useLayerData(
   // Cache for loaded data
   const loadedDataRef = useRef<LoadedData>({
     shapes: new Map(),
-    points: new Map(),
     images: new Map(),
     labels: new Map(),
     shapePrebuiltData: new Map(),
@@ -488,15 +484,6 @@ export function useLayerData(
   >(new Map());
   const stableShapeFeatureStateRef = useRef<
     Map<string, { signature: string; runtime: ShapeFeatureStateRuntime }>
-  >(new Map());
-  // Stable points render resources, keyed by element. `getLayers` runs on every
-  // viewer render (including every pan/zoom frame, via the pickingEnabled gate),
-  // and the PointsLayer composite resets its async-loaded batch whenever the
-  // resource's loader identity changes. Resolving a fresh resource each call
-  // would therefore blank the layer for a frame on every pan — so we memoize by
-  // signature and only re-resolve when the structural inputs actually change.
-  const stablePointsResourceRef = useRef<
-    Map<string, { signature: string; resource: PointsRenderResource }>
   >(new Map());
 
   // Mirror the latest `layers` into a ref. This is read both by async loaders
@@ -556,6 +543,25 @@ export function useLayerData(
     },
     []
   );
+
+  // Points loading/caching/resolution engine (LayerDataEngine step 1b). This
+  // framework-agnostic engine (in @spatialdata/layers) owns the points preload
+  // cache, the stable render-resource memo, and the async load orchestration
+  // that previously lived as `useRef` state + a load-effect branch in this hook.
+  // The hook is now a thin binding: it forwards status into `layerLoadStates`
+  // and re-renders when the engine's cache settles.
+  const pointsEngineRef = useRef<PointsDataEngine | null>(null);
+  if (pointsEngineRef.current === null) {
+    pointsEngineRef.current = new PointsDataEngine({
+      onStatus: (layerId, status) => setLayerResourceStatus(layerId, 'geometry', status),
+    });
+  }
+  const pointsEngine = pointsEngineRef.current;
+
+  useEffect(() => {
+    const unsubscribe = pointsEngine.subscribe(notifyLoadedDataChanged);
+    return unsubscribe;
+  }, [pointsEngine, notifyLoadedDataChanged]);
 
   // Load data for enabled layers that don't have data yet
   useEffect(() => {
@@ -641,7 +647,7 @@ export function useLayerData(
               loadLabels,
             });
           }
-        } else if (config.type === 'points' && !loaded.points.has(elem.key)) {
+        } else if (config.type === 'points' && !pointsEngine.hasData(elem.key)) {
           toLoad.push({
             layerId,
             element: elem,
@@ -816,17 +822,13 @@ export function useLayerData(
                 }
               }
             } else if (element.type === 'points' && loadPoints) {
-              try {
-                setLayerResourceStatus(layerId, 'geometry', 'loading');
-                // todo better type-guards etc here.
-                const e = element.element as PointsElement;
-                const data = await e.loadPoints();
-                loadedDataRef.current.points.set(element.key, data);
-                setLayerResourceStatus(layerId, 'geometry', 'ready');
-              } catch (error) {
-                setLayerResourceStatus(layerId, 'geometry', 'error');
-                console.error(`Failed to load points for ${layerId}:`, error);
-              }
+              // The engine owns loading/caching/status; it reports status back
+              // through the onStatus callback wired at construction.
+              await pointsEngine.ensureLoaded({
+                key: element.key,
+                layerId,
+                element: element.element as PointsElement,
+              });
             } else if (element.type === 'image' && loadImage) {
               try {
                 setLayerResourceStatus(layerId, 'image', 'loading');
@@ -1112,9 +1114,8 @@ export function useLayerData(
         }
       }
     } else if (type === 'points') {
-      loaded.points.delete(key);
+      pointsEngine.evict(key);
       loaded.worldBounds.delete(`points:${key}`);
-      stablePointsResourceRef.current.delete(key);
     } else if (type === 'image') {
       loaded.images.delete(key);
       loaded.worldBounds.delete(`image:${key}`);
@@ -1143,7 +1144,7 @@ export function useLayerData(
       return loadedDataRef.current.shapes.has(elem.key);
     }
     if (elem.type === 'points') {
-      return loadedDataRef.current.points.has(elem.key);
+      return pointsEngine.hasData(elem.key);
     }
     if (elem.type === 'image') {
       return loadedDataRef.current.images.has(elem.key);
@@ -1183,7 +1184,7 @@ export function useLayerData(
           );
         }
         if (elem.type === 'points') {
-          const pointData = loaded.points.get(elem.key);
+          const pointData = pointsEngine.getData(elem.key);
           if (!pointData) return null;
           return getCachedWorldBounds(
             loaded.worldBounds,
@@ -1292,52 +1293,24 @@ export function useLayerData(
           if (layer) deckLayers.push(layer);
         }
       } else if (config.type === 'points') {
-        const pointData = loaded.points.get(elem.key);
-        if (pointData) {
-          // Parity slice (step 1a): render through the @spatialdata/layers
-          // PointsLayer composite instead of the legacy flat renderPointsLayer.
-          // The already-cached x/y batch is handed in as the resolver's
-          // `preloaded` input, so this is the same I/O and the same flat-colour
-          // scatter — just via the composite that later gains filter/colour.
-          //
-          // Resolve through a per-element memo so the composite sees a STABLE
-          // loader identity across renders. `getLayers` re-runs every pan/zoom
-          // frame; a fresh resource each time would reset the composite's loaded
-          // batch and blank the layer for a frame (visible flashing).
-          const resolveCache = { preloaded: pointData, metadataKnown: false };
-          const resolveOptions = { experimentalOptimizations: 'off' as const };
-          const signature = pointsRenderResourceSignature(
-            elem.element as PointsElement,
-            resolveCache,
-            resolveOptions
+        // The engine returns a STABLE render resource (memoized by signature),
+        // so re-running getLayers every pan/zoom frame reuses the same loader
+        // identity and the composite does not reset its batch (no flashing).
+        const resource = pointsEngine.getResource(elem.element as PointsElement, elem.key);
+        if (resource) {
+          deckLayers.push(
+            new PointsLayer({
+              id: layerId,
+              resource,
+              modelMatrix: elem.transform,
+              opacity: config.opacity,
+              visible: config.visible,
+              // Legacy renderPointsLayer defaulted radius to 1px; preserve that
+              // for parity (the composite's own default is smaller).
+              pointSize: config.pointSize ?? 1,
+              ...(config.color ? { color: config.color } : {}),
+            })
           );
-          const cached = stablePointsResourceRef.current.get(elem.key);
-          let resource = cached?.signature === signature ? cached.resource : null;
-          if (!resource) {
-            resource = resolvePointsRenderResource(
-              elem.element as PointsElement,
-              resolveCache,
-              resolveOptions
-            );
-            if (resource) {
-              stablePointsResourceRef.current.set(elem.key, { signature, resource });
-            }
-          }
-          if (resource) {
-            deckLayers.push(
-              new PointsLayer({
-                id: layerId,
-                resource,
-                modelMatrix: elem.transform,
-                opacity: config.opacity,
-                visible: config.visible,
-                // Legacy renderPointsLayer defaulted radius to 1px; preserve that
-                // for parity (the composite's own default is smaller).
-                pointSize: config.pointSize ?? 1,
-                ...(config.color ? { color: config.color } : {}),
-              })
-            );
-          }
         }
       } else if (config.type === 'labels') {
         const labelsData = loaded.labels.get(elem.key);

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -550,13 +550,17 @@ export function useLayerData(
   // that previously lived as `useRef` state + a load-effect branch in this hook.
   // The hook is now a thin binding: it forwards status into `layerLoadStates`
   // and re-renders when the engine's cache settles.
-  const pointsEngineRef = useRef<PointsDataEngine | null>(null);
-  if (pointsEngineRef.current === null) {
-    pointsEngineRef.current = new PointsDataEngine({
-      onStatus: (layerId, status) => setLayerResourceStatus(layerId, 'geometry', status),
-    });
-  }
-  const pointsEngine = pointsEngineRef.current;
+  //
+  // Held in `useState` with a lazy initializer (not a ref): the engine is a
+  // stable value created once, so it is safe to read during render and to list
+  // in effect/callback dependency arrays — unlike a ref, whose `current` must
+  // not be read during render.
+  const [pointsEngine] = useState(
+    () =>
+      new PointsDataEngine({
+        onStatus: (layerId, status) => setLayerResourceStatus(layerId, 'geometry', status),
+      })
+  );
 
   useEffect(() => {
     const unsubscribe = pointsEngine.subscribe(notifyLoadedDataChanged);
@@ -1099,6 +1103,7 @@ export function useLayerData(
     spatialData,
     setLayerResourceStatus,
     notifyLoadedDataChanged,
+    pointsEngine,
   ]);
 
   const reloadElement = useCallback((type: string, key: string) => {
@@ -1124,7 +1129,7 @@ export function useLayerData(
       loaded.worldBounds.delete(`labels:${key}`);
     }
     // The useEffect will pick up the missing data and reload
-  }, []);
+  }, [pointsEngine]);
 
   const getStableSelections = useCallback((key: string, selections: RasterSelection[]) => {
     const signature = serializeRasterSelections(selections);
@@ -1153,7 +1158,7 @@ export function useLayerData(
       return loadedDataRef.current.labels.has(elem.key);
     }
     return false;
-  }, []);
+  }, [pointsEngine]);
 
   const getWorldBoundsForLayer = useCallback(
     (layerId: string): AxisAlignedBounds | null => {
@@ -1236,7 +1241,7 @@ export function useLayerData(
         return null;
       }
     },
-    [layers]
+    [layers, pointsEngine]
   );
 
   const getWorldBoundsForVisibleLayers = useCallback((): AxisAlignedBounds | null => {
@@ -1360,7 +1365,7 @@ export function useLayerData(
     }
 
     return deckLayers;
-  }, [layers, layerOrder, getStableSelections]);
+  }, [layers, layerOrder, getStableSelections, pointsEngine]);
 
   const getImageLayerLoadedData = useCallback((layerId: string): ImageLoaderData | undefined => {
     const elem = resolveLayerElement(layerId, layersRef.current[layerId], elementMap.current);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       '@math.gl/core':
         specifier: 'catalog:'
         version: 4.1.0
+      '@spatialdata/core':
+        specifier: workspace:*
+        version: link:../core
       zod:
         specifier: 'catalog:'
         version: 4.1.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ catalogs:
     jsdom:
       specifier: ^27.4.0
       version: 27.4.0
-    parquet-wasm:
-      specifier: ^0.6.1
-      version: 0.6.1
     react:
       specifier: ^19.2.1
       version: 19.2.1
@@ -155,9 +152,6 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
-      parquet-wasm:
-        specifier: 'catalog:'
-        version: 0.6.1
       prism-react-renderer:
         specifier: ^2.3.0
         version: 2.4.1(react@19.2.1)
@@ -256,9 +250,6 @@ importers:
       ol:
         specifier: ^10.6.1
         version: 10.6.1
-      parquet-wasm:
-        specifier: 'catalog:'
-        version: 0.6.1
       zarrextra:
         specifier: workspace:*
         version: link:../zarrextra
@@ -6364,9 +6355,6 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  parquet-wasm@0.6.1:
-    resolution: {integrity: sha512-wTM/9Y4EHny8i0qgcOlL9UHsTXftowwCqDsAD8axaZbHp0Opp3ue8oxexbzTVNhqBjFhyhLiU3MT0rnEYnYU0Q==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -15844,8 +15832,6 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parquet-wasm@0.6.1: {}
 
   parse-entities@4.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,6 @@ catalog:
   anndata.js: ^0.0.2
   apache-arrow: ^17.0.0
   deck.gl: ~9.3.5
-  parquet-wasm: ^0.6.1
   react: ^19.2.1
   react-dom: ^19.2.1
   typescript: ^5.7.3


### PR DESCRIPTION
## What this lands

Reconstructs the **points / transcript rendering path** across `core` + `layers` + `vis`, on the clean architecture from [ADR 0002](docs/adr/0002-spatially-aware-vector-loading.md) / [ADR 0003](docs/adr/0003-points-render-resource.md), and delivers user-visible **point-size + overdraw controls**. It also lands the first step of the `LayerDataEngine` decomposition ([plan](docs/plans/layer-data-engine-decomposition.md)).

This is intentionally a **milestone PR, not the full feature set** — feature filtering, colour-by-feature, tooltips, and the Morton *tiled* render path are present in `core`/`layers` but not yet wired into the UI. They're the next PR ([roadmap](docs/plans/points-mvp-and-roadmap.md)).

## User-visible

- Points/transcript layers render through the `@spatialdata/layers` `PointsLayer` composite.
- A **Point size** control in the SpatialCanvas layer panel.
- Points are sized in **world units** so the GPU scales them with zoom — overdraw collapses when zoomed out, points grow to reveal individual transcripts when zoomed in — clamped to a pixel range.

## Architecture (the design-bearing parts to review)

- **`resolvePointsRenderResource`** — the store-agnostic boundary that turns a `PointsElement` into a render resource (ADR 0003).
- **`PointsDataEngine`** (`layers/src/engine/`) — framework-agnostic, React-free, unit-tested. Owns the points cache, the stable render-resource memo, and async load orchestration. First sub-engine of the `LayerDataEngine` decomposition; the vis hook is now a thin binding.
- **`@spatialdata/core` points I/O** — bounded/capped loading on `PointsElement`, Morton tiling metadata, dictionary-aware feature catalog, an **opt-in** points worker, and **vendored parquet-wasm** (replaces the npm/CDN dep) with row-group range reads.

## Fixes (surfaced while wiring this up)

- Forever-loading transcripts (points worker is now opt-in, not auto-enabled).
- Stale-disabled "Center on layer" for freshly-loaded layers.
- Per-frame layer flash while panning (stable memoized render resource).
- deck.gl sublayer id-collision assertion on the preloaded scatter path.

## Not in this PR (follow-up)

Feature filtering, colour-by-feature, per-point tooltips, and the Morton **tiled** render path (points currently load as a capped 4M-row preload). Scoped in [`docs/plans/points-mvp-and-roadmap.md`](docs/plans/points-mvp-and-roadmap.md).

## Testing

- `core` 120, `layers` 79 (incl. 6 headless `PointsDataEngine` tests), `vis` 42 — all green; all three packages typecheck clean.
- Verified in the vis demo against a Xenium dataset: transcripts load, Center-on-layer frames the cloud, no pan flash, no console assertions, size control + zoom-adaptive sizing behave as intended.

## Reviewer note

It's a large diff because reconstructing points rendering is irreducible across three packages (none renders points alone). ~3k lines are vendored parquet-wasm and much of `core` is the I/O foundation. The **design-bearing** changes are `PointsDataEngine`, the composite/resolver wiring in `vis`, and the world-unit sizing — the core foundation and vendored wasm are largely mechanical / ADR-sanctioned. Commits are ordered to tell the story (docs → core → layers → vis wiring → fixes → engine → size controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
