### PR TITLE
Unblock the Dependabot queue: drop direct geotiff, fix the pnpm pin, stop the bot rewriting decisions

### DIFF
--- a/.changeset/drop-direct-geotiff.md
+++ b/.changeset/drop-direct-geotiff.md
@@ -1,0 +1,19 @@
+---
+'@spatialdata/avivatorish': patch
+'@spatialdata/vis': patch
+---
+
+Drop the direct `geotiff` dependency from both packages.
+
+`@spatialdata/vis` declared it but never imported it. `@spatialdata/avivatorish`
+imported `fromUrl` / `fromBlob` in exactly one place, feeding a chain of
+non-exported Avivator scaffolding for plain multi-TIFF inputs that nothing
+reached — `createLoader` is OME-NGFF-only by design. Both are now gone, along
+with the matching Vite `external` entries.
+
+No public API changes, and no effect on OME-TIFF support: that runs through viv's
+own `loadOmeTiff`, which resolves its own `geotiff` (`^2.0.5`) independently of
+what we declare. Declaring the dependency ourselves only ever added a second copy
+to consumers' trees — and pinned us to a version we could neither exercise nor
+usefully advance, since geotiff 3's decoder API is a viv-side blocker
+(hms-dbmi/viv#951), not ours.

--- a/.changeset/drop-direct-geotiff.md
+++ b/.changeset/drop-direct-geotiff.md
@@ -11,9 +11,14 @@ non-exported Avivator scaffolding for plain multi-TIFF inputs that nothing
 reached — `createLoader` is OME-NGFF-only by design. Both are now gone, along
 with the matching Vite `external` entries.
 
-No public API changes, and no effect on OME-TIFF support: that runs through viv's
-own `loadOmeTiff`, which resolves its own `geotiff` (`^2.0.5`) independently of
-what we declare. Declaring the dependency ourselves only ever added a second copy
-to consumers' trees — and pinned us to a version we could neither exercise nor
-usefully advance, since geotiff 3's decoder API is a viv-side blocker
-(hms-dbmi/viv#951), not ours.
+No public API changes, and nothing to lose on the OME-TIFF side: there was no
+OME-TIFF loading path to break. The only loaders here are `loadOmeZarr` and
+`loadOmeZarrMultiscalesData`, and the exported `OME_TIFF` type is a type-only
+derivation from viv's `loadOmeTiff` signature — `import type`, so it costs
+nothing at runtime and needs no `geotiff` of our own.
+
+Declaring the dependency only ever added a third copy to consumers' trees, and
+pinned us to a version we could neither exercise nor usefully advance: were an
+OME-TIFF path ever added, it would go through viv, which resolves its own
+`geotiff` (`^2.0.5`) regardless, and geotiff 3's decoder API is a viv-side
+blocker (hms-dbmi/viv#951), not ours.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -113,10 +113,11 @@ updates:
   # generator can emit stores in that version's on-disk layout. Their transitive
   # deps still need patching (the open setuptools alerts live here), but the pin
   # itself is the entire point of the directory and must never be bumped.
+  #
+  # Split in two only because of the setuptools cap below. The two entries are
+  # otherwise identical, and anything that changes one should change both.
   - package-ecosystem: uv
     directories:
-      - /python/v0.5.0
-      - /python/v0.6.1
       - /python/v0.7.2
       - /python/v0.8.0
     schedule:
@@ -128,13 +129,34 @@ updates:
           - '*'
     ignore:
       - dependency-name: spatialdata
-      # The `setuptools<81` cap in the v0.5.0 and v0.6.1 pyproject.toml files is
-      # load-bearing — see the comment there for why. It has to be repeated here
-      # because that comment is not something Dependabot can read: unlike the npm
-      # entry above, the uv ecosystem has no `versioning-strategy`, so the bot is
-      # free to widen a declared constraint. It did exactly that in #112,
-      # rewriting `<81` to `<84` and leaving the paragraph explaining the cap
-      # sitting directly above the line that now contradicted it. CI caught it,
-      # but only after the fixture build failed on the missing `pkg_resources`.
+
+  # The older two releases cap setuptools below 81, which removed `pkg_resources`
+  # while their dependency stack still imports it at runtime — see the comment in
+  # each pyproject.toml. That comment is not something Dependabot reads, and its
+  # default versioning strategy widens a declared constraint to admit the version
+  # it wants: in #112 it rewrote `<81` to `<84`, leaving the paragraph explaining
+  # the cap sitting directly above the line that now contradicted it. CI caught
+  # it, but only after the fixture build died on the missing `pkg_resources`.
+  #
+  # `versioning-strategy: lockfile-only` is the tempting fix and the wrong one.
+  # It would leave the cap alone, but for uv it also stops transitive updates
+  # (dependabot-core#14073) — and receiving those is what these directories are
+  # here for. Ignoring the one dependency keeps the rest of the stack moving.
+  #
+  # v0.7.2 and v0.8.0 are deliberately excluded: both already run setuptools 83
+  # uncapped, so this rule would pin them there for good, security fixes included.
+  - package-ecosystem: uv
+    directories:
+      - /python/v0.5.0
+      - /python/v0.6.1
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      fixtures:
+        patterns:
+          - '*'
+    ignore:
+      - dependency-name: spatialdata
       - dependency-name: setuptools
         versions: ['>=81']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,10 +49,26 @@ updates:
           - 'prism-react-renderer'
       # Everything else, split so a dev-tooling bump never sits behind a runtime
       # one in review.
+      #
+      # Majors are deliberately excluded from both groups so they arrive as
+      # individual PRs. A group is a single merge decision, and a batch is only
+      # worth reviewing as one if every member is safe to take on the same
+      # evidence — a green CI run. That holds for minor/patch; it does not hold
+      # for a major, which needs its own judgement and would otherwise hold the
+      # whole batch hostage while it is being made. (The August 2026 batch put
+      # a geotiff 2 -> 3 major, which viv cannot yet take, in the same PR as
+      # eight uncontroversial bumps.) Security updates are unaffected: they are
+      # matched by the `security-updates` group below, which stays unrestricted.
       production-dependencies:
         dependency-type: production
+        update-types:
+          - minor
+          - patch
       development-dependencies:
         dependency-type: development
+        update-types:
+          - minor
+          - patch
       # Security fixes arrive outside the weekly cadence; batch them so a sweep
       # like the one this file was written for is a single PR, not thirty-six.
       security-updates:
@@ -112,3 +128,13 @@ updates:
           - '*'
     ignore:
       - dependency-name: spatialdata
+      # The `setuptools<81` cap in the v0.5.0 and v0.6.1 pyproject.toml files is
+      # load-bearing — see the comment there for why. It has to be repeated here
+      # because that comment is not something Dependabot can read: unlike the npm
+      # entry above, the uv ecosystem has no `versioning-strategy`, so the bot is
+      # free to widen a declared constraint. It did exactly that in #112,
+      # rewriting `<81` to `<84` and leaving the paragraph explaining the cap
+      # sitting directly above the line that now contradicted it. CI caught it,
+      # but only after the fixture build failed on the missing `pkg_resources`.
+      - dependency-name: setuptools
+        versions: ['>=81']

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Taylor-CCB-Group/SpatialData.js.git"
   },
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.20.0",
   "scripts": {
     "clean": "rm -rf packages/*/dist packages/vis/demo/dist packages/zarrextra/src/*.d.ts packages/zarrextra/src/*.d.ts.map",
     "build": "pnpm -r --filter='!docs' run build",

--- a/packages/avivatorish/package.json
+++ b/packages/avivatorish/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@hms-dbmi/viv": "catalog:",
     "@math.gl/core": "catalog:",
-    "geotiff": "2.1.4-beta.0",
     "zarrextra": "workspace:*",
     "zustand": "^5.0.8"
   },

--- a/packages/avivatorish/src/utils.ts
+++ b/packages/avivatorish/src/utils.ts
@@ -6,7 +6,6 @@ import {
   RENDERING_MODES,
 } from '@hms-dbmi/viv';
 import { Matrix4 } from '@math.gl/core';
-import { fromBlob, fromUrl } from 'geotiff';
 import { useEffect, useState } from 'react';
 
 import { GLOBAL_SLIDER_DIMENSION_FIELDS } from './constants';
@@ -54,50 +53,17 @@ function _isMultiTiff(urlOrFiles: UrlOrFiles) {
   return true;
 }
 
-/**
- * Turns an input string of one or many urls, file, or file array into a uniform array.
- */
-async function generateMultiTiffFileArray(urlOrFiles: UrlOrFiles) {
-  if (Array.isArray(urlOrFiles)) {
-    return urlOrFiles;
-  }
-  if (urlOrFiles instanceof File) {
-    return [urlOrFiles];
-  }
-  return urlOrFiles.split(',');
-}
-
-/**
- * Gets the basic image count for a TIFF using geotiff's getImageCount.
- */
-async function getTiffImageCount(src: string | File) {
-  const from = typeof src === 'string' ? fromUrl : fromBlob;
-  //@ts-expect-error - wtf why is the inference not working here?
-  const tiff = await from(src);
-  return tiff.getImageCount();
-}
 /** addresses `c` channel, `z` z-stack index, `t`: time index */
 export type VivSelection = { c: number; z: number; t: number };
 // all very clever but unnecessary abstraction and also wrong:
 // type VivSelection = { [Key in typeof GLOBAL_SLIDER_DIMENSION_FIELDS[number]]?: number };
-/**
- * Guesses whether string URL or File is one or multiple standard TIFF images.
- */
-async function _generateMultiTiffSources(urlOrFiles: UrlOrFiles) {
-  const multiTiffFiles = await generateMultiTiffFileArray(urlOrFiles);
-  const sources: [VivSelection[], any][] = [];
-  let c = 0;
-  for (const tiffFile of multiTiffFiles) {
-    const selections: VivSelection[] = [];
-    const numImages = await getTiffImageCount(tiffFile);
-    for (let i = 0; i < numImages; i++) {
-      selections.push({ c, z: 0, t: 0 });
-      c += 1;
-    }
-    sources.push([selections, tiffFile]);
-  }
-  return sources;
-}
+
+// `generateMultiTiffFileArray` / `getTiffImageCount` / `_generateMultiTiffSources`
+// lived here, and were the package's only use of `geotiff`. They were Avivator
+// scaffolding for building selections over a multi-file plain-TIFF input, and
+// were never reachable: `createLoader` below is OME-NGFF-only by design. Removing
+// them drops `geotiff` from this package's dependencies — see the changeset for
+// why that matters beyond dead-code hygiene.
 
 class UnsupportedBrowserError extends Error {
   constructor(message: string) {

--- a/packages/avivatorish/vite.config.ts
+++ b/packages/avivatorish/vite.config.ts
@@ -12,7 +12,6 @@ const baseConfig = defineViteConfig({
   external: [
     '@hms-dbmi/viv',
     '@math.gl/core',
-    'geotiff',
     'zarrita',
     // Subpaths too (`zarrextra/workers`): a string entry matches the exact
     // specifier only, which would leave a subpath import to be resolved — and

--- a/packages/vis/package.json
+++ b/packages/vis/package.json
@@ -47,7 +47,6 @@
     "@vivjs/views": "catalog:",
     "deck.gl": "catalog:",
     "fast-deep-equal": "^3.1.3",
-    "geotiff": "2.1.4-beta.0",
     "zarrextra": "workspace:*",
     "zustand": "^5.0.8"
   },

--- a/packages/vis/vite.config.ts
+++ b/packages/vis/vite.config.ts
@@ -18,7 +18,6 @@ const baseConfig = defineViteConfig({
     '@hms-dbmi/viv',
     '@math.gl/core',
     'deck.gl',
-    'geotiff',
     'anndata.js',
     'zarrita',
     /^zarrextra(?:\/.*)?$/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,9 +209,6 @@ importers:
       '@math.gl/core':
         specifier: 'catalog:'
         version: 4.1.0
-      geotiff:
-        specifier: 2.1.4-beta.0
-        version: 2.1.4-beta.0
       zarrextra:
         specifier: workspace:*
         version: link:../zarrextra
@@ -444,9 +441,6 @@ importers:
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
-      geotiff:
-        specifier: 2.1.4-beta.0
-        version: 2.1.4-beta.0
       react:
         specifier: '>=18 <20'
         version: 19.2.8
@@ -5034,10 +5028,6 @@ packages:
 
   geotiff@2.1.3:
     resolution: {integrity: sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==}
-    engines: {node: '>=10.19'}
-
-  geotiff@2.1.4-beta.0:
-    resolution: {integrity: sha512-jb6SYvHMyiCqwqgGGLDAxtig9h1g6O+n1wEyNEE4QgVEXOItYaWrEgPg9SAnwdoZm2yx6DpFtilbGG65hvZgpQ==}
     engines: {node: '>=10.19'}
 
   geotiff@3.1.0-beta.0:
@@ -14510,17 +14500,6 @@ snapshots:
       web-worker: 1.5.0
       xml-utils: 1.10.2
       zstddec: 0.1.0
-
-  geotiff@2.1.4-beta.0:
-    dependencies:
-      '@petamoriken/float16': 3.9.3
-      lerc: 3.0.0
-      pako: 2.2.0
-      parse-headers: 2.0.6
-      quick-lru: 6.1.2
-      web-worker: 1.5.0
-      xml-utils: 1.10.2
-      zstddec: 0.2.0
 
   geotiff@3.1.0-beta.0:
     dependencies:


### PR DESCRIPTION
Triage of the open Dependabot queue. Four PRs were blocked or unmergeable; this clears the causes rather than the symptoms.

## `geotiff` was never ours

`geotiff` was a direct dependency of `vis` and `avivatorish`. Neither used it:

- **`vis`** — declared it, never imported it. Phantom.
- **`avivatorish`** — imported `fromUrl`/`fromBlob` into `getTiffImageCount`, reachable only from `_generateMultiTiffSources`. Neither is exported and nothing calls them; `createLoader` is OME-NGFF-only [by design](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/packages/avivatorish/src/utils.ts). Inherited Avivator scaffolding.

Declaring it cost consumers a third copy in their tree. Viv resolves its own (`^2.0.5`) regardless of what we say, and OpenLayers — via `core`, for `ol/format/WKB.js` — pulls a 3.x. Removing the declaration takes us from three geotiff resolutions to two.

This also disposes of the `geotiff 2 -> 3` major in #114 without having to decide anything about it. It was never ours to take: geotiff 3's decoder API change is a viv-side blocker (hms-dbmi/viv#951). **No effect on OME-TIFF support**, which runs through viv's `loadOmeTiff` either way.

## Groups no longer batch majors

#114 put that major in one PR with eight uncontroversial bumps. A group is a single merge decision, and a batch is only reviewable on one piece of evidence — a green CI run. That holds for minor/patch; it doesn't for a major, which needs its own judgement and otherwise holds the batch hostage while it's being made.

`production-dependencies` and `development-dependencies` are now `update-types: [minor, patch]`. Majors arrive as individual PRs. The `security-updates` group is untouched and still takes everything.

## `setuptools` is ignored above 81

The cap in the v0.5.0 and v0.6.1 `pyproject.toml` files is load-bearing, and carries a paragraph explaining why. But a comment isn't something Dependabot reads, and the uv ecosystem has no `versioning-strategy` to restrain it the way the npm entry is restrained. In #112 it rewrote `<81` to `<84`, leaving the explanation sitting directly above the line that now contradicted it. CI caught it, but only after the fixture build died on the missing `pkg_resources`.

## The pnpm pin was breaking #111

Every job in #111 fails with `Cannot use 'in' operator to search for 'integrity' in undefined`. Nothing is wrong with the actions — `pnpm/action-setup` v6 installs via the self-installer, which trips a resolution bug in the 11.12.0 we pin (pnpm/action-setup#276, pnpm/pnpm#12959). 11.13.1 still reproduces it against our lockfile, so this goes to 11.20.0.

## Reviewing this

Two commits, deliberately split. The lockfile diff is **21 lines** and belongs entirely to the geotiff removal; the pnpm bump carries no lockfile change at all.

That split is load-bearing. Resolving *with* a manifest change under 11.20.0 rewrites peer suffixes across the whole file — ~1500 lines where 11.12.0 touched 21 — so generating the geotiff lockfile under the old pin and bumping separately is what keeps this readable. `--frozen-lockfile`, the form every workflow uses, is a no-op under 11.20.0, so CI is unaffected. Nothing can force that re-serialization early: it'll land on whichever dependency PR next changes the graph. Expect it once, and read it as serialization, not resolution.

## Verified

`build`, `lint:biome` (exit 0), `lint:react` (exit 0), and 803/803 unit tests — under both 11.12.0 and 11.20.0.

## Follow-ups, not in this PR

- **#112 and #114 should be closed**, not merged. The bot will reopen the useful parts of #114 correctly grouped on Monday. #111 should go green on a rebase once this lands.
- **`core` depends on `ol` for a WKB parser.** OpenLayers is the remaining source of geotiff 3, plus a second zarrita, rbush, pbf and earcut — and it propagates to anything taking `core` alongside viv, which is the duplication showing up downstream in MDV. `@loaders.gl/wkt` would add no new transitive tree since deck.gl already brings `@loaders.gl/core`. Wants its own PR and fixture verification; WKB correctness isn't something to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Streamlined TIFF handling by removing unused legacy multi-file plain-TIFF support.
  - OME-TIFF support remains available through the existing image workflow.

- **Chores**
  - Updated the project’s package manager version requirement.
  - Improved automated dependency update grouping and version controls.
  - Added release metadata for the affected visualization packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->