### PR TITLE
Fix broken docs anchors and fail the build on anchor drift

### DIFF
--- a/docs/docs/vis/mdv-integration.mdx
+++ b/docs/docs/vis/mdv-integration.mdx
@@ -101,7 +101,7 @@ Implementation status:
 - [x] `showLoadingOverlay` and `renderTooltip={false}` for external tooltip ownership.
 - [x] `onFeatureHover` / `onFeatureClick` for shape and label picking, with `onShapeHover` / `onShapeClick` kept as compatibility callbacks.
 - [ ] Stable externally supplied Viv/deck view id or layer id suffix (`getVivId` compatibility).
-- [x] Viv extension passthrough: `ImageLayerConfig.vivLayerProps`, `vivImageExtensionResolver`, `vivImagePropsResolver` on `SpatialCanvasViewer` (see [Issue #56 APIs](#issue-56-channel--extension-apis) below).
+- [x] Viv extension passthrough: `ImageLayerConfig.vivLayerProps`, `vivImageExtensionResolver`, `vivImagePropsResolver` on `SpatialCanvasViewer` (see [Issue #56 APIs](#issue-56-channel-and-extension-apis) below).
 
 See [Headless viewer guide](./headless-viewer) for experimentation steps. The `/headless` demo (`packages/vis/demo`) wires MDV-style `ColorPaletteExtension` + `VivContrastExtension` through `vivImageExtensionResolver`; brightness/contrast sliders feed `vivImagePropsResolver` (or saved `vivLayerProps`).
 

--- a/docs/docs/vis/mdv-release-checklist.mdx
+++ b/docs/docs/vis/mdv-release-checklist.mdx
@@ -234,7 +234,7 @@ This repo pins `@hms-dbmi/viv@0.21.0` and deck.gl `9.2.9` (Viv PR [#924](https:/
 - [x] Audit `@spatialdata/vis` Viv paths for extension prop preservation:
   - `packages/vis/src/SpatialCanvas/VivSpatialViewer.tsx`
   - `vivProps` passthrough into `getLayers({ props })`; no post-spread of `layer.props`.
-- [x] Issue [#56](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/56) APIs: `useLayerChannelState`, `useImageLayerContext`, `getChannelSelectionStats`, Viv extension resolvers — see [MDV integration roadmap](./mdv-integration#issue-56-channel--extension-apis).
+- [x] Issue [#56](https://github.com/Taylor-CCB-Group/SpatialData.js/issues/56) APIs: `useLayerChannelState`, `useImageLayerContext`, `getChannelSelectionStats`, Viv extension resolvers — see [MDV integration roadmap](./mdv-integration#issue-56-channel-and-extension-apis).
 - [ ] `/headless` demo visual check: brightness/contrast sliders affect image layer via `vivImagePropsResolver`.
 - [ ] Audit channel-count assumptions and constants:
   - `packages/avivatorish/src/constants.ts`

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -28,6 +28,7 @@ const config: Config = {
   projectName: 'SpatialData.js', // Usually your repo name.
 
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
## What changed

Two links pointed at a stale heading slug in the vis docs:

- `docs/docs/vis/mdv-integration.mdx:104` (same-page link)
- `docs/docs/vis/mdv-release-checklist.mdx:237` (cross-page link)

Both used `#issue-56-channel--extension-apis`, but the heading at `mdv-integration.mdx:108` reads `## Issue #56 channel and extension APIs` and slugifies to `#issue-56-channel-and-extension-apis`. The `&` → `and` rewording moved the slug and left the links behind.

Also set `onBrokenAnchors: 'throw'` in `docs/docusaurus.config.ts`.

## Why

The broken anchors were emitting a `Docusaurus found broken anchors!` warning on `main` — pre-existing, not from any feature branch.

`onBrokenLinks` was already `'throw'`, so a bad *path* failed the build while a bad *fragment* only warned. That asymmetry is what let this drift sit unnoticed. Turning `onBrokenAnchors` up to `'throw'` closes the gap, so heading renames that orphan a link fail CI instead of scrolling past in the build log.

## Notes for reviewers

- Enabling `onBrokenAnchors: 'throw'` doubles as the verification here: the build passing with it on proves there are **zero** broken anchors site-wide, not just that these two were fixed.
- Verified with `cd docs && pnpm build` → `[SUCCESS] Generated static files in "build".`, no broken-anchor warning.
- Heads-up when reproducing: `pnpm build` in `docs/` fails in a clean checkout (`Can't resolve '@spatialdata/vis'`) until the workspace packages are built. Run the root `pnpm build` first. Unrelated to this change.
- Docs-only, no package source touched, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected Issue `#56` cross-reference links in the integration guide and release checklist.
  - Added validation to detect broken page anchors during documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->