### PR TITLE
Keep last-good fill colours while a colour column's rows load

### DIFF
--- a/.changeset/keep-last-good-fill-colours.md
+++ b/.changeset/keep-last-good-fill-colours.md
@@ -1,0 +1,18 @@
+---
+'@spatialdata/vis': patch
+---
+
+Keep the last-good fill colours while a `fillColorByColumn` column's rows are loading.
+
+A selected column with no rows yet was treated as "no colours": the projection wrote
+`fillColorByFeatureId: {}`, so features dropped to the flat fill (shapes) or channel
+colour (labels) for the whole load window. Labels blinked on every column *switch* —
+`LabelsResolver` caches rows per element+column, so a switch always has a frame with
+no rows.
+
+Not-ready is now a loading state. The entry getters keep serving the previous entry
+(same element only — label ids collide across elements), and the feature-state merges
+leave the caller's `featureState` alone when there is no entry at all instead of
+clearing it. The stale entry's identity still drives the rebuild, so the real colours
+appear as soon as the rows settle; a failed load keeps the last good colours and
+surfaces through the resolver's notices as before.

--- a/packages/vis/src/SpatialCanvas/labelsProjection.ts
+++ b/packages/vis/src/SpatialCanvas/labelsProjection.ts
@@ -33,6 +33,13 @@ export interface LabelFillColorEntry {
   signature: string;
   /** The resolver fill-colour rows this map was built from. Rebuild on identity change. */
   rowsSource?: unknown;
+  /**
+   * The element these colours were built against. Label ids are only unique within
+   * an element (they are small integers, so they collide freely across elements),
+   * so a cached entry may be re-served as last-good only while the layer still
+   * points at the same element.
+   */
+  elementKey?: string;
 }
 
 export interface LabelColorLutEntry {
@@ -51,6 +58,25 @@ export interface LabelColorLutEntry {
  * silently halve the channel sliders' range.
  */
 const LABEL_FILL_COLOR_ALPHA = 255;
+
+/**
+ * What to serve while the resolver has no rows for this layer's fill column.
+ *
+ * The labels twin of `lastGoodShapeFillColorEntry`, and load-bearing here in a way
+ * it is not for shapes: `LabelsResolver` caches rows per element+column with no
+ * cross-column stale value, so a plain column switch has a window with no rows at
+ * all. Dropping the entry there flashes every label back to its channel colour
+ * until the new column settles.
+ *
+ * The element must match — label ids are small integers that collide freely across
+ * elements, so another element's entry would colour the wrong labels.
+ */
+export function lastGoodLabelFillColorEntry(
+  cached: LabelFillColorEntry | undefined,
+  elementKey: string
+): LabelFillColorEntry | undefined {
+  return cached?.elementKey === elementKey ? cached : undefined;
+}
 
 export function getLabelFillColorSignature(config: LayerConfig | undefined): string {
   if (config?.type !== 'labels' || !config.fillColorByColumn?.columnName) {
@@ -128,10 +154,18 @@ function mergeLabelFeatureStateForRender(
   if (!config.fillColorByColumn?.columnName) {
     return config.featureState;
   }
+  // A column is selected but its rows have not landed yet (no entry, and no
+  // last-good entry to fall back on). Return the caller's feature-state untouched
+  // rather than writing an empty map: an empty `fillColorByFeatureId` is a real
+  // instruction to the LUT builder, so it clears the colours currently drawn for
+  // the whole load window and the labels flash back to their channel colour.
+  if (!fillColorEntry) {
+    return config.featureState;
+  }
   return {
     ...config.featureState,
     fillColorByFeatureId: {
-      ...(fillColorEntry?.fillColorByFeatureId ?? {}),
+      ...fillColorEntry.fillColorByFeatureId,
       ...config.featureState?.fillColorByFeatureId,
     },
   };

--- a/packages/vis/src/SpatialCanvas/shapesProjection.ts
+++ b/packages/vis/src/SpatialCanvas/shapesProjection.ts
@@ -39,6 +39,31 @@ export interface ShapeFillColorEntry {
   rowsSource?: unknown;
   /** The render data this map was built from. Rebuild on identity change. */
   renderSource?: ShapesRenderData;
+  /**
+   * The element these colours were built against. Feature ids are only unique
+   * within an element, so a cached entry may be re-served as last-good only while
+   * the layer still points at the same element.
+   */
+  elementKey?: string;
+}
+
+/**
+ * What to serve while the resolver has no rows for this layer's fill column.
+ *
+ * Keep the last-good entry rather than dropping to `undefined`: a selected column
+ * whose rows have not landed (a fresh column, a reload, a failed load) must not
+ * blank the colours already on screen. Its stale identity is also what makes the
+ * feature-state runtime rebuild when the real rows arrive.
+ *
+ * The element must match. Feature ids are unique only within an element, so an
+ * entry built for a different element would paint the wrong shapes; there, having
+ * no colours is the honest answer.
+ */
+export function lastGoodShapeFillColorEntry(
+  cached: ShapeFillColorEntry | undefined,
+  elementKey: string
+): ShapeFillColorEntry | undefined {
+  return cached?.elementKey === elementKey ? cached : undefined;
 }
 
 export function getShapeFillColorAlpha(config: ShapesLayerConfig): number {
@@ -86,7 +111,15 @@ function mergeShapeFeatureStateForRender(
   if (!config.fillColorByColumn?.columnName) {
     return config.featureState;
   }
-  const fillColorByFeatureId = fillColorEntry?.fillColorByFeatureId ?? {};
+  // A column is selected but its rows have not landed yet (no entry, and no
+  // last-good entry to fall back on). Leave the caller's feature-state alone
+  // rather than overwriting it with `{}`: writing an empty map here clears
+  // whatever is currently drawn for the whole load window, so the layer flashes
+  // back to its flat fill and the caller's own per-feature colours are lost.
+  if (!fillColorEntry) {
+    return config.featureState;
+  }
+  const fillColorByFeatureId = fillColorEntry.fillColorByFeatureId;
   return {
     ...config.featureState,
     fillColorByFeatureId,

--- a/packages/vis/src/SpatialCanvas/useLayerData.ts
+++ b/packages/vis/src/SpatialCanvas/useLayerData.ts
@@ -56,6 +56,7 @@ import {
   getStableLabelColorLut,
   type LabelColorLutEntry,
   type LabelFillColorEntry,
+  lastGoodLabelFillColorEntry,
 } from './labelsProjection';
 import { renderLabelsLayer } from './renderers/labelsRenderer';
 import { renderShapesLayer } from './renderers/shapesRenderer';
@@ -65,6 +66,7 @@ import {
   getShapeFillColorAlpha,
   getShapeFillColorSignature,
   getStableShapeFeatureStateRuntime,
+  lastGoodShapeFillColorEntry,
   type ShapeFillColorEntry,
   type ShapePrebuiltEntry,
   serializeHiddenIds,
@@ -750,15 +752,18 @@ export function useLayerData(
         cache.delete(layerId);
         return undefined;
       }
-      // No entry until the resolver's rows are actually loaded. The feature-state
+      // No NEW entry until the resolver's rows are actually loaded. The feature-state
       // runtime is memoised on a signature whose only fill term is this entry's
       // presence (`fillColorEntry?.signature`), so an eager empty-map entry with the
       // full signature would suppress the rebuild that makes fill colours appear when
       // the rows settle. Mirrors the old async path: entry exists only once loaded.
       const rows = shapesResolver.getFillColorRows(key);
-      if (!rows) return undefined;
-      const signature = getShapeFillColorSignature(config);
       const cached = cache.get(layerId);
+      // Rows pending (or the column's load failed): keep the colours already on
+      // screen instead of blinking back to the flat fill. A failed load is not
+      // retried from here; it surfaces through the resolver's own notices.
+      if (!rows) return lastGoodShapeFillColorEntry(cached, key);
+      const signature = getShapeFillColorSignature(config);
       if (
         cached &&
         cached.signature === signature &&
@@ -769,6 +774,7 @@ export function useLayerData(
       }
       const entry: ShapeFillColorEntry = {
         signature,
+        elementKey: key,
         fillColorByFeatureId: buildShapeFillColorByFeatureId({
           featureIds: renderData.featureIds,
           rowIndexByFeatureIndex: renderData.rowIndexByFeatureIndex,
@@ -808,19 +814,30 @@ export function useLayerData(
       // Ask for THIS layer's column: two layers may colour one element differently,
       // and the resolver holds their rows separately.
       const rows = labelsResolver.getFillColorRows(key, config.fillColorByColumn.columnName);
-      if (!rows) return undefined;
-      const signature = getLabelFillColorSignature(config);
       const cached = cache.get(layerId);
+      // Rows pending (or the column's load failed): keep the colours already on
+      // screen. This is the ordinary first frame of a column SWITCH here — the
+      // resolver holds rows per element+column, so the new column has nothing yet
+      // and the old column's entry is the only thing standing between the user and
+      // a flash back to the channel colour.
+      if (!rows) return lastGoodLabelFillColorEntry(cached, key);
+      const signature = getLabelFillColorSignature(config);
       // Both terms are needed: the rows change when the COLUMN changes, and the
       // signature changes when the mode does (same rows, different encoding).
-      if (cached && cached.rowsSource === rows && cached.signature === signature) {
+      if (
+        cached &&
+        cached.elementKey === key &&
+        cached.rowsSource === rows &&
+        cached.signature === signature
+      ) {
         return cached;
       }
-      const entry = buildLabelFillColorEntry(config, rows);
-      if (!entry) {
+      const built = buildLabelFillColorEntry(config, rows);
+      if (!built) {
         cache.delete(layerId);
         return undefined;
       }
+      const entry: LabelFillColorEntry = { ...built, elementKey: key };
       cache.set(layerId, entry);
       return entry;
     },

--- a/packages/vis/tests/labelsProjection.spec.ts
+++ b/packages/vis/tests/labelsProjection.spec.ts
@@ -4,6 +4,7 @@ import {
   getStableLabelColorLut,
   type LabelColorLutEntry,
   type LabelFillColorEntry,
+  lastGoodLabelFillColorEntry,
 } from '../src/SpatialCanvas/labelsProjection';
 import type { LabelsLayerConfig } from '../src/SpatialCanvas/types';
 
@@ -174,5 +175,44 @@ describe('getStableLabelColorLut', () => {
 
   it('has no table at all when the layer has no feature state', () => {
     expect(getStableLabelColorLut('layer-1', config(), undefined, WHITE, cache())).toBeUndefined();
+  });
+
+  it('keeps the explicit per-label colours while the column’s rows are pending', () => {
+    // A selected column with no entry yet is a LOADING state, not an instruction to
+    // clear: the caller's own colours must survive the window untouched.
+    const cfg = config({
+      fillColorByColumn: { columnName: 'cell_type', mode: 'categorical' },
+      featureState: { fillColorByFeatureId: { '1': [1, 2, 3, 255] } },
+    });
+
+    const lut = getStableLabelColorLut('layer-1', cfg, undefined, WHITE, cache());
+
+    expect(Array.from(lut?.colors.subarray(4, 8) ?? [])).toEqual([1, 2, 3, 255]);
+  });
+});
+
+describe('lastGoodLabelFillColorEntry', () => {
+  const forElement = (elementKey: string): LabelFillColorEntry => ({
+    signature: 'cell_typecategorical',
+    fillColorByFeatureId: { '1': [10, 20, 30, 255] },
+    rowsSource: {},
+    elementKey,
+  });
+
+  it('keeps serving the previous column’s colours across a column switch', () => {
+    // The switch itself is the gap: rows are cached per element+column, so the newly
+    // selected column has nothing until it settles. Serving the old entry is what
+    // stops every label flashing back to its channel colour in between.
+    const served = lastGoodLabelFillColorEntry(forElement('cells'), 'cells');
+
+    expect(served?.fillColorByFeatureId).toEqual({ '1': [10, 20, 30, 255] });
+  });
+
+  it('refuses an entry built against a different element (label ids collide)', () => {
+    expect(lastGoodLabelFillColorEntry(forElement('nuclei'), 'cells')).toBeUndefined();
+  });
+
+  it('has nothing to serve before the first load', () => {
+    expect(lastGoodLabelFillColorEntry(undefined, 'cells')).toBeUndefined();
   });
 });

--- a/packages/vis/tests/shapesProjection.spec.ts
+++ b/packages/vis/tests/shapesProjection.spec.ts
@@ -83,7 +83,7 @@ describe('getStableShapeFeatureStateRuntime', () => {
     const withOwnColors = {
       ...config,
       featureState: { fillColorByFeatureId: { f1: [9, 8, 7, 255] } },
-    } as unknown as ShapesLayerConfig;
+    } satisfies ShapesLayerConfig;
 
     const runtime = getStableShapeFeatureStateRuntime(
       'layer-1',

--- a/packages/vis/tests/shapesProjection.spec.ts
+++ b/packages/vis/tests/shapesProjection.spec.ts
@@ -2,6 +2,7 @@ import type { ShapeFeatureStateRuntime } from '@spatialdata/layers';
 import { describe, expect, it } from 'vitest';
 import {
   getStableShapeFeatureStateRuntime,
+  lastGoodShapeFillColorEntry,
   type ShapeFillColorEntry,
 } from '../src/SpatialCanvas/shapesProjection';
 import type { ShapesLayerConfig } from '../src/SpatialCanvas/types';
@@ -73,5 +74,45 @@ describe('getStableShapeFeatureStateRuntime', () => {
     const a = getStableShapeFeatureStateRuntime('layer-1', config, sameEntry, cache);
     const b = getStableShapeFeatureStateRuntime('layer-1', config, sameEntry, cache);
     expect(b).toBe(a);
+  });
+
+  it('leaves the caller’s per-feature colours alone while the column’s rows are pending', () => {
+    // A selected column with no entry yet is a LOADING state, not an instruction to
+    // clear. Overwriting `fillColorByFeatureId` with `{}` here wiped the caller's own
+    // colours for the whole load window — the bug MDV had to work around.
+    const withOwnColors = {
+      ...config,
+      featureState: { fillColorByFeatureId: { f1: [9, 8, 7, 255] } },
+    } as unknown as ShapesLayerConfig;
+
+    const runtime = getStableShapeFeatureStateRuntime(
+      'layer-1',
+      withOwnColors,
+      undefined,
+      new Map()
+    );
+
+    expect(runtime.fillColorByFeatureId.get('f1')).toEqual([9, 8, 7, 255]);
+  });
+});
+
+describe('lastGoodShapeFillColorEntry', () => {
+  const forElement = (elementKey: string): ShapeFillColorEntry => ({
+    ...entry({ f1: [10, 20, 30, 255] }),
+    elementKey,
+  });
+
+  it('keeps serving the previous colours while the rows are unavailable', () => {
+    const served = lastGoodShapeFillColorEntry(forElement('cells'), 'cells');
+
+    expect(served?.fillColorByFeatureId).toEqual({ f1: [10, 20, 30, 255] });
+  });
+
+  it('refuses an entry built against a different element (feature ids do not carry)', () => {
+    expect(lastGoodShapeFillColorEntry(forElement('nuclei'), 'cells')).toBeUndefined();
+  });
+
+  it('has nothing to serve before the first load', () => {
+    expect(lastGoodShapeFillColorEntry(undefined, 'cells')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

A `fillColorByColumn` selection whose rows aren't ready yet was treated as *no colours* rather than as a loading state. The vis projection wrote `fillColorByFeatureId: {}` into the rendered feature-state, so every feature dropped to the layer's flat fill (shapes) or channel colour (labels) for the whole load window — and for shapes the caller's own per-feature colours went down with it.

Labels felt it worst: `LabelsResolver` caches rows per element+column with no cross-column stale value, so an ordinary column **switch** always has a frame with no rows at all and the segmentation blinked every time. Shapes was already partly covered (`ShapesResolver` retains `Resolution.lastGood` across a refine), leaving first-load and reload.

MDV carried a workaround for this in its own state.

## How

- New `lastGoodShapeFillColorEntry` / `lastGoodLabelFillColorEntry` in the projection modules, beside the entry shapes whose invalidation rules they extend. When the resolver has no rows (pending, reloading, failed), the getters keep serving the previous entry instead of dropping to `undefined`.
- Entries record the `elementKey` they were built against, and last-good only applies for that same element. Feature ids — and especially small-integer label ids — do not carry across elements, so another element's entry would colour the wrong features.
- `mergeShapeFeatureStateForRender` / `mergeLabelFeatureStateForRender` return `config.featureState` untouched when there is no entry at all (a column selected before anything has ever loaded) rather than overwriting `fillColorByFeatureId` with an empty map.

The stale entry's identity is still the \"the colours are now different\" signal the runtime/LUT caches key on, so the rebuild fires the moment the real rows settle.

## Reviewer notes

- **Behaviour change worth a look:** a column whose load *fails* now keeps showing the last good colours indefinitely instead of clearing to the flat fill. That's the last-good trade; the failure still surfaces through the resolver's notices, and nothing retries from here.
- 9 new unit tests cover both merges and both last-good rules, including the wrong-element refusal. Full suite: 803 passing. `tsc`, biome, `lint:react` (one pre-existing warning in `PointsFeatureState.tsx`, untouched) and the vis build are green.
- **Not verified in a browser.** The bug is a load-window race; catching the flash would need a real dataset with a column switch timed against a load. The existing `labels-color-by` browser scenario drives `LabelsLayer` with a static `featureState` and never reaches this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the last valid fill colors while color data is loading or temporarily unavailable.
  * Prevented existing caller-provided feature colors from being cleared when no replacement data is available.
  * Ensured cached colors are reused only for the matching visual element.
  * Continued displaying the last good colors when loading fails while still surfacing relevant notices.

* **Tests**
  * Added coverage for loading transitions, element matching, fallback behavior, and explicit feature colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->