### PR TITLE
core: fix ineffective biome-ignore on ResolverRegistry (unblock lint gate)

### DIFF
--- a/packages/core/src/engine/SpatialEntryStore.ts
+++ b/packages/core/src/engine/SpatialEntryStore.ts
@@ -17,8 +17,7 @@ import type { EntryResources, ResolveContext, ResolveTask, ResourceResolver } fr
  * special-case a kind here.
  */
 
-// biome-ignore lint/suspicious/noExplicitAny: the registry is heterogeneous by design — each
-// resolver has its own config and element types, and the store deliberately cannot see them.
+// biome-ignore lint/suspicious/noExplicitAny: the registry is heterogeneous by design — each resolver has its own config and element types, and the store deliberately cannot see them.
 export type ResolverRegistry = Readonly<Record<SpatialEntryKind, ResourceResolver<any, any>>>;
 
 // biome-ignore lint/suspicious/noExplicitAny: see above.


### PR DESCRIPTION
## What

The `noExplicitAny` suppression for `ResolverRegistry` in `SpatialEntryStore.ts` is written across two comment lines. Because the continuation line sits between the `// biome-ignore` directive and the annotated `export type`, Biome reports the suppression as **unused** — one `suppressions/unused` error.

That single error fails the `biome-lint` CI job (`pnpm lint:biome` → `biome ci packages/*/src`), which is intentionally clean of prior backlog and therefore treats any error as fatal. The gate is currently red on `main` because of it.

## Fix

Collapse the suppression to a single-line `// biome-ignore`, matching the form the adjacent `AnyResolveContext` suppression already uses. No behaviour change.

## Verification

`pnpm lint:biome` (`biome ci packages/*/src`) now exits `0` (0 errors, warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified an internal lint directive without affecting application behavior or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->