### PR TITLE
Don't offer the obs index as an obs column

### DIFF
--- a/.changeset/tidy-pumas-shave.md
+++ b/.changeset/tidy-pumas-shave.md
@@ -1,0 +1,13 @@
+---
+'@spatialdata/core': patch
+---
+
+`TableElement.getObsColumnNames()` no longer reports the obs index as a column.
+
+The index array sits alongside the columns in the `obs` group, so it was being
+offered anywhere obs columns are listed — as `_index` for tables whose index is
+unnamed (the `blobs` fixture), which is AnnData's internal storage name rather
+than anything meaningful to a user. The name is now read from the `_index`
+attribute on the `obs` group and filtered out; the new
+`TableElement.getObsIndexColumnName()` exposes it for callers that want the
+index itself, alongside the existing `loadObsIndex()`.

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -274,7 +274,28 @@ export class TableElement extends AbstractElement<'tables'> {
   }
 
   /**
+   * Name of the obs array holding the dataframe index, as declared by the
+   * `_index` attribute AnnData writes on the `obs` group. Literally `_index`
+   * when the index is unnamed (the `blobs` fixture), otherwise the index's own
+   * name (e.g. `cell_id`).
+   */
+  getObsIndexColumnName(): string | undefined {
+    const node = this.parsed as ZarrTree;
+    const obsNode = node.obs as ZarrTree | undefined;
+    if (!obsNode || typeof obsNode !== 'object') {
+      return undefined;
+    }
+    const indexName = (obsNode[ATTRS_KEY] as ZAttrsAny | undefined)?._index;
+    return typeof indexName === 'string' ? indexName : undefined;
+  }
+
+  /**
    * Get available obs column names from the parsed tree.
+   *
+   * The index array is excluded: it sits alongside the columns in the `obs`
+   * group but is the row label, not a column of the dataframe, and it is already
+   * reachable as `loadObsIndex()` / `getObsIndexColumnName()`. Offering it as a
+   * column would surface AnnData's internal `_index` name in the UI.
    */
   getObsColumnNames(): string[] {
     const node = this.parsed as ZarrTree;
@@ -282,7 +303,8 @@ export class TableElement extends AbstractElement<'tables'> {
     if (!obsNode || typeof obsNode !== 'object') {
       return [];
     }
-    return Object.keys(obsNode);
+    const indexName = this.getObsIndexColumnName();
+    return Object.keys(obsNode).filter((columnName) => columnName !== indexName);
   }
 
   /**

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -27,7 +27,7 @@ import type {
   ZAttrsAny,
   ZarrTree,
 } from '../types';
-import { ATTRS_KEY, Err, Ok } from '../types';
+import { ATTRS_KEY, Err, Ok, ZARRAY_KEY } from '../types';
 import SpatialDataPointsSource from './VPointsSource';
 import SpatialDataShapesSource from './VShapesSource';
 import SpatialDataTableSource from './VTableSource';
@@ -274,18 +274,35 @@ export class TableElement extends AbstractElement<'tables'> {
   }
 
   /**
+   * The `obs` group node, or `undefined` when this table has no `obs` or the
+   * node turns out to be an array rather than a group.
+   *
+   * `ZarrTree`'s index signature admits a `LazyZarrArray` at every key, and a
+   * lazy array is an object too — so a `typeof === 'object'` test alone lets one
+   * through, and its own properties would then read as obs column names.
+   * `ZARRAY_KEY` is the discriminator (it is required on `LazyZarrArray`,
+   * absent on groups), the same one `serializeZarrTree` uses.
+   */
+  private getObsGroup(): ZarrTree | undefined {
+    const tableNode = this.parsed;
+    if (ZARRAY_KEY in tableNode) {
+      return undefined;
+    }
+    const obsNode = tableNode.obs;
+    if (!obsNode || typeof obsNode !== 'object' || ZARRAY_KEY in obsNode) {
+      return undefined;
+    }
+    return obsNode;
+  }
+
+  /**
    * Name of the obs array holding the dataframe index, as declared by the
    * `_index` attribute AnnData writes on the `obs` group. Literally `_index`
    * when the index is unnamed (the `blobs` fixture), otherwise the index's own
    * name (e.g. `cell_id`).
    */
   getObsIndexColumnName(): string | undefined {
-    const node = this.parsed as ZarrTree;
-    const obsNode = node.obs as ZarrTree | undefined;
-    if (!obsNode || typeof obsNode !== 'object') {
-      return undefined;
-    }
-    const indexName = (obsNode[ATTRS_KEY] as ZAttrsAny | undefined)?._index;
+    const indexName = this.getObsGroup()?.[ATTRS_KEY]?._index;
     return typeof indexName === 'string' ? indexName : undefined;
   }
 
@@ -298,9 +315,8 @@ export class TableElement extends AbstractElement<'tables'> {
    * column would surface AnnData's internal `_index` name in the UI.
    */
   getObsColumnNames(): string[] {
-    const node = this.parsed as ZarrTree;
-    const obsNode = node.obs as ZarrTree | undefined;
-    if (!obsNode || typeof obsNode !== 'object') {
+    const obsNode = this.getObsGroup();
+    if (!obsNode) {
       return [];
     }
     const indexName = this.getObsIndexColumnName();

--- a/packages/core/tests/tableElement.spec.ts
+++ b/packages/core/tests/tableElement.spec.ts
@@ -2,7 +2,7 @@ import { assert, describe, expect, it, vi } from 'vitest';
 import { ATTRS_KEY } from 'zarrextra';
 import { SpatialData } from '../src/store/index.js';
 
-function createMockSpatialData() {
+function createMockSpatialData(obs: Record<string | symbol, unknown> = {}) {
   const rootStore = {
     tree: {
       tables: {
@@ -13,7 +13,7 @@ function createMockSpatialData() {
             region_key: 'region',
             'spatialdata-encoding-type': 'ngff:regions_table',
           },
-          obs: {},
+          obs,
         },
       },
     },
@@ -69,5 +69,43 @@ describe('TableElement direct table reads', () => {
     };
 
     await expect(table.loadObsColumns(['score'])).resolves.toEqual([[1, 2, 3]]);
+  });
+});
+
+describe('TableElement obs column names', () => {
+  it('omits the unnamed index that AnnData stores as `_index` (blobs fixture shape)', () => {
+    const sdata = createMockSpatialData({
+      [ATTRS_KEY]: { _index: '_index', 'encoding-type': 'dataframe' },
+      _index: {},
+      instance_id: {},
+      region: {},
+    });
+    assert(sdata.tables, 'sdata.tables on mock object should be truthy');
+    const table = sdata.tables.cells_table;
+
+    expect(table.getObsIndexColumnName()).toBe('_index');
+    expect(table.getObsColumnNames()).toEqual(['instance_id', 'region']);
+  });
+
+  it('omits a named index too', () => {
+    const sdata = createMockSpatialData({
+      [ATTRS_KEY]: { _index: 'cell_id', 'encoding-type': 'dataframe' },
+      cell_id: {},
+      leiden: {},
+    });
+    assert(sdata.tables, 'sdata.tables on mock object should be truthy');
+    const table = sdata.tables.cells_table;
+
+    expect(table.getObsIndexColumnName()).toBe('cell_id');
+    expect(table.getObsColumnNames()).toEqual(['leiden']);
+  });
+
+  it('keeps every key when obs declares no index', () => {
+    const sdata = createMockSpatialData({ leiden: {}, score: {} });
+    assert(sdata.tables, 'sdata.tables on mock object should be truthy');
+    const table = sdata.tables.cells_table;
+
+    expect(table.getObsIndexColumnName()).toBeUndefined();
+    expect(table.getObsColumnNames()).toEqual(['leiden', 'score']);
   });
 });

--- a/packages/core/tests/tableElement.spec.ts
+++ b/packages/core/tests/tableElement.spec.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it, vi } from 'vitest';
-import { ATTRS_KEY } from 'zarrextra';
+import { ATTRS_KEY, ZARRAY_KEY } from 'zarrextra';
 import { SpatialData } from '../src/store/index.js';
 
 function createMockSpatialData(obs: Record<string | symbol, unknown> = {}) {
@@ -98,6 +98,19 @@ describe('TableElement obs column names', () => {
 
     expect(table.getObsIndexColumnName()).toBe('cell_id');
     expect(table.getObsColumnNames()).toEqual(['leiden']);
+  });
+
+  it('treats an obs node that is an array rather than a group as having no columns', () => {
+    const sdata = createMockSpatialData({
+      [ZARRAY_KEY]: { shape: [2] },
+      [ATTRS_KEY]: { _index: '_index' },
+      get: () => Promise.resolve({}),
+    });
+    assert(sdata.tables, 'sdata.tables on mock object should be truthy');
+    const table = sdata.tables.cells_table;
+
+    expect(table.getObsIndexColumnName()).toBeUndefined();
+    expect(table.getObsColumnNames()).toEqual([]);
   });
 
   it('keeps every key when obs declares no index', () => {

--- a/packages/vis/src/SpatialCanvas/index.tsx
+++ b/packages/vis/src/SpatialCanvas/index.tsx
@@ -554,6 +554,9 @@ function SpatialCanvasInner({
     // flips to 'ready' in lockstep with the load, so the button enables immediately.
     (selectedLayerReadyResource === 'ready' || hasRenderableLayerData(selectedConfig.id));
 
+  // The obs index is already left out by `getObsColumnNames()`; what remains to
+  // drop here are the two association keys, which are structural rather than
+  // annotation.
   // TODO: include extra annotation columns carried by the shapes element itself,
   // not just associated table obs columns. Longer term, expose entries
   // corresponding to vars in X / layers once core has a clean annotation API.


### PR DESCRIPTION
## What

`TableElement.getObsColumnNames()` returned every key in the `obs` group, which includes the array holding the dataframe index. It now reads the index name from the `_index` attribute AnnData writes on the `obs` group and filters it out, and exposes that name as a new `TableElement.getObsIndexColumnName()`.

- [packages/core/src/models/index.ts](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/fix/obs-index-not-a-column/packages/core/src/models/index.ts) — `getObsIndexColumnName()`; `getObsColumnNames()` filters the index out
- [packages/core/tests/tableElement.spec.ts](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/fix/obs-index-not-a-column/packages/core/tests/tableElement.spec.ts) — unnamed `_index` (blobs shape), named index, and obs with no declared index
- [packages/vis/src/SpatialCanvas/index.tsx](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/fix/obs-index-not-a-column/packages/vis/src/SpatialCanvas/index.tsx) — comment only; the `availableTooltipFields` filter now only drops the two association keys
- patch changeset for `@spatialdata/core`

## Why

`SpatialCanvas` builds `availableTooltipFields` from `getObsColumnNames()` minus the table's `instanceKey`/`regionKey`. For the `blobs` fixture (`test-fixtures/v0.7.2/blobs.zarr`, table annotating `blobs_labels`) that left `_index` as the *only* offered field, in both the Tooltip fields and Fill colour pickers — AnnData's internal storage name for an unnamed index, not a column anyone authored. The index is the row label; its values are already reachable via `loadObsIndex()`.

## Note for reviewers: this is not a load-failure fix

This was raised as `_index` producing no tooltip values and no fill colours. That does **not** reproduce. `obs/_index` is a normal `string-array` zarr array (values `"1"`…`"30"`), `_loadColumn` resolves it through the `encoding-type: 'string-array'` branch, and `loadAssociatedTableFeatureRows(..., extraColumnNames: ['_index'])` returns `extraColumns[0] = ['1','2',…]` with matching `rowIds`. Verified in the running demo too: hovering a label showed `_index  3`, and Fill colour by `_index` produced per-label colours. So the alternative fix — teaching `loadObsColumns` to resolve the index name — would have been a no-op. The change here is a modelling correction, not a repair.

## Behaviour change to be aware of

For the `blobs` fixture, both panels now offer nothing (`instance_id` and `region` are the only real obs columns, and both are structural association keys). The Tooltip fields panel reads "No eligible obs columns found on the associated table". That is accurate, but it does mean `blobs.zarr` can no longer exercise those panels by hand — `_index` was inadvertently serving as a stand-in test column.

## Verification

- Against the unmodified fixture: `getObsIndexColumnName()` → `_index`, `getObsColumnNames()` → `['instance_id','region']`.
- Against a scratch copy of the fixture with one extra obs column `blob_label` (and `region` widened to include `blobs_circles` so the shapes Fill colour panel renders): Fill colour dropdown offers `None` / `blob_label`; Tooltip fields offers `blob_label`; hovering a label gives `element` / `id 3` / `blob_label 3`. Real columns still load; only the index is no longer offered.
- `pnpm --filter @spatialdata/core test` 358 passed, `--filter @spatialdata/vis test` 103 passed, core builds, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to retrieve the declared observation index column name.
  * Observation column listings now exclude the index column when it is defined.

* **Bug Fixes**
  * Improved handling of unnamed, named, and absent observation indexes.

* **Documentation**
  * Clarified how observation indexes and structural association keys are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->