### PR TITLE
Guard Textual's Header title race that flakes the TUI tests

### DIFF
--- a/python/spatialdata-js-util/src/spatialdata_js_util/tui/screens.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/tui/screens.py
@@ -17,7 +17,6 @@ from textual.widgets import (
     Checkbox,
     DataTable,
     Footer,
-    Header,
     Input,
     Label,
     ListItem,
@@ -50,6 +49,7 @@ from ..verify import (
 )
 from ..store import list_points_keys, read_points_element_attrs
 from .app import WriterApp
+from .widgets import SafeHeader
 from .models import CommandId, TaskSpec
 
 
@@ -113,7 +113,7 @@ class HomeScreen(WriterScreen):
         self.query_one("#command-list", ListView).focus()
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static(
             "spatialdata-js-util — pick a command.",
             id="home-title",
@@ -200,7 +200,7 @@ class ZarrPathScreen(InputFormScreen):
         self.command = command
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("SpatialData Zarr store path", classes="screen-title")
         yield Input(placeholder="/path/to/store.zarr", id="zarr-path")
         with Horizontal():
@@ -258,7 +258,7 @@ class PointsKeyScreen(WriterScreen):
         self.command = command
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Select Points element", classes="screen-title")
         yield ListView(id="points-key-list")
         with Horizontal():
@@ -318,7 +318,7 @@ class MortonFromZarrScreen(InputFormScreen):
     INPUT_ORDER = ("feature-key", "row-group-size", "compression", "output-element")
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Morton-sort Points from Zarr", classes="screen-title")
         with VerticalScroll():
             yield Label("Feature key column (optional)")
@@ -455,7 +455,7 @@ class MortonFileScreen(InputFormScreen):
     )
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Morton-sort CSV/Parquet", classes="screen-title")
         with VerticalScroll():
             yield Label("Input path")
@@ -527,7 +527,7 @@ class MultiscaleScreen(InputFormScreen):
     )
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Multiscale Points Parquet", classes="screen-title")
         with VerticalScroll():
             yield Label("Input path")
@@ -604,7 +604,7 @@ class IndexPermutationsScreen(InputFormScreen):
         self.from_zarr_context = from_zarr_context
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Write index permutations", classes="screen-title")
         with VerticalScroll():
             yield Label("Source Zarr")
@@ -742,7 +742,7 @@ class RecompressImagesScreen(InputFormScreen):
     )
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Recompress images", classes="screen-title")
         with VerticalScroll():
             yield Label("Source store")
@@ -920,7 +920,7 @@ class TablesToCscScreen(InputFormScreen):
     INPUT_ORDER = ("source", "dest", "tables")
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Convert tables to CSC", classes="screen-title")
         with VerticalScroll():
             yield Static(
@@ -1027,7 +1027,7 @@ class ConfirmScreen(WriterScreen):
         self._handled = False
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Confirm in-place write", classes="screen-title")
         yield Static(self.task_spec.confirm_message, id="confirm-message")
         with Horizontal():
@@ -1071,7 +1071,7 @@ class RunScreen(WriterScreen):
         self.task_spec = task_spec
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static(self.task_spec.title, classes="screen-title")
         yield RichLog(id="run-log", highlight=True, markup=False)
         yield Footer()
@@ -1154,7 +1154,7 @@ class VerifyReportScreen(WriterScreen):
         self._handled = False
 
     def compose(self) -> ComposeResult:
-        yield Header()
+        yield SafeHeader()
         yield Static("Run complete", classes="screen-title")
         with VerticalScroll():
             if self.error:

--- a/python/spatialdata-js-util/src/spatialdata_js_util/tui/widgets.py
+++ b/python/spatialdata-js-util/src/spatialdata_js_util/tui/widgets.py
@@ -1,0 +1,50 @@
+"""Widgets that work around defects in the installed Textual version."""
+
+from __future__ import annotations
+
+from textual.css.query import NoMatches
+from textual.dom import NoScreen
+from textual.events import Mount
+from textual.widgets import Header
+
+# `HeaderTitle` is not re-exported from `textual.widgets`; the override below
+# needs the same class the base implementation queries for.
+from textual.widgets._header import HeaderTitle
+
+
+class SafeHeader(Header):
+    """`Header` that tolerates its title watcher running before compose mounts.
+
+    Textual's `Header._on_mount` registers title watchers with `init=True`, and
+    their callback does `query_one(HeaderTitle)` guarded only against
+    `NoScreen`. `HeaderTitle` is a child yielded by `Header.compose()`, so when
+    the watcher runs before that child has mounted the query raises `NoMatches`
+    — which escapes into the app's message pump and fails whatever is driving
+    the app.
+
+    It is timing-dependent: it surfaced on loaded CI runners and never
+    reproduced locally, including under CPU contention. Verified against textual
+    8.2.8, the latest release when this was written.
+
+    Delete this once upstream catches `NoMatches` as well;
+    `test_tui.py::TestSafeHeader` asserts the stock `Header` still has the
+    defect, so it will fail and prompt the removal when that lands.
+    """
+
+    def _on_mount(self, event: Mount) -> None:
+        # Textual dispatches a handler for every class in the MRO, so defining
+        # `_on_mount` here does not replace the base one — it runs first, and
+        # the unguarded original would still follow. `prevent_default` is what
+        # actually suppresses it.
+        event.prevent_default()
+
+        async def set_title() -> None:
+            try:
+                self.query_one(HeaderTitle).update(self.format_title())
+            except (NoScreen, NoMatches):
+                pass
+
+        self.watch(self.app, "title", set_title)
+        self.watch(self.app, "sub_title", set_title)
+        self.watch(self.screen, "title", set_title)
+        self.watch(self.screen, "sub_title", set_title)

--- a/python/spatialdata-js-util/tests/test_tui.py
+++ b/python/spatialdata-js-util/tests/test_tui.py
@@ -17,7 +17,13 @@ anndata = pytest.importorskip("anndata")
 sparse = pytest.importorskip("scipy.sparse")
 sd = pytest.importorskip("spatialdata")
 
-from textual.widgets import Button, Checkbox, Input, ListView  # noqa: E402
+from textual.app import App, ComposeResult  # noqa: E402
+from textual.css.query import NoMatches  # noqa: E402
+from textual.widget import Widget  # noqa: E402
+from textual.widgets import Button, Checkbox, Header, Input, ListView  # noqa: E402
+from textual.widgets._header import HeaderTitle  # noqa: E402
+
+from spatialdata_js_util.tui.widgets import SafeHeader  # noqa: E402
 
 from spatialdata_js_util.codecs import htj2k_available  # noqa: E402
 from spatialdata_js_util.tui.app import WriterApp  # noqa: E402
@@ -398,3 +404,61 @@ class TestRecompressPyramidControls:
             app.screen.query_one("#run", Button).press()
             await pilot.pause()
             assert isinstance(app.screen, RecompressImagesScreen)
+
+
+class TestSafeHeader:
+    """`SafeHeader` guards a race in Textual's own `Header`.
+
+    `Header._on_mount` registers title watchers whose callback does
+    `query_one(HeaderTitle)` guarded only against `NoScreen`. `HeaderTitle` is a
+    compose child, so a watcher running before it mounts raises `NoMatches` into
+    the app's message pump. Removing the child and then touching a watched
+    reactive reproduces that window deterministically.
+    """
+
+    @staticmethod
+    def _app_with(header_class: type[Widget]) -> App:
+        class _HeaderApp(App):
+            def compose(self) -> ComposeResult:
+                yield header_class()
+
+        return _HeaderApp()
+
+    @pytest.mark.asyncio
+    async def test_title_change_survives_a_missing_header_title(self) -> None:
+        app = self._app_with(SafeHeader)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.query_one(SafeHeader).query_one(HeaderTitle).remove()
+            app.title = "changed"
+            await pilot.pause()  # must not raise NoMatches
+
+    @pytest.mark.asyncio
+    async def test_title_still_renders_like_the_stock_header(self) -> None:
+        """The guard must not cost the behaviour it guards."""
+        rendered = {}
+        for header_class in (SafeHeader, Header):
+            app = self._app_with(header_class)
+            async with app.run_test() as pilot:
+                app.title = "My Title"
+                app.sub_title = "sub"
+                await pilot.pause()
+                title = app.query_one(header_class).query_one(HeaderTitle)
+                rendered[header_class.__name__] = str(title.render())
+
+        assert rendered["SafeHeader"] == rendered["Header"]
+        assert "My Title" in rendered["SafeHeader"]
+
+    @pytest.mark.asyncio
+    async def test_stock_header_still_has_the_defect(self) -> None:
+        """Tripwire: delete `SafeHeader` when this starts failing.
+
+        A newer Textual that catches `NoMatches` makes the workaround dead code.
+        """
+        app = self._app_with(Header)
+        with pytest.raises(NoMatches):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app.query_one(Header).query_one(HeaderTitle).remove()
+                app.title = "changed"
+                await pilot.pause()


### PR DESCRIPTION
## What

Adds `tui.widgets.SafeHeader` and uses it for the twelve `yield Header()` sites in `screens.py`.

## Why

TUI tests fail intermittently in CI with:

```
textual.css.query.NoMatches: No nodes match 'HeaderTitle' on Header()
```

Seen on `TestRecompressPyramidControls::test_pyramid_checkbox_builds_levels` in [run 30698635186](https://github.com/Taylor-CCB-Group/SpatialData.js/actions/runs/30698635186). Re-running the identical commit passed, so it is a flake rather than a code defect — but it will keep costing re-runs.

The cause is upstream, in textual 8.2.8's `Header._on_mount`:

```python
def _on_mount(self, _: Mount) -> None:
    async def set_title() -> None:
        try:
            self.query_one(HeaderTitle).update(self.format_title())
        except NoScreen:          # NoMatches is NOT caught
            pass
    self.watch(self.app, "title", set_title)
    ...
```

`HeaderTitle` is a child yielded by `Header.compose()`, and `DOMNode.watch()` defaults to `init=True`, so `set_title()` can run before that child is mounted. `query_one` then raises `NoMatches`, which the handler does not catch and which escapes into the app's message pump, failing whatever is driving the app.

8.2.8 is the latest release on PyPI, so there is no upgrade to take. Our own code sets no `TITLE`/`SUB_TITLE` and never assigns `app.title`, so there is nothing to fix at the call sites.

## Worth knowing when reviewing

**Subclassing alone does not work.** Textual's `MessagePump._get_dispatch_methods` iterates `self.__class__.__mro__` and dispatches a handler for *every* class in it, so defining `_on_mount` on the subclass does not replace the base — it runs first and the unguarded original still follows. My first attempt failed exactly this way, with the traceback pointing at `_header.py:221` while `self` was `SafeHeader()`.

The fix is `event.prevent_default()`, which sets `_no_default_action` and breaks that MRO loop ("This will prevent handlers in any base classes from being called"). That is the load-bearing line, hence the comment on it.

## Tests

Removing `HeaderTitle` and then touching a watched reactive reproduces the race deterministically, which the three new tests use:

- `SafeHeader` survives it.
- `SafeHeader` renders exactly what stock `Header` renders (`'My Title — sub'` from both), so the guard does not cost the behaviour it guards.
- Stock `Header` still raises. **This one is a tripwire** — when a newer Textual catches `NoMatches`, it fails and prompts deleting the workaround.

Full Python suite: 152 passed, 1 skipped.

Note the original CI failure could not be reproduced locally (5/5 in isolation, 14/14 three times as a file, 6 more full-file runs under 8 competing CPU-bound processes), so the case for the fix rests on the code path above rather than on a local repro.

## Relationship to #116

Independent — branched from `main`, no overlap. #116 hit this flake, which is what surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)