### PR TITLE
Fix invalid test.yml and broken fixture generation; add independent workflow lint gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,13 @@ jobs:
     # React-shipping packages via eslint-plugin-react-hooks. The backlog has been
     # cleared, so this is a required gate: any new finding fails the check.
     steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
+      # Every step in this file carries a distinct `name:`. Four jobs check out
+      # with byte-identical `uses:` blocks, so unnamed steps give reviewers (and
+      # tools applying line-anchored review suggestions) no way to tell them
+      # apart — that ambiguity is how a duplicate `with:` key landed in this job
+      # in #92 and broke the whole workflow.
+      - name: Check out repository (react-lint)
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -32,7 +36,8 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node
+        uses: actions/setup-node@v5
         with:
           node-version: '24.14.1'
           cache: 'pnpm'
@@ -53,7 +58,8 @@ jobs:
     # tests are intentionally out of scope (still carry findings), so this gate is
     # narrower than `pnpm lint` (biome check .).
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out repository (biome-lint)
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -62,7 +68,8 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node
+        uses: actions/setup-node@v5
         with:
           node-version: '24.14.1'
           cache: 'pnpm'
@@ -76,19 +83,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out repository (test)
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node
+        uses: actions/setup-node@v5
         with:
           node-version: '24.14.1'
           cache: 'pnpm'
 
-      - uses: astral-sh/setup-uv@v7
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -141,7 +151,7 @@ jobs:
 
           # Wait for server to be ready (up to ~30s)
           # Check both root and a fixture path to ensure server is fully ready
-          for i in {1..30}; do
+          for _ in {1..30}; do
             if curl -sSf http://localhost:38473/ >/dev/null && \
                curl -sSf http://localhost:38473/v0.5.0/blobs.zarr/zmetadata >/dev/null; then
               echo "Test server is up and serving fixtures"
@@ -165,7 +175,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out repository (production-browser)
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -174,12 +185,14 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@v5
+      - name: Setup Node
+        uses: actions/setup-node@v5
         with:
           node-version: '24.14.1'
           cache: 'pnpm'
 
-      - uses: astral-sh/setup-uv@v7
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,10 @@ jobs:
 
       - name: Generate test fixtures (Python spatialdata 0.7.2)
         if: steps.cache-production-browser-fixtures.outputs.cache-hit != 'true'
-        run: pnpm test:fixtures:generate:0.7.2 -- --output-dir test-fixtures-production-browser
+        # No `--` before the flags: pnpm forwards the separator through to the
+        # script verbatim, and argparse treats everything after a bare `--` as
+        # positional, so `-- --output-dir X` fails with "unrecognized arguments".
+        run: pnpm test:fixtures:generate:0.7.2 --output-dir test-fixtures-production-browser
 
       - name: Expose production browser fixtures
         run: ln -s test-fixtures-production-browser test-fixtures

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,44 @@
+name: Workflow Lint
+
+# Deliberately a SEPARATE workflow file, and it must stay that way.
+#
+# A workflow cannot validate itself. Once a file stops parsing, GitHub can no
+# longer evaluate its `on:` triggers, so none of its own jobs run — the failure
+# surfaces only as a 0-second run with no jobs and no logs, which reads like
+# infra flake rather than a broken file. That is exactly how a duplicate `with:`
+# key reached main in #92: the PR's last green check predated the bad edit, and
+# nothing re-ran to contradict it.
+#
+# This file parses independently of the others, so it still runs when they are
+# broken and reports a real annotation with a file:line.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository (workflow-lint)
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      # actionlint covers both halves of the problem: a strict YAML syntax check
+      # (duplicate keys, bad indentation — the things GitHub silently rejects)
+      # and semantic checks on top (unknown `uses:` refs, invalid expressions,
+      # shellcheck over `run:` blocks). Pinned to an exact version: this gate is
+      # meant to fail on our mistakes, not on a linter release.
+      - name: Lint workflow files (actionlint)
+        uses: docker://rhysd/actionlint:1.7.12


### PR DESCRIPTION
## Problem

`main` is currently red: [run 30333189501](https://github.com/Taylor-CCB-Group/SpatialData.js/actions/runs/30333189501) failed in 0s with no jobs and no logs.

That is not a test failure. [#92](https://github.com/Taylor-CCB-Group/SpatialData.js/pull/92) left a duplicate `with:` key on the `react-lint` checkout step, so `test.yml` no longer parses:

```yaml
      - uses: actions/checkout@v5
        with:
          persist-credentials: false
        with:                          # <- duplicate mapping key
          persist-credentials: false
```

## Root cause

CodeRabbit's review was correct and correctly anchored. At the reviewed commit (`2d677c9`), line 168 was the new `flat-polygon-browser` job's bare checkout, which genuinely needed `persist-credentials: false`; `react-lint` at line 24 already had it.

The suggestion got applied to both. Its committable block leads with the context line `- uses: actions/checkout@v5`, and this file has **four byte-identical checkout steps** — so a text-matching edit has no way to know which one was meant.

Nothing downstream caught it. Once the file stopped parsing, GitHub could no longer evaluate its `on:` triggers, so no `pull_request` check re-ran on the force-push; the PR kept showing the green run from *before* the review.

## Changes

1. **Remove the duplicate key** — restores `test.yml` to a parseable state.

2. **Add `.github/workflows/workflow-lint.yml`** running [actionlint](https://github.com/rhysd/actionlint) over `.github/workflows`.

   Separate file on purpose, and it should stay that way: **a workflow cannot validate itself**, so the check that would have caught this is exactly the one that could not run. An independent file still parses when its neighbours are broken, converting a silent 0s run into a real annotation.

3. **Give every step in `test.yml` a distinct `name:`** — removes the ambiguity that caused the misapplied edit, rather than only detecting its consequences. Also makes job diffs readable and the Actions UI legible.

4. **Fix fixture generation in `production-browser`** (found by this PR's own CI, see below).

Plus `for i in {1..30}` → `for _`, clearing the one pre-existing shellcheck finding so the new gate starts green.

## The second bug, and why it stayed hidden

With `test.yml` parseable again, `production-browser` ran for real for the first time — and failed:

```
generate_fixtures.py: error: unrecognized arguments: -- --output-dir test-fixtures-production-browser
```

`pnpm run <script> -- <args>` forwards the `--` separator to the script verbatim, and argparse treats everything after a bare `--` as positional. Verified both halves locally:

```
$ pnpm echoargs -- --output-dir X
ARGS: ["--version","0.7.2","--","--output-dir","X"]     # separator survives
```

This was latent in #92, not new here. The job's only previously-green run shows `Generate test fixtures -> skipped`: it shared a fixture cache key with the `test` job, hit that cache, and never ran the generation step. Giving it a distinct key — the correct fix for the collision CodeRabbit flagged — forced a cache miss and finally executed the bad invocation.

Same shape as the first bug, one layer down: a correct review comment, a fix that was right on its own terms, and no gate positioned to see what it uncovered.

## Verification

actionlint 1.7.12 run locally against the broken merged commit:

```
.github/workflows/test.yml:27:9: key "with" is duplicated in element of "steps" section.
  previously defined at line:25,col:9 [syntax-check]
```

…and against this branch's tree: clean, exit 0. On the first CI run here, `actionlint`, `react-lint`, `biome-lint` and `test` all passed.

## Follow-up (not in this PR)

`main` has no branch protection and no rulesets — I checked. The 05:55 failure was visible two minutes before the merge and nothing gated it. Requiring these checks would be worth doing separately; it needs a repo-settings change rather than a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)