### PR TITLE
Read AnnData's nullable-encoded columns and v3 categoricals

### DIFF
--- a/.changeset/nullable-anndata-columns.md
+++ b/.changeset/nullable-anndata-columns.md
@@ -1,0 +1,30 @@
+---
+'@spatialdata/core': minor
+---
+
+Read AnnData's nullable-encoded columns, and report their kind.
+
+A nullable column is a **group** of `values` + `mask`, not an array, so opening its
+path as an array fails outright. The visible symptom is usually a missing *index*
+rather than a missing value, because `obs/_index` and `var/_index` are ordinary
+columns — a table would load with `varN` in place of gene names, or with no row ids.
+This is not a legacy shape to tolerate: AnnData 0.13 defaults to zarr v3 and writes
+string columns this way by default, `_index` included, so it is what a freshly
+written `spatialdata` store looks like.
+
+All three nullable encodings are read (`nullable-string-array`, `nullable-integer`,
+`nullable-boolean`), with the mask honoured — a masked entry decodes as `null`, which
+the missing-value handling already treats as absent, so it stays distinguishable from
+a real `0` or `''` rather than being silently rendered as one.
+
+`getObsColumnKinds` recognises the same three. Without this the kind lookup fell
+through to array metadata that a group does not have and returned `undefined`,
+sending `'auto'` mode back to sniffing decoded values for exactly the columns AnnData
+now writes by default — the case that lookup exists to avoid.
+
+Also fixes zarr v3 categoricals decoding to their raw integer codes. The categories
+array is written as `string` on v3, and the text check tested for one v2 spelling of
+that dtype (`v2:object`), so the column resolved to codes — plausible-looking numbers
+rather than an error. The check now asks zarrita whether the dtype is text, which
+covers v3 `string` and v2 `U`/`S` alike, and pandas' `-1` missing code maps to `null`
+instead of indexing off the end of the categories.

--- a/packages/core/src/models/VAnnDataSource.ts
+++ b/packages/core/src/models/VAnnDataSource.ts
@@ -1,7 +1,9 @@
+import * as zarr from 'zarrita';
 import { get as zarrGet, open as zarrOpen } from 'zarrita';
 import type { TableColumnData } from '../types';
 import type { DataSourceParams } from '../Vutils';
 import { dirname } from '../Vutils';
+import { isNullableEncoding, readNullableArray } from './nullableArrays';
 import ZarrDataSource from './VZarrDataSource';
 
 function prependSlash(path: string) {
@@ -107,6 +109,8 @@ export default class AnnDataSource extends ZarrDataSource {
       codesPath = `${path}/codes`;
     } else if (encodingType === 'string-array') {
       return this.getFlatArrDecompressed(path);
+    } else if (isNullableEncoding(encodingType)) {
+      return readNullableArray(storeRoot.resolve(path));
     } else {
       const { dtype } = await zarrOpen(storeRoot.resolve(path), { kind: 'array' });
       if (dtype === 'v2:object') {
@@ -168,9 +172,21 @@ export default class AnnDataSource extends ZarrDataSource {
    */
   async getFlatArrDecompressed(path: string) {
     const { storeRoot } = this;
-    const arr = await zarrOpen(storeRoot.resolve(path), { kind: 'array' });
+    const location = storeRoot.resolve(path);
+    // A nullable column is a group, so opening it as an array throws. Resolve the
+    // node first rather than assuming, since index paths reach here directly.
+    const node = await zarrOpen(location);
+    if (node instanceof zarr.Group) {
+      if (!isNullableEncoding(node.attrs['encoding-type'])) {
+        throw new Error(
+          `Expected an array at ${path}, but found a group encoded as ` +
+            `${String(node.attrs['encoding-type'] ?? 'unknown')}.`
+        );
+      }
+      return (await readNullableArray(location)) as string[];
+    }
     // Zarrita supports decoding vlen-utf8-encoded string arrays.
-    const data = await zarrGet(arr);
+    const data = await zarrGet(node);
     if (data.data?.[Symbol.iterator]) {
       return Array.from(data.data) as string[];
     }

--- a/packages/core/src/models/VAnnDataSource.ts
+++ b/packages/core/src/models/VAnnDataSource.ts
@@ -95,16 +95,14 @@ export default class AnnDataSource extends ZarrDataSource {
     let categoriesValues: string[] | undefined;
     let codesPath: string | undefined;
     if (categories) {
-      const { dtype } = await zarrOpen(storeRoot.resolve(`${prefix}/${categories}`), {
-        kind: 'array',
-      });
-      if (dtype === 'v2:object') {
-        categoriesValues = await this.getFlatArrDecompressed(`${prefix}/${categories}`);
+      const categoriesPath = `${prefix}/${categories}`;
+      if (await this.hasTextValues(categoriesPath)) {
+        categoriesValues = await this.getFlatArrDecompressed(categoriesPath);
       }
     } else if (encodingType === 'categorical') {
-      const { dtype } = await zarrOpen(storeRoot.resolve(`${path}/categories`), { kind: 'array' });
-      if (dtype === 'v2:object') {
-        categoriesValues = await this.getFlatArrDecompressed(`${path}/categories`);
+      const categoriesPath = `${path}/categories`;
+      if (await this.hasTextValues(categoriesPath)) {
+        categoriesValues = await this.getFlatArrDecompressed(categoriesPath);
       }
       codesPath = `${path}/codes`;
     } else if (encodingType === 'string-array') {
@@ -123,7 +121,24 @@ export default class AnnDataSource extends ZarrDataSource {
     if (!categoriesValues) {
       return data as TableColumnData;
     }
-    return Array.from(data, (i) => categoriesValues[i as number]);
+    // Pandas encodes a missing categorical as code -1, which indexes nothing.
+    return Array.from(data, (code) => {
+      const index = Number(code);
+      return index < 0 ? null : categoriesValues[index];
+    });
+  }
+
+  /**
+   * Whether the array at *path* holds text, and so needs decoding to strings.
+   *
+   * Covers zarr v3 `string` arrays as well as v2's `object` and fixed-width
+   * unicode. Testing for `v2:object` alone silently leaves categorical columns
+   * resolving to their raw integer codes, which look like plausible data rather
+   * than an error.
+   */
+  private async hasTextValues(path: string): Promise<boolean> {
+    const arr = await zarrOpen(this.storeRoot.resolve(path), { kind: 'array' });
+    return arr.is('string') || arr.is('object');
   }
 
   /**

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -29,6 +29,7 @@ import type {
   ZarrTree,
 } from '../types';
 import { ATTRS_KEY, Err, Ok, ZARRAY_KEY } from '../types';
+import { NULLABLE_ENCODING_KINDS } from './nullableArrays';
 import SpatialDataPointsSource from './VPointsSource';
 import SpatialDataShapesSource from './VShapesSource';
 import SpatialDataTableSource from './VTableSource';
@@ -211,10 +212,20 @@ export type TableKeys = {
   instanceKey: string;
 };
 
-/** AnnData `encoding-type` values that settle the kind on their own. */
+/**
+ * AnnData `encoding-type` values that settle the kind on their own.
+ *
+ * The nullable encodings have to be listed here rather than left to the dtype
+ * branch below: they are groups of `values` + `mask`, so there is no array
+ * metadata on the node itself to fall back to. Leaving them out is not a
+ * missing edge case — AnnData 0.13 writes string columns this way by default on
+ * zarr v3, `obs/_index` included, so the columns that most need a declared kind
+ * are exactly the ones that would arrive without one.
+ */
 const OBS_KIND_BY_ENCODING: Record<string, TableColumnKind> = {
   categorical: 'categorical',
   'string-array': 'string',
+  ...NULLABLE_ENCODING_KINDS,
 };
 
 /**
@@ -415,9 +426,8 @@ export class TableElement extends AbstractElement<'tables'> {
    * `undefined` for a column that is absent or whose node we do not recognise.
    */
   getObsColumnKinds(columnNames: string[]): Array<TableColumnKind | undefined> {
-    const node = this.parsed as ZarrTree;
-    const obsNode = node.obs as ZarrTree | undefined;
-    if (!obsNode || typeof obsNode !== 'object') {
+    const obsNode = this.getObsGroup();
+    if (!obsNode) {
       return columnNames.map(() => undefined);
     }
     return columnNames.map((columnName) => classifyObsColumnNode(obsNode[columnName]));

--- a/packages/core/src/models/nullableArrays.ts
+++ b/packages/core/src/models/nullableArrays.ts
@@ -1,5 +1,5 @@
 import { type Location, type Readable, get as zarrGet, open as zarrOpen } from 'zarrita';
-import type { TableValue } from '../types';
+import type { TableColumnKind, TableValue } from '../types';
 
 /**
  * AnnData's nullable encodings, which store a column as a *group* rather than an
@@ -14,12 +14,20 @@ import type { TableValue } from '../types';
  *
  * See the AnnData on-disk specification, "Nullable integers, booleans and
  * strings" — all three share this group layout at encoding-version 0.1.0.
+ *
+ * The mapped value is the kind of the column's `values`, which is what the
+ * encoding name already tells us — the mask changes which entries are present,
+ * never what type they are. Declared here rather than at the classifier so the
+ * three encoding names are listed once: reading them and classifying them have
+ * to stay in step, and they live in different modules.
  */
-export const NULLABLE_ENCODING_TYPES = new Set([
-  'nullable-string-array',
-  'nullable-integer',
-  'nullable-boolean',
-]);
+export const NULLABLE_ENCODING_KINDS: Record<string, TableColumnKind> = {
+  'nullable-string-array': 'string',
+  'nullable-integer': 'numeric',
+  'nullable-boolean': 'boolean',
+};
+
+export const NULLABLE_ENCODING_TYPES = new Set(Object.keys(NULLABLE_ENCODING_KINDS));
 
 export function isNullableEncoding(encodingType: unknown): boolean {
   return typeof encodingType === 'string' && NULLABLE_ENCODING_TYPES.has(encodingType);

--- a/packages/core/src/models/nullableArrays.ts
+++ b/packages/core/src/models/nullableArrays.ts
@@ -1,0 +1,63 @@
+import { type Location, type Readable, get as zarrGet, open as zarrOpen } from 'zarrita';
+import type { TableValue } from '../types';
+
+/**
+ * AnnData's nullable encodings, which store a column as a *group* rather than an
+ * array: a `values` array plus a boolean `mask` marking the null positions.
+ *
+ * Readers that open a column path as an array fail outright on these — the
+ * symptom is a missing index rather than a missing value, because
+ * `obs/_index` and `var/_index` are themselves ordinary columns. AnnData writes
+ * this layout by default from 0.13 onwards (and `spatialdata` inherits it), so
+ * it turns up in freshly written stores, not only in ones that have been
+ * rewritten.
+ *
+ * See the AnnData on-disk specification, "Nullable integers, booleans and
+ * strings" — all three share this group layout at encoding-version 0.1.0.
+ */
+export const NULLABLE_ENCODING_TYPES = new Set([
+  'nullable-string-array',
+  'nullable-integer',
+  'nullable-boolean',
+]);
+
+export function isNullableEncoding(encodingType: unknown): boolean {
+  return typeof encodingType === 'string' && NULLABLE_ENCODING_TYPES.has(encodingType);
+}
+
+/**
+ * Read a nullable-encoded column into a flat array, with `null` at masked
+ * positions.
+ *
+ * The mask is read alongside the values rather than ignored: a masked entry is
+ * absent, not empty, and callers that render it (tooltips, legends) need to be
+ * able to tell those apart.
+ */
+export async function readNullableArray(location: Location<Readable>): Promise<TableValue[]> {
+  const valuesArray = await zarrOpen(location.resolve('values'), { kind: 'array' });
+  const values = await zarrGet(valuesArray);
+
+  // The specification requires a mask, but a values-only group is still
+  // unambiguous, so read what is there rather than failing on a missing mask.
+  let mask: boolean[] | undefined;
+  try {
+    const maskArray = await zarrOpen(location.resolve('mask'), { kind: 'array' });
+    mask = toArray((await zarrGet(maskArray)).data).map(Boolean);
+  } catch {
+    mask = undefined;
+  }
+
+  return toArray(values.data).map((value, index) => (mask?.[index] ? null : value));
+}
+
+/**
+ * Materialise a zarrita chunk as a plain array.
+ *
+ * Zarrita returns several backing types — native TypedArrays plus its own
+ * `BoolArray`/`ByteStringArray`/`UnicodeStringArray`. They are all iterable but
+ * do not share an indexable interface, so the union has no common supertype to
+ * narrow to; iterating is the one operation defined across all of them.
+ */
+function toArray(data: unknown): TableValue[] {
+  return Array.from(data as Iterable<TableValue>);
+}

--- a/packages/core/tests/nullableStringArray.spec.ts
+++ b/packages/core/tests/nullableStringArray.spec.ts
@@ -1,0 +1,163 @@
+import { execSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import SpatialDataTableSource from '../src/models/VTableSource.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const writerRoot = join(__dirname, '../../../python/spatialdata-js-util');
+
+/**
+ * Write a SpatialData store whose table uses AnnData's nullable encodings.
+ *
+ * These are groups of `values` + `mask`, not arrays. AnnData writes them by
+ * default from 0.13 onwards, so this is what a freshly written store looks like
+ * — a reader that opens `var/_index` as an array fails on it and has no variable
+ * names to show.
+ *
+ * Note that only the index ends up as `nullable-string-array`: AnnData's
+ * `strings_to_categoricals` turns string *columns* into categoricals on write,
+ * so the nullable string case is reached through `obs/_index` and `var/_index`.
+ * A nullable *integer* column exercises the same group layout with a mask that
+ * actually has a bit set.
+ */
+function writeNullableTableFixture(storeRoot: string) {
+  execSync(
+    `uv run --extra write python - <<'PY'
+import anndata as ad
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+import spatialdata as sd
+from pathlib import Path
+from spatialdata.models import TableModel
+
+root = Path(${JSON.stringify(storeRoot)})
+
+adata = ad.AnnData(X=sp.random(10, 6, density=0.5, format="csc", random_state=0, dtype=np.float32))
+adata.var.index = pd.array([f"GENE{i}" for i in range(6)], dtype="string")
+adata.obs.index = pd.array([f"cell{i}" for i in range(10)], dtype="string")
+adata.obs["region"] = pd.Categorical(["img"] * 10)
+adata.obs["instance_id"] = np.arange(10)
+# A genuine missing value, so the mask is exercised rather than only the
+# all-present case.
+adata.var["measured"] = pd.array([1, 2, None, 4, 5, 6], dtype="Int64")
+
+table = TableModel.parse(
+    adata, region="img", region_key="region", instance_key="instance_id"
+)
+
+ad.settings.zarr_write_format = 3
+ad.settings.auto_shard_zarr_v3 = False
+ad.settings.allow_write_nullable_strings = True
+sd.SpatialData(tables={"table": table}).write(root, overwrite=True)
+
+# Fail loudly here rather than letting the test assert against the wrong layout.
+encoding = __import__("json").loads(
+    (root / "tables" / "table" / "var" / "_index" / "zarr.json").read_text()
+)["attributes"]["encoding-type"]
+assert encoding == "nullable-string-array", f"fixture wrote {encoding!r}"
+PY`,
+    { cwd: writerRoot, stdio: 'pipe' }
+  );
+}
+
+function createFilesystemStore(root: string) {
+  const readStoreBytes = async (relativePath: string): Promise<Uint8Array | null> => {
+    const fullPath = join(root, relativePath);
+    try {
+      const info = await stat(fullPath);
+      if (info.isDirectory()) {
+        return null;
+      }
+      return await readFile(fullPath);
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    async get(path: string) {
+      const relativePath = path.startsWith('/') ? path.slice(1) : path;
+      return readStoreBytes(relativePath);
+    },
+    async getRange(
+      path: string,
+      range: { offset?: number; length?: number; suffixLength?: number }
+    ) {
+      const relativePath = path.startsWith('/') ? path.slice(1) : path;
+      const bytes = await readStoreBytes(relativePath);
+      if (!bytes) {
+        return null;
+      }
+      if (range.suffixLength != null) {
+        return bytes.subarray(bytes.length - range.suffixLength);
+      }
+      const offset = range.offset ?? 0;
+      const length = range.length ?? bytes.length - offset;
+      return bytes.subarray(offset, offset + length);
+    },
+  };
+}
+
+describe('nullable-encoded AnnData columns', () => {
+  let fixtureRoot: string;
+  let source: SpatialDataTableSource;
+
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(join(tmpdir(), 'nullable-anndata-'));
+    const storeRoot = join(fixtureRoot, 'store.zarr');
+    writeNullableTableFixture(storeRoot);
+    source = new SpatialDataTableSource({
+      store: createFilesystemStore(storeRoot),
+      fileType: '.zarr',
+    });
+  }, 300_000);
+
+  afterAll(async () => {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('reads var names from a nullable-string-array index', async () => {
+    const names = await source.loadVarIndex('tables/table');
+    expect(names).toEqual(['GENE0', 'GENE1', 'GENE2', 'GENE3', 'GENE4', 'GENE5']);
+  });
+
+  it('reads a nullable-string-array obs index', async () => {
+    const [ids] = await source.loadObsColumns(['tables/table/obs/_index']);
+    expect(Array.from(ids ?? [])).toEqual([
+      'cell0',
+      'cell1',
+      'cell2',
+      'cell3',
+      'cell4',
+      'cell5',
+      'cell6',
+      'cell7',
+      'cell8',
+      'cell9',
+    ]);
+  });
+
+  it('still prefers instance_key over the obs index when the table declares one', async () => {
+    // Not a nullable-encoding concern, but it shares the code path — the new
+    // branch must not divert reads that were already resolving correctly.
+    const ids = await source.loadObsIndex('tables/table');
+    expect(ids).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+  });
+
+  it('reads a nullable integer column, preserving the missing entry as null', async () => {
+    const [measured] = await source.loadVarColumns(['tables/table/var/measured']);
+    // Masked entries must stay distinguishable from a real zero.
+    expect(Array.from(measured ?? [], (v) => (v === null ? null : Number(v)))).toEqual([
+      1,
+      2,
+      null,
+      4,
+      5,
+      6,
+    ]);
+  });
+});

--- a/packages/core/tests/nullableStringArray.spec.ts
+++ b/packages/core/tests/nullableStringArray.spec.ts
@@ -3,8 +3,10 @@ import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { FileSystemStore } from '@zarrita/storage';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import SpatialDataTableSource from '../src/models/VTableSource.js';
+import { readZarr } from '../src/store/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const writerRoot = join(__dirname, '../../../python/spatialdata-js-util');
@@ -41,6 +43,12 @@ adata.var.index = pd.array([f"GENE{i}" for i in range(6)], dtype="string")
 adata.obs.index = pd.array([f"cell{i}" for i in range(10)], dtype="string")
 adata.obs["region"] = pd.Categorical(["img"] * 10)
 adata.obs["instance_id"] = np.arange(10)
+# Nullable obs columns, so the kind lookup is exercised on columns and not only
+# on the index (which \`getObsColumnNames\` filters out).
+adata.obs["qc_count"] = pd.array([1, None, 3, 4, 5, 6, 7, 8, 9, 10], dtype="Int64")
+adata.obs["passes_qc"] = pd.array(
+    [True, None, False, True, True, False, True, True, False, True], dtype="boolean"
+)
 # A genuine missing value, so the mask is exercised rather than only the
 # all-present case.
 adata.var["measured"] = pd.array([1, 2, None, 4, 5, 6], dtype="Int64")
@@ -58,10 +66,21 @@ ad.settings.allow_write_nullable_strings = True
 sd.SpatialData(tables={"table": table}).write(root, overwrite=True)
 
 # Fail loudly here rather than letting the test assert against the wrong layout.
-encoding = __import__("json").loads(
-    (root / "tables" / "table" / "var" / "_index" / "zarr.json").read_text()
-)["attributes"]["encoding-type"]
-assert encoding == "nullable-string-array", f"fixture wrote {encoding!r}"
+json = __import__("json")
+
+
+def encoding_of(*parts):
+    path = root.joinpath("tables", "table", *parts, "zarr.json")
+    return json.loads(path.read_text())["attributes"]["encoding-type"]
+
+
+for parts, expected in [
+    (("var", "_index"), "nullable-string-array"),
+    (("obs", "qc_count"), "nullable-integer"),
+    (("obs", "passes_qc"), "nullable-boolean"),
+]:
+    actual = encoding_of(*parts)
+    assert actual == expected, f"fixture wrote {actual!r} for {'/'.join(parts)}"
 PY`,
     { cwd: writerRoot, stdio: 'pipe' }
   );
@@ -107,11 +126,12 @@ function createFilesystemStore(root: string) {
 
 describe('nullable-encoded AnnData columns', () => {
   let fixtureRoot: string;
+  let storeRoot: string;
   let source: SpatialDataTableSource;
 
   beforeAll(async () => {
     fixtureRoot = await mkdtemp(join(tmpdir(), 'nullable-anndata-'));
-    const storeRoot = join(fixtureRoot, 'store.zarr');
+    storeRoot = join(fixtureRoot, 'store.zarr');
     writeNullableTableFixture(storeRoot);
     source = new SpatialDataTableSource({
       store: createFilesystemStore(storeRoot),
@@ -167,5 +187,48 @@ describe('nullable-encoded AnnData columns', () => {
       5,
       6,
     ]);
+  });
+
+  describe('declared column kinds', () => {
+    /**
+     * The kind lookup runs on the consolidated metadata rather than on decoded
+     * values, so it is only meaningful against a tree opened from a real store —
+     * a mock tree would assert the shape we chose to write in the mock.
+     */
+    async function openTable() {
+      const sdata = await readZarr(new FileSystemStore(storeRoot));
+      const table = sdata.tables?.table;
+      if (!table) {
+        throw new Error('fixture store has no `table`');
+      }
+      return table;
+    }
+
+    it('reports the kind of a nullable column instead of leaving it undefined', async () => {
+      const table = await openTable();
+      const kinds = Object.fromEntries(
+        ['qc_count', 'passes_qc', 'region', 'instance_id'].map((name) => [
+          name,
+          table.getObsColumnKinds([name])[0],
+        ])
+      );
+      // The nullable pair is the point: they are groups, so there is no array
+      // metadata to fall back on and an unlisted encoding yields `undefined`,
+      // which sends callers back to sniffing decoded values.
+      expect(kinds).toEqual({
+        qc_count: 'numeric',
+        passes_qc: 'boolean',
+        region: 'categorical',
+        instance_id: 'numeric',
+      });
+    });
+
+    it('still excludes the index from the obs columns when it is nullable-encoded', async () => {
+      const table = await openTable();
+      expect(table.getObsColumnNames()).not.toContain('_index');
+      expect(table.getObsColumnNames()).toEqual(
+        expect.arrayContaining(['region', 'instance_id', 'qc_count', 'passes_qc'])
+      );
+    });
   });
 });

--- a/packages/core/tests/nullableStringArray.spec.ts
+++ b/packages/core/tests/nullableStringArray.spec.ts
@@ -44,6 +44,9 @@ adata.obs["instance_id"] = np.arange(10)
 # A genuine missing value, so the mask is exercised rather than only the
 # all-present case.
 adata.var["measured"] = pd.array([1, 2, None, 4, 5, 6], dtype="Int64")
+# A categorical with a missing entry. Written as a zarr v3 \`string\` categories
+# array, which is the case a v2-only dtype check silently mis-reads as codes.
+adata.var["family"] = pd.Categorical(["kinase", "kinase", None, "gpcr", "gpcr", "kinase"])
 
 table = TableModel.parse(
     adata, region="img", region_key="region", instance_key="instance_id"
@@ -146,6 +149,11 @@ describe('nullable-encoded AnnData columns', () => {
     // branch must not divert reads that were already resolving correctly.
     const ids = await source.loadObsIndex('tables/table');
     expect(ids).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+  });
+
+  it('decodes a zarr v3 categorical to labels rather than raw codes', async () => {
+    const [family] = await source.loadVarColumns(['tables/table/var/family']);
+    expect(Array.from(family ?? [])).toEqual(['kinase', 'kinase', null, 'gpcr', 'gpcr', 'kinase']);
   });
 
   it('reads a nullable integer column, preserving the missing entry as null', async () => {

--- a/packages/core/tests/tableElement.spec.ts
+++ b/packages/core/tests/tableElement.spec.ts
@@ -173,6 +173,30 @@ describe('obs column kinds from consolidated metadata', () => {
     ).toEqual(['numeric', 'numeric', 'boolean', 'string', 'categorical']);
   });
 
+  it('classifies nullable columns from the encoding alone', () => {
+    // A nullable column is a GROUP of `values` + `mask`, so the node carries no
+    // array metadata of its own — the encoding name is the only thing on it that
+    // says what the column holds. AnnData 0.13 writes string columns this way by
+    // default on zarr v3, so this is the common shape, not an exotic one.
+    const nullableNode = (encodingType: string, valuesDataType: string) => ({
+      [ATTRS_KEY]: { 'encoding-type': encodingType, 'encoding-version': '0.1.0' },
+      values: arrayNode({ data_type: valuesDataType }),
+      mask: arrayNode({ data_type: 'bool' }),
+    });
+
+    const table = tableWithObs({
+      barcode: nullableNode('nullable-string-array', 'string'),
+      qc_count: nullableNode('nullable-integer', 'int64'),
+      passes_qc: nullableNode('nullable-boolean', 'bool'),
+    });
+
+    expect(table.getObsColumnKinds(['barcode', 'qc_count', 'passes_qc'])).toEqual([
+      'string',
+      'numeric',
+      'boolean',
+    ]);
+  });
+
   it('returns undefined for absent or unrecognised columns', () => {
     const table = tableWithObs({
       mystery: { [ATTRS_KEY]: { 'encoding-type': 'something-new' } },


### PR DESCRIPTION
> **Stacked on #100** — targets `claude/spatialdata-python-package-17c6d7` because the test fixture writes a real store with `python/spatialdata-js-util`. Review the base PR first; this diff is 6 files under `packages/core`.

Teaches the reader two shapes it did not handle, both of which fail *silently* — plausible output rather than an error.

## Nullable-encoded columns

AnnData stores a nullable column as a **group** of `values` + `mask`, not an array, so opening its path as an array fails outright. The symptom is usually a missing *index* rather than a missing value, because `obs/_index` and `var/_index` are ordinary columns — a table loads with `varN` in place of gene names, or with no row ids at all.

This is not a legacy shape to tolerate. `anndata` 0.13 defaults to `zarr_write_format = 3` and writes string columns this way by default, `_index` included, so it is simply what a freshly written `spatialdata` 0.8 store looks like. I confirmed the pandas dtype makes no difference — a plain `object` index and a `pd.array(..., dtype="string")` one both come out nullable.

All three encodings are read (`nullable-string-array`, `nullable-integer`, `nullable-boolean`) with the mask honoured, so a masked entry decodes as `null`. The missing-value handling from #95 already treats `null` as absent, so it stays distinguishable from a real `0` or `''` rather than being rendered as one.

## Declared kinds for the same columns

`getObsColumnKinds` did not recognise them either. It settles the kind from `encoding-type` where one is decisive and otherwise falls back to dtype in the node's array metadata — which a group does not have — so every nullable column came back `undefined`, sending `'auto'` mode back to sniffing decoded values. That is the case the lookup exists to avoid, and on a current store it would have applied to most of the text columns.

The three encoding names live in `nullableArrays.ts` next to the reader, mapped to the kind of their `values`. Listing them at the classifier instead would mean two places that must agree about what AnnData writes, in different modules.

## zarr v3 categoricals

Separately: a v3 categorical decoded to its raw integer codes. The categories array is written as `string` on v3, and the text check tested for one v2 spelling of that dtype (`v2:object`), so the column resolved to codes — plausible-looking numbers, no error anywhere. It now asks zarrita whether the dtype is text, which covers v3 `string` and v2 `U`/`S` alike. Pandas' `-1` missing code maps to `null` instead of indexing off the end of the categories array.

Confirmed on a real store: `feature_types` reads `"Gene Expression"` and `genome` reads `"Unknown"` where both previously came back as `0`.

## Testing

- Unit cases in `tableElement.spec.ts` for all three encodings against mock tree nodes.
- Two end-to-end cases that open the fixture store through `readZarr` and assert kinds off the real tree — a mock would only assert the shape the mock chose to write.
- The fixture asserts its own encodings before the tests run, so it fails loudly rather than misleadingly if `anndata` changes what it writes.

I checked the kind test fails without the fix (`qc_count: undefined` where `'numeric'` is expected) rather than passing for unrelated reasons.

## Known gap

The `0.5.0` / `0.6.1` / `0.7.2` integration fixtures all predate nullable encodings — I checked, and every one writes `obs/_index` as a `string-array` **array**. So the integration net has never seen this shape and stays green through it. A `v0.8.0` fixture would close that; left for its own PR since it touches fixture generation and CI time.

Related: #97 (the guards would not have fixed any of this on their own — the group branch is incomplete independently of the casts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
