### PR TITLE
Pass Deck’s shader assembler to FlatPolygonLayer’s Model

### DIFF
--- a/.changeset/fix-shapes-layer-shader-assembler.md
+++ b/.changeset/fix-shapes-layer-shader-assembler.md
@@ -1,0 +1,5 @@
+---
+'@spatialdata/layers': patch
+---
+
+Fix a production shader compilation error when rendering shapes layers.

--- a/packages/layers/src/FlatPolygonLayer.ts
+++ b/packages/layers/src/FlatPolygonLayer.ts
@@ -240,6 +240,9 @@ export class FlatPolygonLayer extends (Layer as any) {
       topology: 'triangle-list',
       bufferLayout: [],
       isInstanced: false,
+      // Hand-rolled Models do not inherit Deck's assembler automatically. It owns
+      // the DECKGL_FILTER_* hook declarations consumed by our shaders.
+      shaderAssembler: this.context.shaderAssembler,
     });
   }
 }

--- a/packages/layers/tests/flatPolygonLayer.spec.ts
+++ b/packages/layers/tests/flatPolygonLayer.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const modelOptions = vi.hoisted((): Array<{ shaderAssembler?: unknown }> => []);
+
+vi.mock('@luma.gl/engine', () => ({
+  Model: class {
+    constructor(_device: unknown, options: { shaderAssembler?: unknown }) {
+      modelOptions.push(options);
+    }
+  },
+}));
+
+import { FlatPolygonLayer } from '../src/FlatPolygonLayer';
+
+describe('FlatPolygonLayer shaders', () => {
+  it('uses Deck’s shader assembler when creating its hand-rolled Model', () => {
+    const layer = new FlatPolygonLayer({
+      id: 'flat-polygon-shader-modules',
+      ringPositions: new Float32Array([0, 0, 1, 0, 0, 1]),
+      ringVertexCount: 3,
+      triangleData: new Uint32Array([0, 1, 2, 7]),
+      triangleCount: 1,
+      featureColors: new Uint8Array([0, 0, 0, 255]),
+      featureCount: 1,
+      featureScale: new Float32Array([1]),
+    });
+    const shaderAssembler = {};
+    layer.context = { defaultShaderModules: [], shaderAssembler };
+
+    layer._getModel();
+
+    expect(modelOptions.at(-1)).toMatchObject({ shaderAssembler });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix production shader hook resolution for `FlatPolygonLayer` hand-rolled Models.
- Pass Deck’s `shaderAssembler` into the Model configuration.
- Add a regression test verifying the assembler is forwarded.

## Testing

- Added a Vitest regression test for shader assembler propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polygon rendering by ensuring custom shader hooks are correctly applied during model creation.
  * Added coverage to verify shader configuration is passed through as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->