### PR TITLE
Make HTJ2K lossy presets bit-depth relative

### DIFF
--- a/docs/docs/vis/codec-fixtures.mdx
+++ b/docs/docs/vis/codec-fixtures.mdx
@@ -138,11 +138,15 @@ JP2K and HTJ2K share preset names (`lossless`, `balanced`, `small`). HTJ2K encod
 uses OpenJPH WASM (`experimental.openjph_htj2k`) via
 `HTJ2KEncoder.setQuality(reversible, quality)`. The quality argument is a float
 quantization factor (lower = higher fidelity, larger output) — not JP2K-style
-0–100. Presets map to `balanced: 0.0002`, `small: 0.001` (calibrated roughly on
-Xenium morphology; see `python/spatialdata-js-util/docs/htj2k-wasm-encode-design.md`).
-Override with CLI `--quality 0.001` or per-image JSON `"quality": 0.001` (implies
-lossy unless `"reversible": true`). A future codec-demo UI may add interactive `q`
-exploration on sample regions.
+0–100. The step is relative to the dtype's full range, so HTJ2K presets are
+expressed as a multiple of the input's LSB and resolve from the raster's dtype:
+`balanced: 2 LSB`, `small: 5 LSB` — `0.0078125`/`0.01953125` for `uint8`,
+`0.000030518`/`0.000076294` for `uint16`. A step below one LSB encodes *larger*
+than lossless for a bit-identical image, so the presets stay clear above that
+floor; see `python/spatialdata-js-util/docs/htj2k-wasm-encode-design.md`.
+Override with CLI `--quality 0.001` or per-image JSON `"quality": 0.001` (an
+absolute step, not an LSB multiple; implies lossy unless `"reversible": true`).
+A future codec-demo UI may add interactive `q` exploration on sample regions.
 
 `generate_codec_fixtures.py --experimental-htj2k` also writes
 `htj2k-quality-sweep.manifest.json`, encoding the same Mandelbrot plane at several

--- a/packages/vis/demo/src/CodecFixtureDemo.tsx
+++ b/packages/vis/demo/src/CodecFixtureDemo.tsx
@@ -306,7 +306,8 @@ function Htj2kEncodeDemoPanel({
       {htj2kDemo ? (
         <div style={{ color: '#888', marginBottom: 8 }}>
           Toggle <code>mandelbrot_*</code> layers to compare HTJ2K presets (balanced{' '}
-          <code>q=0.0002</code>, small <code>q=0.001</code>). Interactive per-<code>q</code>{' '}
+          <code>2 LSB</code>, small <code>5 LSB</code> — on this <code>uint16</code> plane,{' '}
+          <code>q=3.05e-5</code> and <code>q=7.63e-5</code>). Interactive per-<code>q</code>{' '}
           transcoding in the viewer is planned for a later pass.
         </div>
       ) : null}

--- a/python/spatialdata-js-util/README.md
+++ b/python/spatialdata-js-util/README.md
@@ -153,13 +153,28 @@ working.
 ### Presets and `--quality`
 
 `--quality` is the OpenJPH quantization step: **lower means higher fidelity and a
-larger codestream** — not a JPEG-style 0–100 scale.
+larger codestream** — not a JPEG-style 0–100 scale. The step is relative to the
+dtype's full dynamic range, so one input LSB is `1/256` for 8-bit data and
+`1/65536` for 16-bit.
 
-| Preset | JPEG 2000 | HTJ2K |
-|--------|-----------|-------|
-| `lossless` | reversible, round-trip verified | `reversible=True` |
-| `balanced` | `level=100` | `quality=0.0002` |
-| `small` | `level=75` | `quality=0.001` |
+HTJ2K presets are therefore expressed as a **multiple of the input's LSB**, and
+resolve to a concrete step from the raster's dtype:
+
+| Preset | JPEG 2000 | HTJ2K | `uint8` | `uint16` |
+|--------|-----------|-------|---------|----------|
+| `lossless` | reversible, round-trip verified | `reversible=True` | — | — |
+| `balanced` | `level=100` | 2 LSB | `0.0078125` | `0.000030518` |
+| `small` | `level=75` | 5 LSB | `0.01953125` | `0.000076294` |
+
+A step **below one input LSB is strictly worse than lossless**: it cannot buy
+fidelity the data does not have, so the irreversible transform returns a
+bit-identical image while encoding *larger* than `--preset lossless`. Passing
+such a `--quality` warns and names the floor. The resolved step is recorded in
+the manifest under `encode_options`.
+
+An explicit `--quality` is an absolute step, not an LSB multiple, so pick it for
+the raster's dtype — `0.0005` below is ~33 LSB of `uint16` morphology, but would
+be 0.13 LSB (worse than lossless) on 8-bit input:
 
 ```bash
 spatialdata-js-util images recompress input.zarr out.zarr \

--- a/python/spatialdata-js-util/docs/htj2k-wasm-encode-design.md
+++ b/python/spatialdata-js-util/docs/htj2k-wasm-encode-design.md
@@ -48,35 +48,56 @@ to copy `openjph-wasm` dist assets (`index.mjs` + `wasm/`) into the Python packa
 wheel. The copied `vendor/openjph/` blobs are gitignored; CI and
 `pnpm test:python` run the vendor step after `pnpm install`.
 
-Preset mapping:
+Preset mapping — the lossy steps are **relative to the input's bit depth**:
 
-| Preset | `encode({ reversible, quality })` |
-|--------|-----------------------------------|
-| `lossless` | `{ reversible: true }` |
-| `balanced` | `{ reversible: false, quality: 0.0002 }` |
-| `small` | `{ reversible: false, quality: 0.001 }` |
+| Preset | `quality` in LSB | `uint8` step | `uint16` step |
+|--------|------------------|--------------|---------------|
+| `lossless` | — (`reversible: true`) | — | — |
+| `balanced` | 2 | `0.0078125` | `0.000030518` |
+| `small` | 5 | `0.01953125` | `0.000076294` |
 
-`quality` is a float quantization factor (lower = better fidelity, larger output).
-Integer values above ~15 with `reversible=false` produce degenerate output.
+`quality` is a float quantization step, normalised to the dtype's **full dynamic
+range** (lower = better fidelity, larger output). Integer values above ~15 with
+`reversible=false` produce degenerate output.
 
-### Preset calibration (rough)
+### Why presets are bit-depth relative
 
-Early presets (`balanced: 0.005`, `small: 0.01`) were tuned on 64×64 Mandelbrot
-fixtures. On full-range Xenium morphology `uint16` chunks (1024×1024 planes), that
-`balanced` setting was far more lossy than JP2K `balanced` (`level=100`).
+One input LSB is `1 / 2**bits`, so the same absolute `quality` means different
+things at different depths. Measured on 1024² planes (`imagecodecs` 2026.6.26;
+size as a ratio to the reversible encode of the same plane):
 
-Spot checks on one morphology pyramid chunk (`RMSE` on decoded vs source):
+| Step, in LSB | `uint8` H&E | `uint8` retina | `uint16` cells3d | mean error |
+|--------------|-------------|----------------|------------------|-----------|
+| 0.05 | **1.89×** | **2.76×** | — | 0 |
+| 0.26 | **1.39×** | **1.60×** | — | 0 |
+| 1 | 0.92× | 0.58× | 1.00× | ~0.2 LSB |
+| 2 (`balanced`) | 0.68× | 0.29× | 0.93× | ~0.6 LSB |
+| 5 (`small`) | 0.39× | 0.13× | 0.83× | ~1.6 LSB |
 
-| Setting | Encoded (1024² `uint16`) | RMSE |
-|---------|--------------------------|------|
-| JP2K `balanced` | ~722 KiB | ~0.3 |
-| HTJ2K `q=0.0002` (new `balanced`) | ~419 KiB | ~5 |
-| HTJ2K `q=0.001` (new `small`) | ~128 KiB | ~22 |
-| HTJ2K `q=0.005` (old `balanced`) | ~39 KiB | ~60 |
+Both effects are content-independent: a step measured in LSB is the
+dtype-independent knob, and below ~1 LSB (`HTJ2K_QUALITY_FLOOR_LSB`) the
+irreversible 9/7 path is strictly dominated — it returns a bit-identical image
+for more bytes than reversible 5/3. Presets stay above that floor; an explicit
+`quality` below it warns.
 
-Preset names are aligned **roughly** with JP2K intent on real morphology data,
-not bit-identical rate control. For per-dataset tuning, prefer explicit `quality`
-rather than presets alone.
+The earlier absolute presets (`balanced: 0.0002`, `small: 0.001`) were
+calibrated only on full-range Xenium morphology `uint16`, where they are 13.1
+and 65.5 LSB. On `uint8` they are 0.05 and 0.26 LSB, so both encoded *larger*
+than `lossless` for a bit-identical image — the expected size ordering reversed.
+
+Preset names track JP2K intent **roughly**, not bit-identical rate control. For
+per-dataset tuning prefer an explicit `quality`, remembering it is an absolute
+step rather than an LSB multiple.
+
+### Known defect: saturated samples wrap on the lossy path
+
+Lossy HTJ2K reconstructs samples at the dtype ceiling slightly out of range, and
+**both** decoders (`imagecodecs` and `openjph-wasm`) wrap rather than clamp:
+`255 → 0` for `uint8`, `65535 → 0` for `uint16`. On an H&E plane with a
+saturated white background that is isolated black pixels — 14 of 1,048,576 at
+`balanced`. Clipping the source to `254` removes them entirely and the
+reversible path is unaffected, so encode `lossless` where data touches the dtype
+maximum until this is fixed upstream.
 
 ### CLI and JSON
 

--- a/python/spatialdata-js-util/scripts/htj2k_fixtures.py
+++ b/python/spatialdata-js-util/scripts/htj2k_fixtures.py
@@ -12,6 +12,7 @@ from spatialdata_js_util.codecs import (
     htj2k_available,
 )
 from spatialdata_js_util.codecs.htj2k_wasm import encode_htj2k_wasm
+from spatialdata_js_util.images import htj2k_preset_quality
 from spatialdata_js_util.store import write_json
 
 from fixture_writer import CodecImageWrite, WrittenFixture, write_codec_spatialdata, write_codec_spatialdata_images
@@ -34,18 +35,25 @@ HTJ2K_QUALITY_SWEEP: tuple[dict[str, Any], ...] = (
 
 HTJ2K_ENCODE_DEMO_SIZE = 512
 HTJ2K_ENCODE_DEMO_CHUNKS: tuple[int, int, int, int, int] = (1, 1, 1, 64, 64)
-HTJ2K_ENCODE_DEMO_PRESETS: tuple[dict[str, Any], ...] = (
-    {"label": "lossless", "suffix": "lossless", "encode_options": {"reversible": True}},
-    {
-        "label": "balanced (q=0.0002)",
-        "suffix": "balanced",
-        "encode_options": {"reversible": False, "quality": 0.0002},
-    },
-    {
-        "label": "small (q=0.001)",
-        "suffix": "small",
-        "encode_options": {"reversible": False, "quality": 0.001},
-    },
+
+# The demo plane is uint16, and presets are relative to the input's bit depth, so
+# resolve them here rather than restating absolute steps that would drift.
+HTJ2K_ENCODE_DEMO_DTYPE = np.dtype("uint16")
+
+
+def _demo_preset(preset: str) -> dict[str, Any]:
+    quality = htj2k_preset_quality(preset, HTJ2K_ENCODE_DEMO_DTYPE)
+    if quality is None:
+        return {"label": preset, "suffix": preset, "encode_options": {"reversible": True}}
+    return {
+        "label": f"{preset} (q={quality:g})",
+        "suffix": preset,
+        "encode_options": {"reversible": False, "quality": quality},
+    }
+
+
+HTJ2K_ENCODE_DEMO_PRESETS: tuple[dict[str, Any], ...] = tuple(
+    _demo_preset(preset) for preset in ("lossless", "balanced", "small")
 )
 
 

--- a/python/spatialdata-js-util/scripts/write_synthetic.py
+++ b/python/spatialdata-js-util/scripts/write_synthetic.py
@@ -16,8 +16,11 @@ if _SRC_DIR not in sys.path:
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
+import numpy as np
+
 from spatialdata_js_util.codecs import CODEC_HTJ2K_OPENJPH, CODEC_JPEG2K
 from spatialdata_js_util.codecs import htj2k_available
+from spatialdata_js_util.images import htj2k_preset_quality
 
 from fixture_writer import WrittenFixture, write_codec_spatialdata
 from synthetic_images import fractal_tczyx_image, mandelbrot_plane, volume_tczyx
@@ -67,7 +70,8 @@ def _encode_options(args: argparse.Namespace) -> dict[str, Any] | None:
         return {"reversible": True}
     if args.quality is not None:
         return {"reversible": False, "quality": args.quality}
-    preset_quality = {"balanced": 0.0002, "small": 0.001}.get(args.preset)
+    # Presets are relative to the input's bit depth; synthetic planes are uint16.
+    preset_quality = htj2k_preset_quality(args.preset, np.dtype("uint16"))
     if preset_quality is not None:
         return {"reversible": False, "quality": preset_quality}
     return {"reversible": True}

--- a/python/spatialdata-js-util/src/spatialdata_js_util/__init__.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/__init__.py
@@ -27,8 +27,11 @@ from .codecs import (
 )
 from .images import (
     HTJ2K_PRESETS,
+    HTJ2K_QUALITY_FLOOR_LSB,
     JP2K_PRESETS,
     RecompressedSpatialData,
+    dtype_quantum,
+    htj2k_preset_quality,
     recompress_spatialdata,
     resolve_recompression_config,
 )
@@ -58,6 +61,7 @@ __all__ = [
     "CODEC_HTJ2K_OPENJPH",
     "CODEC_JPEG2K",
     "HTJ2K_PRESETS",
+    "HTJ2K_QUALITY_FLOOR_LSB",
     "JP2K_PRESETS",
     "MORTON_CODE_2D_COLUMN",
     "MORTON_CODE_EXTREME_VALUE_INDICATOR",
@@ -69,8 +73,10 @@ __all__ = [
     "backend_report",
     "build_spatialdata_multiscale_metadata",
     "convert_store_tables_to_csc",
+    "dtype_quantum",
     "has_pyramid",
     "htj2k_available",
+    "htj2k_preset_quality",
     "is_htj2k_codec",
     "morton_sort_points",
     "recompress_spatialdata",

--- a/python/spatialdata-js-util/src/spatialdata_js_util/cli.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/cli.py
@@ -227,9 +227,11 @@ def _add_images_commands(subparsers: argparse._SubParsersAction) -> None:
         type=float,
         metavar="Q",
         help=(
-            "HTJ2K quantization factor (lower = better fidelity, larger output). "
-            "Implies lossy encoding; use with --codec experimental.openjph_htj2k. "
-            "Overrides preset quality."
+            "HTJ2K quantization step, relative to the dtype's full range "
+            "(lower = better fidelity, larger output). Implies lossy encoding; use "
+            "with --codec experimental.openjph_htj2k. Overrides preset quality. "
+            "Below one input LSB (1/256 for 8-bit, 1/65536 for 16-bit) the output "
+            "is bit-identical but LARGER than --preset lossless; that warns."
         ),
     )
     recompress.add_argument(

--- a/python/spatialdata-js-util/src/spatialdata_js_util/codecs/__init__.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/codecs/__init__.py
@@ -14,9 +14,12 @@ from .backends import (
 )
 from .chunks import chunk_grid, chunk_slices, pad_chunk
 from .encoding import (
+    HTJ2K_DEFAULT_QUALITY_LSB,
+    HTJ2K_QUALITY_FLOOR_LSB,
     decode_htj2k_plane,
     decode_image_chunk,
     decode_image_plane,
+    dtype_quantum,
     encode_image_chunk,
     encode_image_plane,
     htj2k_encode_options,
@@ -38,7 +41,9 @@ __all__ = [
     "CODEC_HTJ2K_LEGACY",
     "CODEC_HTJ2K_OPENJPH",
     "CODEC_JPEG2K",
+    "HTJ2K_DEFAULT_QUALITY_LSB",
     "HTJ2K_ENCODER",
+    "HTJ2K_QUALITY_FLOOR_LSB",
     "SUPPORTED_IMAGE_CODECS",
     "Htj2kCodec",
     "Jpeg2kCodec",
@@ -50,6 +55,7 @@ __all__ = [
     "decode_htj2k_plane",
     "decode_image_chunk",
     "decode_image_plane",
+    "dtype_quantum",
     "encode_image_chunk",
     "encode_image_plane",
     "htj2k_available",

--- a/python/spatialdata-js-util/src/spatialdata_js_util/codecs/encoding.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/codecs/encoding.py
@@ -15,21 +15,46 @@ from .backends import require_backend
 from .names import CODEC_HTJ2K_OPENJPH, CODEC_JPEG2K, is_htj2k_codec
 
 
-def htj2k_encode_options(encode_options: dict[str, Any]) -> tuple[bool, float]:
+# A quantization step below one input LSB cannot buy fidelity the input does not
+# have: the irreversible 9/7 path returns a bit-identical image while spending
+# more bytes than the reversible 5/3 path. See `images.HTJ2K_PRESETS`.
+HTJ2K_QUALITY_FLOOR_LSB = 1.0
+
+# Fallback for `reversible=False` with no step given, in LSB. Matches the
+# `balanced` preset.
+HTJ2K_DEFAULT_QUALITY_LSB = 2.0
+
+
+def dtype_quantum(dtype: np.dtype) -> float:
+    """Return one LSB of *dtype* as a fraction of its full dynamic range.
+
+    OpenJPH's quantization step is normalised to the dtype's full range, so this
+    is the unit that makes a step comparable across bit depths.
+    """
+    info = np.iinfo(dtype)
+    return 1.0 / (int(info.max) - int(info.min) + 1)
+
+
+def htj2k_encode_options(
+    encode_options: dict[str, Any], *, dtype: np.dtype | None = None
+) -> tuple[bool, float]:
     """Map encode options to the OpenJPH ``(reversible, quality)`` pair.
 
     ``quality`` is the OpenJPH quantization step: lower means higher fidelity and
-    a larger codestream. It is *not* a JPEG-style 0–100 quality.
+    a larger codestream. It is *not* a JPEG-style 0–100 quality. It is relative
+    to *dtype*'s full dynamic range, so the default is derived from *dtype* when
+    one is given rather than being a bit-depth-blind constant.
     """
     reversible = bool(encode_options.get("reversible", True))
     if reversible:
         return True, 0.0
-    quality = encode_options.get("quality", encode_options.get("level", 0.0002))
+    default = HTJ2K_DEFAULT_QUALITY_LSB * dtype_quantum(dtype) if dtype is not None else 0.0002
+    quality = encode_options.get("quality", encode_options.get("level", default))
     return False, float(quality)
 
 
 def _encode_htj2k(volume: np.ndarray, encode_options: dict[str, Any] | None = None) -> bytes:
-    reversible, quality = htj2k_encode_options(encode_options or {})
+    reversible, quality = htj2k_encode_options(encode_options or {}, dtype=volume.dtype)
     return require_backend().encode(volume, reversible=reversible, quality=quality)
 
 

--- a/python/spatialdata-js-util/src/spatialdata_js_util/codecs/encoding.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/codecs/encoding.py
@@ -30,8 +30,20 @@ def dtype_quantum(dtype: np.dtype) -> float:
 
     OpenJPH's quantization step is normalised to the dtype's full range, so this
     is the unit that makes a step comparable across bit depths.
+
+    Only integer dtypes have an LSB to be relative to. That reflects what this
+    codec path writes today, not a limit of HTJ2K — if float support is added,
+    give those dtypes a quantum here rather than reading the error as permanent.
     """
-    info = np.iinfo(dtype)
+    resolved = np.dtype(dtype)
+    if resolved.kind not in ("i", "u"):
+        raise TypeError(
+            f"HTJ2K quantization steps are relative to an integer dtype's full range, "
+            f"and {resolved} has no LSB to scale by. Images are currently written as "
+            f"<=16-bit integers, so no step is derived for this dtype yet — pass an "
+            f"explicit `quality` (an absolute step) or `reversible=True` to encode it."
+        )
+    info = np.iinfo(resolved)
     return 1.0 / (int(info.max) - int(info.min) + 1)
 
 
@@ -41,15 +53,21 @@ def htj2k_encode_options(
     """Map encode options to the OpenJPH ``(reversible, quality)`` pair.
 
     ``quality`` is the OpenJPH quantization step: lower means higher fidelity and
-    a larger codestream. It is *not* a JPEG-style 0–100 quality. It is relative
-    to *dtype*'s full dynamic range, so the default is derived from *dtype* when
-    one is given rather than being a bit-depth-blind constant.
+    a larger codestream. It is *not* a JPEG-style 0–100 quality.
+
+    A caller-supplied ``quality``/``level`` is used as given. Only the fallback
+    is derived from *dtype*, so that the default scales with bit depth instead of
+    being a bit-depth-blind constant; deriving it needs an integer dtype.
     """
     reversible = bool(encode_options.get("reversible", True))
     if reversible:
         return True, 0.0
-    default = HTJ2K_DEFAULT_QUALITY_LSB * dtype_quantum(dtype) if dtype is not None else 0.0002
-    quality = encode_options.get("quality", encode_options.get("level", default))
+    quality = encode_options.get("quality", encode_options.get("level"))
+    if quality is None:
+        # Derived only when the caller gave no step. An explicit `quality` is an
+        # absolute value, so it must not depend on the dtype — deriving eagerly
+        # would reject dtypes that can be encoded perfectly well by naming a step.
+        quality = HTJ2K_DEFAULT_QUALITY_LSB * dtype_quantum(dtype) if dtype is not None else 0.0002
     return False, float(quality)
 
 

--- a/python/spatialdata-js-util/src/spatialdata_js_util/images.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/images.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import tempfile
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,10 +17,12 @@ from .codecs import (
     CODEC_HTJ2K_OPENJPH,
     CODEC_JPEG2K,
     HTJ2K_ENCODER,
+    HTJ2K_QUALITY_FLOOR_LSB,
     SUPPORTED_IMAGE_CODECS,
     chunk_grid,
     chunk_slices,
     decode_image_plane,
+    dtype_quantum,
     encode_image_plane,
     is_htj2k_codec,
     pad_chunk,
@@ -51,11 +54,27 @@ JP2K_PRESETS: dict[ImagePreset, dict[str, Any]] = {
     "small": {"reversible": False, "level": 75},
 }
 
+# Lossy HTJ2K presets are a multiple of the input's LSB, not an absolute step.
+# OpenJPH's `quality` is normalised to the dtype's full range, so size and error
+# both track the step measured in LSB — the same multiple costs the same on uint8
+# and uint16. Below ~1 LSB (`HTJ2K_QUALITY_FLOOR_LSB`) the irreversible path is
+# strictly dominated: it returns a bit-identical image for more bytes than
+# reversible. See docs/htj2k-wasm-encode-design.md for the measurements.
 HTJ2K_PRESETS: dict[ImagePreset, dict[str, Any]] = {
     "lossless": {"reversible": True},
-    "balanced": {"reversible": False, "quality": 0.0002},
-    "small": {"reversible": False, "quality": 0.001},
+    # Mean error ~0.6 LSB, p99 2 LSB.
+    "balanced": {"reversible": False, "quality_lsb": 2.0},
+    # Mean error ~1.6 LSB, p99 5 LSB.
+    "small": {"reversible": False, "quality_lsb": 5.0},
 }
+
+
+def htj2k_preset_quality(preset: ImagePreset, dtype: np.dtype) -> float | None:
+    """Resolve an HTJ2K preset to a quantization step, or ``None`` if reversible."""
+    quality_lsb = HTJ2K_PRESETS[preset].get("quality_lsb")
+    if quality_lsb is None:
+        return None
+    return float(quality_lsb) * dtype_quantum(dtype)
 
 
 @dataclass(frozen=True)
@@ -265,7 +284,14 @@ def _array_metadata_from_source(
     return meta
 
 
-def _preset_encode_options(config: dict[str, Any], *, codec: str) -> dict[str, Any]:
+def _preset_encode_options(
+    config: dict[str, Any], *, codec: str, dtype: np.dtype | None = None
+) -> dict[str, Any]:
+    """Resolve config plus preset into concrete encode options.
+
+    HTJ2K presets are bit-depth relative, so *dtype* is required to resolve one;
+    it also lets an explicit ``quality`` be checked against the input's LSB.
+    """
     presets = HTJ2K_PRESETS if codec == CODEC_HTJ2K_OPENJPH else JP2K_PRESETS
     preset_family = "HTJ2K" if codec == CODEC_HTJ2K_OPENJPH else "JP2K"
     encode_options = dict(config.get("encode_options", {}))
@@ -289,10 +315,42 @@ def _preset_encode_options(config: dict[str, Any], *, codec: str) -> dict[str, A
             options[key] = config[key]
 
     explicit_lossless = config.get("reversible") is True or encode_options.get("reversible") is True
+
+    # An explicit `quality` overrides the preset, including its LSB multiple.
+    preset_quality_lsb = options.pop("quality_lsb", None)
+    if preset_quality_lsb is not None and options.get("quality") is None:
+        if dtype is None:
+            described = f"{preset!r} preset" if preset is not None else "quality_lsb setting"
+            raise ValueError(
+                f"Resolving the HTJ2K {described} needs the input dtype: the "
+                "quantization step is relative to the input's bit depth."
+            )
+        options["quality"] = float(preset_quality_lsb) * dtype_quantum(dtype)
+
     if options.get("quality") is not None and not explicit_lossless:
         options["reversible"] = False
+        _warn_if_quality_below_input_resolution(options["quality"], dtype)
 
     return options
+
+
+def _warn_if_quality_below_input_resolution(quality: float, dtype: np.dtype | None) -> None:
+    """Warn when a step is finer than one input LSB, which encodes larger than
+    lossless for a bit-identical image. Only an explicit ``quality`` can ask for
+    this; presets stay above the floor."""
+    if dtype is None:
+        return
+    floor = HTJ2K_QUALITY_FLOOR_LSB * dtype_quantum(dtype)
+    if quality >= floor:
+        return
+    warnings.warn(
+        f"HTJ2K quality={quality:g} is finer than one {dtype} LSB ({dtype_quantum(dtype):g}); "
+        f"the irreversible transform will return a bit-identical image while encoding "
+        f"LARGER than lossless. Use quality>={floor:g} for a genuinely smaller file, "
+        f"or reversible=True (preset 'lossless') for the smallest exact one.",
+        UserWarning,
+        stacklevel=3,
+    )
 
 
 def _sibling_image_label(image_config: dict[str, Any]) -> str:
@@ -383,7 +441,7 @@ def _recompress_image_array(
 
     chunks = _normalize_chunks(config.get("chunks", "auto"), shape, image=True)
     _validate_browser_image_codec_chunks(chunks, raster_path)
-    encode_options = _preset_encode_options(config, codec=codec)
+    encode_options = _preset_encode_options(config, codec=codec, dtype=dtype)
     is_lossless = bool(encode_options.get("reversible", False))
 
     if dest_array_path.exists():

--- a/python/spatialdata-js-util/src/spatialdata_js_util/images.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/images.py
@@ -338,7 +338,9 @@ def _warn_if_quality_below_input_resolution(quality: float, dtype: np.dtype | No
     """Warn when a step is finer than one input LSB, which encodes larger than
     lossless for a bit-identical image. Only an explicit ``quality`` can ask for
     this; presets stay above the floor."""
-    if dtype is None:
+    # Nothing to compare against for a dtype with no LSB (see `dtype_quantum`);
+    # an explicit step stays legal there, so this stays silent rather than raising.
+    if dtype is None or dtype.kind not in ("i", "u"):
         return
     floor = HTJ2K_QUALITY_FLOOR_LSB * dtype_quantum(dtype)
     if quality >= floor:

--- a/python/spatialdata-js-util/src/spatialdata_js_util/tui/screens.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/tui/screens.py
@@ -772,7 +772,11 @@ class RecompressImagesScreen(InputFormScreen):
                 allow_blank=False,
                 id="preset",
             )
-            yield Label("HTJ2K quality — quantization step, lower = better (blank = use preset)")
+            yield Label(
+                "HTJ2K quality — quantization step relative to the dtype's full range, "
+                "lower = better (blank = use preset). Below one input LSB "
+                "(1/256 for 8-bit, 1/65536 for 16-bit) it encodes larger than lossless."
+            )
             yield Input(placeholder="0.0002", id="quality")
             yield Label("Chunks")
             yield Input(value="auto", placeholder="auto, or one integer per axis", id="chunks")

--- a/python/spatialdata-js-util/tests/test_recompress.py
+++ b/python/spatialdata-js-util/tests/test_recompress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import imagecodecs
@@ -12,8 +13,11 @@ from spatialdata_js_util import (
     CODEC_HTJ2K_OPENJPH,
     CODEC_JPEG2K,
     HTJ2K_PRESETS,
+    HTJ2K_QUALITY_FLOOR_LSB,
     JP2K_PRESETS,
+    dtype_quantum,
     htj2k_available,
+    htj2k_preset_quality,
     recompress_spatialdata,
     resolve_recompression_config,
 )
@@ -221,10 +225,12 @@ def test_preset_encode_options_quality_implies_lossy_htj2k() -> None:
     assert _preset_encode_options(
         {"quality": 0.001},
         codec=CODEC_HTJ2K_OPENJPH,
+        dtype=np.dtype("uint16"),
     ) == {"reversible": False, "quality": 0.001}
     assert _preset_encode_options(
         {"preset": "lossless", "quality": 0.001},
         codec=CODEC_HTJ2K_OPENJPH,
+        dtype=np.dtype("uint16"),
     ) == {"reversible": False, "quality": 0.001}
 
 
@@ -234,17 +240,54 @@ def test_lossy_presets_are_not_extreme_low_bitrate() -> None:
 
 
 def test_htj2k_presets_do_not_pass_jp2k_rate_control_levels() -> None:
-    assert HTJ2K_PRESETS["balanced"] == {"reversible": False, "quality": 0.0002}
-    assert HTJ2K_PRESETS["small"] == {"reversible": False, "quality": 0.001}
+    assert HTJ2K_PRESETS["balanced"] == {"reversible": False, "quality_lsb": 2.0}
+    assert HTJ2K_PRESETS["small"] == {"reversible": False, "quality_lsb": 5.0}
     assert "level" not in HTJ2K_PRESETS["balanced"]
     assert _preset_encode_options(
         {"preset": "balanced"},
         codec=CODEC_HTJ2K_OPENJPH,
-    ) == {"reversible": False, "quality": 0.0002}
+        dtype=np.dtype("uint16"),
+    ) == {"reversible": False, "quality": 2.0 / 65536}
     assert _preset_encode_options(
         {"preset": "balanced"},
         codec=CODEC_JPEG2K,
     ) == {"reversible": False, "level": 100}
+
+
+def test_htj2k_preset_quality_scales_with_bit_depth() -> None:
+    """A preset is a fidelity target in LSB, so its step tracks the bit depth."""
+    for preset, lsb in (("balanced", 2.0), ("small", 5.0)):
+        assert htj2k_preset_quality(preset, np.dtype("uint8")) == lsb / 256
+        assert htj2k_preset_quality(preset, np.dtype("int8")) == lsb / 256
+        assert htj2k_preset_quality(preset, np.dtype("uint16")) == lsb / 65536
+        assert htj2k_preset_quality(preset, np.dtype("int16")) == lsb / 65536
+    assert htj2k_preset_quality("lossless", np.dtype("uint8")) is None
+
+
+def test_lossy_presets_stay_above_the_input_resolution_floor() -> None:
+    """Below ~1 LSB the irreversible path is strictly dominated by reversible."""
+    for dtype in (np.dtype("uint8"), np.dtype("int8"), np.dtype("uint16"), np.dtype("int16")):
+        floor = HTJ2K_QUALITY_FLOOR_LSB * dtype_quantum(dtype)
+        for preset in ("balanced", "small"):
+            assert htj2k_preset_quality(preset, dtype) > floor
+
+
+def test_resolving_an_htj2k_preset_without_a_dtype_is_an_error() -> None:
+    with pytest.raises(ValueError, match="needs the input dtype"):
+        _preset_encode_options({"preset": "balanced"}, codec=CODEC_HTJ2K_OPENJPH)
+
+
+def test_explicit_quality_finer_than_the_input_lsb_warns() -> None:
+    with pytest.warns(UserWarning, match="finer than one uint8 LSB"):
+        _preset_encode_options(
+            {"quality": 0.0002}, codec=CODEC_HTJ2K_OPENJPH, dtype=np.dtype("uint8")
+        )
+    # The same step is a sane request for uint16, where it is ~13 LSB.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _preset_encode_options(
+            {"quality": 0.0002}, codec=CODEC_HTJ2K_OPENJPH, dtype=np.dtype("uint16")
+        )
 
 
 @pytest.mark.skipif(
@@ -256,9 +299,85 @@ def test_htj2k_balanced_preset_produces_reasonable_chunk_size() -> None:
     options = _preset_encode_options(
         {"preset": "balanced"},
         codec=CODEC_HTJ2K_OPENJPH,
+        dtype=plane.dtype,
     )
     encoded = encode_image_plane(plane, CODEC_HTJ2K_OPENJPH, options)
     assert 1_000 < len(encoded) < plane.nbytes
+
+
+def _encoded_preset_sizes(plane: np.ndarray) -> dict[str, int]:
+    sizes = {}
+    for preset in ("lossless", "balanced", "small"):
+        options = _preset_encode_options(
+            {"preset": preset}, codec=CODEC_HTJ2K_OPENJPH, dtype=plane.dtype
+        )
+        sizes[preset] = len(encode_image_plane(plane, CODEC_HTJ2K_OPENJPH, options))
+    return sizes
+
+
+@pytest.mark.skipif(
+    not htj2k_available(),
+    reason="No HTJ2K encoder is available in this environment.",
+)
+@pytest.mark.parametrize("dtype", ["uint8", "uint16"])
+def test_htj2k_lossy_presets_are_smaller_than_lossless(dtype: str) -> None:
+    """size(small) <= size(balanced) <= size(lossless), at every bit depth.
+
+    This ordering is what a user asking for a smaller file assumes. It used to
+    be reversed for uint8: the presets were absolute quantization steps tuned on
+    uint16, so on 8-bit input they asked for a step ~20x finer than the data's
+    own resolution and the irreversible path spent more bits than the reversible
+    one to return a bit-identical image. `balanced` encoded 2.8x LARGER than
+    `lossless` on this plane.
+    """
+    plane = mandelbrot_plane(256)
+    if dtype == "uint8":
+        plane = (plane >> 8).astype(np.uint8)
+
+    sizes = _encoded_preset_sizes(plane)
+
+    assert sizes["small"] <= sizes["balanced"] <= sizes["lossless"], sizes
+    # Not merely ordered — a lossy preset has to actually buy something.
+    assert sizes["small"] < sizes["lossless"], sizes
+
+
+@pytest.mark.skipif(
+    not htj2k_available(),
+    reason="No HTJ2K encoder is available in this environment.",
+)
+def test_htj2k_presets_hold_fidelity_across_bit_depths() -> None:
+    """The same preset costs the same error *in LSB* whatever the dtype.
+
+    That equivalence is the point of expressing presets as an LSB multiple: the
+    uint8 plane and the uint16 plane holding the same picture must degrade
+    alike, rather than the uint16 one being quantized 256x more coarsely.
+    """
+    plane8 = (mandelbrot_plane(256) >> 8).astype(np.uint8)
+    plane16 = plane8.astype(np.uint16)
+
+    options8 = _preset_encode_options(
+        {"preset": "balanced"}, codec=CODEC_HTJ2K_OPENJPH, dtype=plane8.dtype
+    )
+    options16 = _preset_encode_options(
+        {"preset": "balanced"}, codec=CODEC_HTJ2K_OPENJPH, dtype=plane16.dtype
+    )
+    assert options16["quality"] == options8["quality"] / 256
+
+    error8 = np.abs(
+        decode_htj2k_plane(encode_image_plane(plane8, CODEC_HTJ2K_OPENJPH, options8))
+        .reshape(plane8.shape)
+        .astype(np.int64)
+        - plane8.astype(np.int64)
+    )
+    error16 = np.abs(
+        decode_htj2k_plane(encode_image_plane(plane16, CODEC_HTJ2K_OPENJPH, options16))
+        .reshape(plane16.shape)
+        .astype(np.int64)
+        - plane16.astype(np.int64)
+    )
+    # Same picture, same preset, same absolute error — the uint16 container
+    # does not make the encode coarser.
+    assert error16.mean() == pytest.approx(error8.mean(), abs=0.05)
 
 
 def test_recompress_spatialdata_rewrites_image_and_labels(tmp_path: Path) -> None:

--- a/python/spatialdata-js-util/tests/test_recompress.py
+++ b/python/spatialdata-js-util/tests/test_recompress.py
@@ -21,7 +21,11 @@ from spatialdata_js_util import (
     recompress_spatialdata,
     resolve_recompression_config,
 )
-from spatialdata_js_util.codecs import decode_htj2k_plane, encode_image_plane
+from spatialdata_js_util.codecs import (
+    decode_htj2k_plane,
+    encode_image_plane,
+    htj2k_encode_options,
+)
 from spatialdata_js_util.images import _preset_encode_options
 
 from synthetic_images import mandelbrot_plane
@@ -288,6 +292,35 @@ def test_explicit_quality_finer_than_the_input_lsb_warns() -> None:
         _preset_encode_options(
             {"quality": 0.0002}, codec=CODEC_HTJ2K_OPENJPH, dtype=np.dtype("uint16")
         )
+
+
+def test_dtype_quantum_rejects_dtypes_with_no_lsb() -> None:
+    """The message must read as a current limit, not a permanent one."""
+    with pytest.raises(TypeError, match="no LSB to scale by") as excinfo:
+        dtype_quantum(np.dtype("float32"))
+    assert "currently" in str(excinfo.value)
+
+
+def test_explicit_step_encodes_a_dtype_that_has_no_derived_step() -> None:
+    """Only the *derived* default needs an LSB.
+
+    An explicit `quality` is an absolute step, so it must not be rejected for a
+    dtype the preset machinery cannot scale — otherwise widening dtype support
+    would be blocked on the default rather than on the codec.
+    """
+    float32 = np.dtype("float32")
+    assert htj2k_encode_options({"reversible": False, "quality": 0.001}, dtype=float32) == (
+        False,
+        0.001,
+    )
+    assert htj2k_encode_options({"reversible": False, "level": 0.001}, dtype=float32) == (
+        False,
+        0.001,
+    )
+    assert htj2k_encode_options({"reversible": True}, dtype=float32) == (True, 0.0)
+
+    with pytest.raises(TypeError, match="no LSB to scale by"):
+        htj2k_encode_options({"reversible": False}, dtype=float32)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What

`HTJ2K_PRESETS` set absolute quantization steps (`balanced: 0.0002`, `small: 0.001`). They now carry an LSB multiple (`balanced: 2`, `small: 5`) resolved against the raster's dtype.

## Why

OpenJPH's `quality` is a quantization step **normalised to the dtype's full dynamic range**, so one input LSB is `1/2**bits`. The old values were calibrated only on full-range Xenium morphology `uint16`, where they are 13.1 and 65.5 LSB and behave sensibly. On 8-bit input they are 0.05 and 0.26 LSB — finer than the data's own resolution.

Below ~1 LSB the irreversible 9/7 path cannot buy fidelity the input does not have, so it returns a **bit-identical** image while spending *more* bytes than reversible 5/3. Both lossy presets therefore encoded **larger** than `lossless` on `uint8`, and `small` larger than `balanced`. A user asking for a smaller file got a bigger one, paid no quality cost for it, and nothing in the manifest or CLI output said so.

Measured on 1024² planes (`imagecodecs` 2026.6.26; size relative to the reversible encode of the same plane):

| Step, in LSB | `uint8` H&E | `uint8` retina | `uint16` cells3d | mean error |
|---|---|---|---|---|
| 0.05 (old `balanced` @ 8-bit) | **1.89×** | **2.76×** | — | 0 |
| 0.26 (old `small` @ 8-bit) | **1.39×** | **1.60×** | — | 0 |
| 1 | 0.92× | 0.58× | 1.00× | ~0.2 LSB |
| 2 (new `balanced`) | 0.68× | 0.29× | 0.93× | ~0.6 LSB |
| 5 (new `small`) | 0.39× | 0.13× | 0.83× | ~1.6 LSB |

Both effects are content-independent. The LSB multiple is the dtype-independent knob: at a given multiple, a `uint8` plane and a `uint16` plane holding the same picture encode to the same size with the same error in LSB. The ~1 LSB crossover holds regardless of content and bit depth.

End-to-end through the writer on an H&E plane: `balanced` 0.68×, `small` 0.39× lossless.

## Reviewer, please weigh in on

**1. `uint16` `balanced` moves from 13.1 LSB to 2 LSB.** Better fidelity (mean error 3.08 → 0.41 counts), weaker compression (0.72× → 0.93×). A single LSB multiple cannot be both above the 8-bit floor and as aggressive as the old `uint16` tuning. I chose genuine dtype-independence; the alternative is a depth-indexed table, at the cost of a preset meaning different things per depth. Happy to switch if you'd rather keep `uint16` aggressive.

**2. A separate defect surfaced while measuring.** Lossy HTJ2K wraps samples at the dtype ceiling — `255 → 0` for `uint8`, `65535 → 0` for `uint16` — in **both** the `imagecodecs` and vendored `openjph-wasm` decoders, so the encoder is emitting out-of-range reconstructions that neither clamps. On an H&E plane with saturated white background that is 14 isolated black pixels of 1,048,576 at `balanced`. Clipping the source to `254` removes them entirely; the reversible path is unaffected.

This **predates the change but was masked** — 8-bit lossy presets were silently bit-identical, so nothing lossy ever ran on 8-bit input. It is documented under "Known defect" in the design doc and tracked separately; it is not fixed here.

## Also in this change

- Warn when an explicit `--quality` is finer than one input LSB, naming the measured floor. Presets can no longer produce such a step.
- Fix the same bit-depth-blind `0.0002` default in `htj2k_encode_options`.
- The resolved step now lands in the manifest under `encode_options`, so the actual value is no longer invisible.
- README, design doc, docs site, TUI and fixture generators point at the new definition rather than restating absolute values.

## Tests

Two regression tests, both of which **fail against the old presets**:

- `size(small) <= size(balanced) <= size(lossless)` for `uint8` and `uint16` — the ordering a user assumes, previously reversed (`balanced` was 2.8× lossless on the test plane).
- A preset costs the same error in LSB across dtypes.

Plus coverage for preset→step resolution per dtype, the floor, and the warning.

Full Python suite: 156 passed, 1 skipped. `biome ci packages/*/src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTJ2K quality presets now scale relative to the input image’s data type and bit depth.
  * Added clearer quality handling for lossless thresholds, explicit quantization values, and warnings for overly fine settings.
  * Preset quality values are now calculated dynamically for generated fixtures and demos.

* **Documentation**
  * Updated CLI help, user guides, demos, and design documentation with the revised quality behavior and known lossy-mode limitations.

* **Tests**
  * Expanded coverage across 8-bit and 16-bit data, including quality scaling, warnings, output size, and fidelity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->