### PR TITLE
Make deckgl-stack and docs-stack actually claim their dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,31 @@ updates:
       # Everything else, split so a dev-tooling bump never sits behind a runtime
       # one in review.
       #
+      # The `exclude-patterns` below are what make the two stack groups above
+      # work at all. Between them these groups match `dependency-type: production`
+      # and `dependency-type: development`, which is every dependency there is.
+      # The documented rule is that the first matching group wins and both stack
+      # groups are declared first, but that is not the observed behaviour: in
+      # practice these two claimed everything, and neither `deckgl-stack` nor
+      # `docs-stack` had opened a single PR in the lifetime of this file.
+      #
+      # Docusaurus 3.10.2 is what exposed it. `@docusaurus/core` and
+      # `preset-classic` are runtime deps of docs/ and went to production; the
+      # matching `types`, `tsconfig` and `module-type-aliases` are dev deps and
+      # went to development. Two PRs (#123, #124), each mergeable alone, each
+      # leaving the docs site half-upgraded — precisely what `docs-stack` was
+      # written to prevent. On the deck.gl side the same split is worse than
+      # cosmetic; see the note above that group.
+      #
+      # An exclusion has to be listed here for every pattern in a stack group,
+      # in both of these groups. If a pattern is added above and not in both
+      # lists below, that group silently stops claiming it and the dependency is
+      # quietly absorbed back into these two. The lists are spelled out rather
+      # than shared through a YAML anchor on purpose: dependabot-core is Ruby,
+      # and `YAML.safe_load` rejects aliases with `Psych::BadAlias` unless the
+      # caller opts in. Whether it does is not something this file should bet on
+      # — a parse error here disables every update in the repository.
+      #
       # Majors are deliberately excluded from both groups so they arrive as
       # individual PRs. A group is a single merge decision, and a batch is only
       # worth reviewing as one if every member is safe to take on the same
@@ -64,11 +89,37 @@ updates:
         update-types:
           - minor
           - patch
+        exclude-patterns:
+          # deckgl-stack
+          - 'deck.gl'
+          - '@deck.gl/*'
+          - '@luma.gl/*'
+          - '@loaders.gl/*'
+          - '@math.gl/*'
+          - '@hms-dbmi/viv'
+          - '@vivjs/*'
+          # docs-stack
+          - '@docusaurus/*'
+          - '@mdx-js/*'
+          - 'prism-react-renderer'
       development-dependencies:
         dependency-type: development
         update-types:
           - minor
           - patch
+        exclude-patterns:
+          # deckgl-stack
+          - 'deck.gl'
+          - '@deck.gl/*'
+          - '@luma.gl/*'
+          - '@loaders.gl/*'
+          - '@math.gl/*'
+          - '@hms-dbmi/viv'
+          - '@vivjs/*'
+          # docs-stack
+          - '@docusaurus/*'
+          - '@mdx-js/*'
+          - 'prism-react-renderer'
       # Security fixes arrive outside the weekly cadence; batch them so a sweep
       # like the one this file was written for is a single PR, not thirty-six.
       security-updates:


### PR DESCRIPTION
Neither group has ever opened a PR.

Every npm Dependabot PR in this repository's history has been `production-dependencies`, `development-dependencies`, or an individual major. `deckgl-stack` and `docs-stack` have been inert config since the file was written — including through #114/#115 and again through #123/#124.

## Why

Between them, `dependency-type: production` and `dependency-type: development` match every dependency there is. The [documented rule](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) is that the first matching group wins, and both stack groups are declared first, so this shouldn't happen — but it does. `exclude-patterns` is the mechanism that doesn't depend on that ordering being honoured.

## What exposed it

Docusaurus 3.10.2, split across two PRs:

| PR | Group | Packages | Declared in |
|---|---|---|---|
| #124 | production-dependencies | `@docusaurus/core`, `@docusaurus/preset-classic` | `dependencies` |
| #123 | development-dependencies | `module-type-aliases`, `tsconfig`, `types` | `devDependencies` |

Each is mergeable alone, and either one alone leaves the docs site with type definitions from one version and a runtime from another. `docs/` runs `tsc`, so that mismatch is exercised rather than theoretical. Keeping the set in one PR is the entire stated purpose of `docs-stack`.

**`deckgl-stack` is the one that matters.** Its comment warns that bumping deck.gl, luma.gl and viv out of step yields a tree that installs cleanly and breaks at runtime on mismatched GL context internals. It hasn't bitten yet only because no update has come through for that stack — the failure mode is waiting on the next deck.gl release, not hypothetical.

## Note on the anchor

The exclusion list is written out twice rather than shared through a YAML anchor. dependabot-core is Ruby, and `YAML.safe_load` raises `Psych::BadAlias` unless the caller opts into aliases — verified locally. Whether it opts in isn't something this file should bet on, because a parse error here disables every update in the repository. The duplication is guarded by a comment; the two lists must stay in sync.

## Verified

- Config parses under Ruby `YAML.safe_load` with aliases disabled — the strict case.
- Both exclusion lists cover every pattern in both stack groups (checked programmatically, not by eye).
- The uv `ignore` scoping from #120 is unchanged.

## What to watch

This can't be fully verified until Dependabot next runs, and there are two possible outcomes:

1. **Intended** — Docusaurus and deck.gl updates arrive as single `docs-stack` / `deckgl-stack` PRs.
2. **Fallback** — the stack groups still don't fire, and their members now arrive as individual PRs instead of being absorbed into the dependency-type groups. Noisier, but strictly safer than today: a split pair can't be half-merged without noticing.

Either way the current failure mode is gone. If it lands as (2), the next step is dropping the pattern groups entirely and relying on individual PRs for those stacks.

Worth merging before the next deck.gl release rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)