### PR TITLE
Memory accounting before memory management: ADR 0005 rungs 1-3

### DIFF
--- a/.changeset/bound-parquet-caches.md
+++ b/.changeset/bound-parquet-caches.md
@@ -1,0 +1,39 @@
+---
+'@spatialdata/core': minor
+---
+
+Bound the two parquet caches on `SpatialDataTableSource` by resident bytes
+([ADR 0005](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/docs/adr/0005-memory-accounting-before-management.md)
+rung 2), and add the `ByteLruCache` they are built on.
+
+`parquetTableBytes` (compressed file bytes) and `parquetTableCache` (decoded
+Arrow tables) were plain `Record`s with no eviction of any kind. A source held
+**both tiers of every parquet file any caller had ever touched**, simultaneously,
+until the source itself was discarded — double memory for zero eviction benefit.
+That is a leak, and this fixes it rather than building an architecture around it:
+both are now byte-bounded LRUs that report `byteLength`, and memory is
+assertable in a test for the first time.
+
+**Breaking for anyone reading those two fields directly.** They are no longer
+plain objects: `source.parquetTableBytes[path]` becomes
+`source.parquetTableBytes.get(path)`, with `peek` for a read that should not
+count as a use, plus `has`, `delete`, `clear`, `size` and `byteLength`. Nothing
+in this repository outside `VTableSource` touched either one.
+
+Ceilings default to 128 MB encoded and 256 MB decoded per source, overridable
+via the new `parquetCacheLimits` field on `DataSourceParams`. The numbers are
+guesses that bound a leak, not a measured working set — the ADR is explicit that
+they stay guesses until something measures them, so they are a constructor
+option rather than a constant you would have to fork the library to change.
+
+Two semantics worth knowing:
+
+- **A value larger than the whole budget is admitted, not refused**, and left as
+  the sole resident. Refusing it would be the worse failure: `loadParquetBytes`
+  runs roughly twenty times per points load, so a file that can never be admitted
+  becomes twenty refetches of the file that was already too big to fetch once.
+- **Entries are inserted before their size is known.** The decoded cache holds
+  the in-flight promise — that is what dedupes concurrent callers onto one WASM
+  decode — so it is sized at zero until the table lands, then recounted. Arrow's
+  `Data.byteLength` walks the whole child tree, so it is asked exactly once per
+  table and the total is maintained incrementally from there.

--- a/.changeset/bound-parquet-caches.md
+++ b/.changeset/bound-parquet-caches.md
@@ -26,6 +26,14 @@ guesses that bound a leak, not a measured working set — the ADR is explicit th
 they stay guesses until something measures them, so they are a constructor
 option rather than a constant you would have to fork the library to change.
 
+`ByteLruCache` also exposes `deleteIf(key, value)` and `recountIf(key, value)`,
+which act only while the entry is still the one the caller inserted. A late
+settlement — a decode that failed after its key was re-requested, or after
+eviction made room — must not reach in and resize or delete whatever took its
+place, and an unguarded `delete` there silently drops a live, valid entry. It is
+the same rule `VTableSource.evictIfCurrent` applies to its promise-keyed `Map`s,
+spelled for a cache whose reads carry recency.
+
 Two semantics worth knowing:
 
 - **A value larger than the whole budget is admitted, not refused**, and left as

--- a/.changeset/fill-chunk-cache-seam.md
+++ b/.changeset/fill-chunk-cache-seam.md
@@ -1,0 +1,38 @@
+---
+'@spatialdata/vis': minor
+'@spatialdata/core': patch
+---
+
+Give zarr imagery a decoded chunk cache
+([ADR 0005](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/docs/adr/0005-memory-accounting-before-management.md)
+rung 3). There was not one before — not an undersized one, none at all.
+
+fizarrita has always accepted a `{ get, set }` cache on `getWorker`, and
+`zarrextra` has always plumbed it through `enableWorkerChunkDecode({ cache })`.
+`ensureCodecWorkers()` called that with no options, so `cache` was `undefined`
+and fizarrita fell back to its no-op. The seam was exported, documented, typed
+end to end, and empty. Every tile therefore paid a network round-trip *and* a
+re-decode every time it came back into view.
+
+It is now filled with a byte-bounded LRU, default 256 MB, overridable with
+`ensureCodecWorkers({ chunkCacheMaxBytes })` on the first call. `getChunkCache()`
+returns it for inspection (`byteLength` is what it currently holds) or for
+`clear()`.
+
+`RasterElement.getStore()` is now memoized, and that is load-bearing rather than
+tidiness: fizarrita keys chunks as `store_N:{array path}:{chunk key}`, where `N`
+comes from a `WeakMap` on the **store instance**, and `createPrefixedStore`
+returns a fresh object literal on every call. Handing out a new view per caller
+would give one chunk a different key per view, so the cache would fill with
+duplicates and never hit. One stable view per element is what makes it a cache.
+
+Two limits worth stating plainly:
+
+- **Absent chunks are cached as data.** fizarrita materialises a full zero-filled
+  typed array for a missing chunk and caches it like any other, so a sparse array
+  can spend real bytes on nothing. The byte bound makes that survivable; it does
+  not make it free.
+- **In-flight requests are still not deduped.** fizarrita reads the cache while
+  building its task list and writes back only after the worker returns, so two
+  concurrent requests for the same chunk both fetch and both decode. That is an
+  upstream gap this seam cannot close.

--- a/.changeset/fill-chunk-cache-seam.md
+++ b/.changeset/fill-chunk-cache-seam.md
@@ -26,13 +26,14 @@ returns a fresh object literal on every call. Handing out a new view per caller
 would give one chunk a different key per view, so the cache would fill with
 duplicates and never hit. One stable view per element is what makes it a cache.
 
-Two limits worth stating plainly:
+Two things worth stating plainly about what ends up in there:
 
 - **Absent chunks are cached as data.** fizarrita materialises a full zero-filled
   typed array for a missing chunk and caches it like any other, so a sparse array
   can spend real bytes on nothing. The byte bound makes that survivable; it does
   not make it free.
-- **In-flight requests are still not deduped.** fizarrita reads the cache while
-  building its task list and writes back only after the worker returns, so two
-  concurrent requests for the same chunk both fetch and both decode. That is an
-  upstream gap this seam cannot close.
+- **Concurrent readers of one chunk share a single fetch and decode.** fizarrita
+  keys in-flight operations the same way it keys this cache, closing the window
+  between "someone started fetching this" and "the result is cacheable". So the
+  cache sees one write per chunk however many readers wanted it, and the byte
+  total counts each chunk once.

--- a/.changeset/fizarrita-2-1-0.md
+++ b/.changeset/fizarrita-2-1-0.md
@@ -1,0 +1,35 @@
+---
+'zarrextra': minor
+---
+
+Move to `@fideus-labs/fizarrita` and `@fideus-labs/worker-pool` 2.1.0.
+
+A major bump upstream, but a no-op at this seam: the pieces `zarrextra` touches —
+`getWorker`, `ChunkCache`, `GetWorkerOptions`, the codec-worker entry — are
+unchanged in shape. What moved is internal to fizarrita (`createDefaultWorker`
+relocating to a `create-worker` module, a `WorkerLike` abstraction so the pool can
+run on `node:worker_threads`), and all of it is still exported from the package
+root we import from. Nothing here needed editing to compile.
+
+What we get for it is the whole of what ADR 0005 recorded as owed upstream:
+
+- **Concurrent readers of one chunk now share a single fetch and decode.**
+  fizarrita keys in-flight operations the same way it keys the chunk cache, so
+  the window between "someone started fetching this" and "the result is
+  cacheable" no longer costs a duplicate round-trip and a duplicate decompression.
+  This is what makes the chunk cache worth its bytes on a pan that re-enters
+  ground already in flight.
+- **Metadata reads and the chunk-shape probe are memoised per `(store, path)`.**
+  Every `getWorker` call used to re-read `zarr.json`/`.zarray` and re-run
+  `probeActualChunkShape`, *before* the cache was consulted — so a populated
+  chunk cache could not eliminate them and every tile paid for both.
+- **Codec classification no longer mistakes compressed chunks for uncompressed
+  ones.** The old check named the compressors it knew; anything else — JPEG 2000
+  and HTJ2K among them — took the not-compressed branch and reported its
+  *compressed* length as its decompressed size, feeding a wrong number to chunk
+  shape inference. It now allowlists the codecs that preserve byte count instead.
+  This one affects our imagery directly.
+- **`getWorker` accepts an `AbortSignal`**, forwarded to every `store.get`.
+  Not taken up here yet — `rejectOnAbort` still only settles the promise early,
+  so a cancelled read stops being awaited while its fetch and decode run on.
+  Wiring it through is now possible and is deliberately left as its own change.

--- a/.changeset/forward-abort-signal.md
+++ b/.changeset/forward-abort-signal.md
@@ -1,0 +1,34 @@
+---
+'zarrextra': minor
+---
+
+Make a cancelled chunk read actually cancel.
+
+`getZarrChunk` accepted an `AbortSignal` and wrapped the read in `rejectOnAbort`,
+which raced the signal against the promise and rejected early. That stopped the
+caller *awaiting* the read and nothing more: the store request and the worker
+decode ran to completion, unobserved. A pan that outran its tiles paid the full
+network and decode cost of every tile it had already abandoned, and the only
+visible sign was that the numbers never quite added up.
+
+The signal is now handed to whichever backend is serving the read, both of which
+take it as a first-class option:
+
+- **fizarrita** (worker decode) aborts the store requests it makes — metadata,
+  chunk-shape probe, and chunk fetches alike — and drops chunk tasks still queued
+  on the worker pool rather than starting them.
+- **zarrita** (main thread) forwards it to every `store.get` and re-checks it
+  between chunks, so a multi-chunk read stops early instead of running the rest
+  out.
+
+Neither interrupts a decode already running on a worker; that result is decoded
+and discarded. So this bounds what a cancelled read *starts*, not what it has
+already handed over — worth knowing before treating cancellation as free.
+
+`rejectOnAbort` is deleted rather than kept alongside: fizarrita rejects promptly
+with the signal's reason on its own, and two things racing to reject one read is
+a good way to end up unable to say which reason a caller will see.
+
+The signal is also now structurally excluded from the backend-level options set
+once by `enableWorkerChunkDecode`. Cancellation belongs to a single read, and a
+signal parked on the backend would quietly govern every read it ever served.

--- a/.changeset/memory-reporting-scalar.md
+++ b/.changeset/memory-reporting-scalar.md
@@ -1,0 +1,20 @@
+---
+'@spatialdata/core': minor
+---
+
+Add `MemoryReporting` — `{ readonly byteLength: number }` — the first rung of
+[ADR 0005](https://github.com/Taylor-CCB-Group/SpatialData.js/blob/main/docs/adr/0005-memory-accounting-before-management.md).
+
+The library had a memory *policy* and no memory *accounting*: `DEFAULT_POINTS_MEMORY_CAP`
+is a row count applied to one element kind, and nothing anywhere could answer
+"how many bytes are resident right now?". This is that answer, and only that
+answer — no tiers, no eviction, no ceiling.
+
+The name is doing the work. `byteLength` is what `TypedArray`, `ArrayBuffer` and
+`DataView` already call this, so every payload we actually hold satisfies the
+interface structurally, with no wrapper and no import. That is what makes it
+cheap enough to put on every cache rather than on a chosen few.
+
+Implementors take on one obligation: keep the number cheap to read — a running
+total maintained on insert and evict, not a scan of the residents per read — so
+that callers can poll it freely.

--- a/.changeset/parquet-table-cache-rejection-cleanup.md
+++ b/.changeset/parquet-table-cache-rejection-cleanup.md
@@ -1,0 +1,27 @@
+---
+'@spatialdata/core': patch
+---
+
+Stop a transient parquet fetch failure from poisoning `loadParquetTable` for the
+lifetime of the source.
+
+`parquetTableCache` stores the table promise *before* it settles. That is
+deliberate and correct — it is what makes concurrent callers for the same file
+share one `readParquet` + `tableFromIPC` decode instead of racing two WASM
+parses of the same bytes. What was missing is the other half: nothing ever
+removed a promise that settled as a *rejection*. A single failed read — a
+dropped connection, a 503, a store not yet warm — left a rejected promise
+parked at that path forever, and every subsequent read of that element replayed
+a network error that had long since cleared. The only recovery was to construct
+a new source.
+
+The cached promise now evicts itself on rejection, and only if it is still the
+current entry for that path, so a retry that already superseded it is not
+clobbered by the earlier promise's late rejection. This is the same
+`evictIfCurrent` discipline `loadParquetDatasetMetadata` and
+`discoverMultipartPartPaths` already use.
+
+In-flight dedup and the caching of successful tables are unchanged, and so is
+the deliberate skip-vs-fail policy in `docs/plans/parquet-io-error-handling.md`:
+the rejection still propagates unchanged to the caller that provoked it. It just
+stops being the answer given to the next one.

--- a/docs/adr/0004-resource-resolver-owned-by-core.md
+++ b/docs/adr/0004-resource-resolver-owned-by-core.md
@@ -42,7 +42,9 @@ work cannot proceed concurrently without conflicting.
 
 This is the decisive one, and it is not a matter of taste.
 
-`tgpu-htj2k` renders 1.5 Gpx HTJ2K imagery from a real Xenium SpatialData store
+[`intraspatial`](https://github.com/xinaesthete/intraspatial) — the project this
+ADR and ADR 0005 formerly named `tgpu-htj2k`, before the relevant code migrated
+there — renders 1.5 Gpx HTJ2K imagery from a real Xenium SpatialData store
 through three.js/WebGPU **today**. It depends on `@spatialdata/core` and
 `zarrextra`, and its ADR-0010 excludes the rest by name:
 
@@ -116,7 +118,7 @@ concept.
    - `PointsResolver`, `ShapesResolver` → **`core`**. Every type they touch
      (`PointsLoadResult`, `PointsFeatureCatalog`, `ShapesRenderData`,
      `ShapesTooltipMetadata`) is already a `core` type, and both are what
-     `tgpu-htj2k` was forced to hand-roll.
+     `intraspatial` was forced to hand-roll.
    - `ImagesResolver`, `LabelsResolver` → **`vis`**, for now. See below.
 
    **`core` defines no image port.** *(Amended 2026-07-14; see "Amendment —
@@ -125,12 +127,12 @@ concept.
 
 7. **No runtime dependency enters `core`.** No Effect, no `neverthrow`, no
    TanStack in a public signature. `core` is the dependency root for
-   `tgpu-htj2k` as well as `layers`, and that repo's engine core is deliberately
+   `intraspatial` as well as `layers`, and that repo's engine core is deliberately
    dependency-free. A library may be used *inside* a resolver's implementation
    (see the `RequestSlot` spike) but must not appear in `core`'s interface.
 
    This is a **current position resting on another repo's position**, not a law.
-   It is revisable if `tgpu-htj2k`'s dependency-free stance is renegotiated —
+   It is revisable if `intraspatial`'s dependency-free stance is renegotiated —
    which is exactly the kind of cross-repo conversation §"Cross-repo consequence"
    already flags as *owed*. Read it as *not now*, not as *never*. Nothing in the
    Step 0 / Step 1 work turns on the answer either way, and the `RequestSlot`
@@ -163,12 +165,12 @@ Three things follow, and together they keep images out of `core` for now:
   instead of vendoring near-duplicates"*, and *"the long-term shape of serialized
   image state is still **evolving**."* It is a de-vendored fork of code that also
   lives upstream in Viv and in MDV. A port designed against it today would encode
-  a guess about an unsettled model — into the interface `tgpu-htj2k` depends on.
+  a guess about an unsettled model — into the interface `intraspatial` depends on.
 - **The second consumer does not need it.** Per §Non-goals below, `zarrextra`'s
-  `VivCompatiblePixelSource` **already serves both Viv and `tgpu-htj2k` today**;
+  `VivCompatiblePixelSource` **already serves both Viv and `intraspatial` today**;
   the shared seam for images already exists and sits *below* the Resolver. Images
   is the one kind of the four where the duplication argument — the entire reason
-  for this ADR — **does not apply**. `tgpu-htj2k` needs `PointsResolver` and
+  for this ADR — **does not apply**. `intraspatial` needs `PointsResolver` and
   `ShapesResolver` from `core`; it does not need an images resolver from anyone.
 - So an image port in `core` would pay a real cost to solve a problem that is not
   there.
@@ -196,8 +198,8 @@ stays with the renderer, deliberately.
 
 | Concern | Owner | Why |
 |---|---|---|
-| **Element-level** resource lifecycle — preload, catalog, row codes, geometry, tooltip metadata, fill colour | **Resource Resolver** (`core`) | Identical for every renderer. Duplicating it is what `tgpu-htj2k` was forced to do. |
-| **Tile-level** lifecycle — which tiles, at what LOD, when to abort on pan | **Renderer Adapter** | Genuinely renderer-specific. deck's `TileLayer` and `tgpu-htj2k`'s `Select` + `loadScheduler` (Nyquist + frustum + nearest-first) implement *different, correct* policies for *different* viewports and budgets. |
+| **Element-level** resource lifecycle — preload, catalog, row codes, geometry, tooltip metadata, fill colour | **Resource Resolver** (`core`) | Identical for every renderer. Duplicating it is what `intraspatial` was forced to do. |
+| **Tile-level** lifecycle — which tiles, at what LOD, when to abort on pan | **Renderer Adapter** | Genuinely renderer-specific. deck's `TileLayer` and `intraspatial`'s `Select` + `loadScheduler` (Nyquist + frustum + nearest-first) implement *different, correct* policies for *different* viewports and budgets. |
 | The **loader** facet — `capabilities`, `loadInBounds()` | **`core`**, shared | Already ADR 0003's decision. This is the seam both tile schedulers call. |
 | The **byte-level chunk/table cache** | **`core`**, shared ([ADR 0005](0005-memory-accounting-before-management.md)) | Registered downward at the store layer, so it is shared regardless of who schedules. |
 
@@ -235,7 +237,7 @@ vertex**.
 Adapter question. The images resolver is thin (loader construction, omero channel
 defaults, multi-selection stats); the heavy lifting — multiscale pyramid, tile
 fetch, codec — is in `zarrextra`, whose `VivCompatiblePixelSource` **already serves
-both Viv and `tgpu-htj2k` today**. The shared seam for images therefore already
+both Viv and `intraspatial` today**. The shared seam for images therefore already
 exists and sits *below* the Resolver. A renderer-agnostic Resolver buys the 3D
 option without spending it: go all-in on WebGPU for 3D and the Resolver does not
 change; stay on Viv for 2D and it does not change either.
@@ -263,7 +265,7 @@ Only this sentence changes: *"The canonical ordered render description lives in
 |---|---|
 | deck.gl (`@spatialdata/layers`) | shipping |
 | Viv image props (`@spatialdata/layers`) | shipping — and *already a distinct output shape*: images do not produce `Layer[]`, which is why every interface sketch grew an awkward optional `buildVivProps?` |
-| three.js / TSL (`tgpu-htj2k`) | shipping |
+| three.js / TSL (`intraspatial`) | shipping |
 | headless (no renderer) | shipping — and today cannot reach any of this logic |
 
 Four adapters, three of them live. The Viv wart is worth dwelling on: it was the
@@ -274,7 +276,7 @@ it.
 
 - **Group Entry compositing / blend rendering ops.** `CONTEXT.md` reserves
   **Group Entry** and says plainly: *"Avoid: framebuffer layer until the
-  rendering behavior exists."* That still holds. `tgpu-htj2k`'s
+  rendering behavior exists."* That still holds. `intraspatial`'s
   `splatDensity.ts` is a GPU splat-by-blending **primitive**, not a prototype of
   Render Stack compositing, and adopting it would mean adopting the whole WebGPU
   stack. A group layer-hierarchy — where blend ops would live — is expected to
@@ -292,8 +294,8 @@ it.
 
 ## Cross-repo consequence
 
-`tgpu-htj2k` ADR-0008's cross-repo layering table assigns `Select` / `Tileset` /
-`TileCache` / render backends to `tgpu-htj2k` as their **permanent** home. That
+`intraspatial` ADR-0008's cross-repo layering table assigns `Select` / `Tileset` /
+`TileCache` / render backends to `intraspatial` as their **permanent** home. That
 was decided when the only SpatialData.ts equivalent lived behind deck.gl. If the
 Resolver moves to `core`, the table should be renegotiated: **resolution to
 `core`, render backends stay.** This ADR does not unilaterally amend another

--- a/docs/adr/0005-memory-accounting-before-management.md
+++ b/docs/adr/0005-memory-accounting-before-management.md
@@ -1,6 +1,6 @@
 # Memory Accounting Before Memory Management
 
-**Status:** proposed
+**Status:** accepted
 **Related:** [ADR 0004](0004-resource-resolver-owned-by-core.md), [ADR 0002](0002-spatially-aware-vector-loading.md)
 
 Adopt byte-level **memory accounting** now; adopt a **Resource Ceiling** only when
@@ -51,7 +51,16 @@ The seam is real, exported, documented, and free: `enableWorkerChunkDecode({ cac
 will accept any `{get, set}` object today with no changes to fizarrita or
 `zarrextra`.
 
-### Prior art: `tgpu-htj2k`
+### Prior art: `intraspatial`
+
+> **Naming.** The relevant code has migrated to
+> <https://github.com/xinaesthete/intraspatial> and is called `intraspatial`
+> from here on. Earlier drafts of this ADR, ADR 0004, and the plans under
+> `docs/plans/` referred to it by its former name; all of those were renamed in
+> the same pass, so nothing is left half-renamed. The former name survives in
+> exactly one place — ADR 0004's first mention — where it is doing the job of
+> telling a reader of the older ADR that the two names are the same project.
+
 
 ```ts
 /** Anything holding resident host memory can report it in bytes (mirrors TypedArray). */
@@ -133,7 +142,7 @@ provoked.
 
 ## Rationale for deferring 4–5
 
-`tgpu-htj2k` **built and unit-tested** `selectWithinBudget` — a degrade-to-fit
+`intraspatial` **built and unit-tested** `selectWithinBudget` — a degrade-to-fit
 ceiling — and then **never called it in production**. Its ADR-0010 defers it
 *"until an actual OOM (e.g. a grazing oblique strip) can be provoked"*, because
 the geometry (Nyquist + frustum + LOD gradient) already bounds the working set to

--- a/docs/adr/0005-memory-accounting-before-management.md
+++ b/docs/adr/0005-memory-accounting-before-management.md
@@ -225,10 +225,10 @@ attached.
    every `store.get` — metadata, probe, and chunk fetches — with still-queued pool
    tasks dropped when it fires
    ([worker-pool#15](https://github.com/fideus-labs/worker-pool/pull/15)).
-   **Not yet taken up here:** `zarrextra`'s `rejectOnAbort` still only settles the
-   promise early, so a cancelled read stops being awaited but its fetch and decode
-   still run to completion. Forwarding the signal is now a change we can make and
-   have not.
+   Taken up here: `zarrextra` forwards the caller's signal to both backends and
+   its `rejectOnAbort` wrapper is gone. That wrapper only stopped us *awaiting* a
+   read — the fetch and the decode ran to completion regardless — so a pan that
+   outran its tiles paid full price for every tile it had abandoned.
 
 ## Consequences
 

--- a/docs/adr/0005-memory-accounting-before-management.md
+++ b/docs/adr/0005-memory-accounting-before-management.md
@@ -170,11 +170,13 @@ authorities themselves.
   **store object instance**. `createPrefixedStore` returns a **fresh object literal
   on every call**, so two prefixed views over the same root get different `store_N`
   and would double-cache. Hold a stable prefixed-store instance per element.
-- **Neither seam gives in-flight dedup.** fizarrita checks the cache while building
-  its task list and writes it only after the worker returns, so two concurrent
-  requests for the same chunk both fetch and both decode. Key pending promises
-  yourself — `parquetTableCache` is the in-repo precedent, and also the cautionary
-  tale (see the rejection-poisoning bug above).
+- **In-flight dedup is fizarrita's job now, not ours.** It used to check the cache
+  while building its task list and write back only after the worker returned, so
+  two concurrent requests for one chunk both fetched and both decoded; the note
+  here said to key pending promises ourselves. Since 2.1.0 it keys them itself,
+  the same way it keys the chunk cache, so the zarr side needs nothing. The
+  parquet side still keys its own — `parquetTableCache` is the in-repo precedent,
+  and also the cautionary tale (see the rejection-poisoning bug above).
 - **`Resolution.stale` needs a drop policy, and it bounds the `Resolution`
   contract.** A `failed` resolution holding `stale: PointsLoadResult` pins roughly
   48 MB indefinitely. Today's code leaks the same memory implicitly; the type makes
@@ -195,25 +197,38 @@ authorities themselves.
 
 ## Owed upstream to fizarrita
 
-Worth filing alongside the `zarrextra` asks already listed in
-`tgpu-htj2k/docs/zarrextra-worker-decode.md`:
+**All four are resolved as of fizarrita 2.1.0.** Kept as a record of what was
+wrong and where it was fixed, because two of them shaped decisions elsewhere in
+this ADR and the reasoning is easier to follow with the original complaint
+attached.
 
-1. **`probeDecompressedSize` does not recognise `imagecodecs_jpeg2k` or HTJ2K.** Its
-   compression sniff knows only `gzip|zlib|blosc|zstd|lz4|bz2|lzma|snappy`, so for
-   JP2K-backed images it takes the "not compressed" branch and returns the
-   *compressed* byte length as the decompressed size, then feeds that to
-   `inferChunkShape`. Usually it fails to divide cleanly and falls back to the
-   metadata shape harmlessly — but it can emit spurious `chunk_shape does not match`
-   warnings and, worst case, adopt a bogus inferred shape. **This affects our
-   imagery.**
-2. **Two extra store round-trips per tile.** Every `getWorker` call re-reads
-   `zarr.json`/`.zarray` *and* runs `probeActualChunkShape` (another `store.get`,
-   plus up to five one-past-the-end probes). The probe runs **before** the cache is
-   consulted, so even a populated chunk cache would not eliminate it.
-3. **No in-flight dedup on the chunk path.**
-4. **No `AbortSignal`.** `GetWorkerOptions` has no `signal`, and `zarrextra`'s
-   `rejectOnAbort` only settles the promise early — the fetch and the worker decode
-   run to completion regardless.
+1. ~~**`probeDecompressedSize` does not recognise `imagecodecs_jpeg2k` or HTJ2K.**~~
+   Its compression sniff knew only `gzip|zlib|blosc|zstd|lz4|bz2|lzma|snappy`, so
+   for JP2K-backed images it took the "not compressed" branch and returned the
+   *compressed* byte length as the decompressed size, then fed that to
+   `inferChunkShape`. **This affected our imagery.** Fixed in
+   [worker-pool#9](https://github.com/fideus-labs/worker-pool/pull/9) by inverting
+   the test: allowlist the codecs known to *preserve* byte count and treat an
+   unrecognised codec as size-changing, since misjudging that way costs one decode
+   through the existing fallback while the other way returns a silently wrong
+   number.
+2. ~~**Two extra store round-trips per tile.**~~ Every `getWorker` call re-read
+   `zarr.json`/`.zarray` *and* ran `probeActualChunkShape`, before the cache was
+   consulted, so even a populated chunk cache could not eliminate them. Fixed in
+   [worker-pool#14](https://github.com/fideus-labs/worker-pool/pull/14), which
+   memoises both per `(store, path)`.
+3. ~~**No in-flight dedup on the chunk path.**~~ Fixed in
+   [worker-pool#10](https://github.com/fideus-labs/worker-pool/pull/10): in-flight
+   operations are keyed the same way the chunk cache is, so concurrent readers of
+   one chunk share a single fetch and a single decode.
+4. ~~**No `AbortSignal`.**~~ `GetWorkerOptions` now takes a `signal`, forwarded to
+   every `store.get` — metadata, probe, and chunk fetches — with still-queued pool
+   tasks dropped when it fires
+   ([worker-pool#15](https://github.com/fideus-labs/worker-pool/pull/15)).
+   **Not yet taken up here:** `zarrextra`'s `rejectOnAbort` still only settles the
+   promise early, so a cancelled read stops being awaited but its fetch and decode
+   still run to completion. Forwarding the signal is now a change we can make and
+   have not.
 
 ## Consequences
 

--- a/docs/plans/layer-data-engine-decomposition.md
+++ b/docs/plans/layer-data-engine-decomposition.md
@@ -7,7 +7,7 @@
 > This plan proposes a `LayerDataEngine` in `@spatialdata/layers`. That is one
 > package too high: the orchestration layer is the **Resource Resolver**, it is
 > renderer-agnostic, and it belongs in `@spatialdata/core`. A second Resource
-> Resolver already exists in `tgpu-htj2k` precisely because `core` did not offer
+> Resolver already exists in `intraspatial` precisely because `core` did not offer
 > one and `layers` is behind deck.gl.
 >
 > It also leaves open question 2 ("one engine, or per-type sub-engines?"), which is

--- a/docs/plans/resource-resolver-handoff.md
+++ b/docs/plans/resource-resolver-handoff.md
@@ -68,7 +68,7 @@ core     Resource Resolver    reconcile · cache · supersede · stream · evict
    │      │                              PointsLayer · shapesLayer · LabelsLayer
    │      └──► vis   React binding (useSyncExternalStore) · panels · Viv passthrough
    │
-   ├──► tgpu-htj2k   three.js/TSL Renderer Adapter   (separate repo, already live)
+   ├──► intraspatial   three.js/TSL Renderer Adapter   (separate repo, already live)
    │
    └──► headless     no renderer
 ```
@@ -135,7 +135,7 @@ race fixes, no memory work.
 > port to invent** — and because `avivatorish` is a de-vendoring holding pen for
 > code that also lives upstream in Viv and MDV, with an image-state model its own
 > README calls *"still evolving"*. `zarrextra`'s `VivCompatiblePixelSource`
-> already serves both Viv and `tgpu-htj2k`, so the images seam already exists
+> already serves both Viv and `intraspatial`, so the images seam already exists
 > *below* the resolver: images is the one kind where the duplication argument does
 > not apply. **Add no image port to `core`.** See ADR 0004 §"Amendment — the image
 > port".
@@ -191,7 +191,7 @@ Assign these to different people. They do not conflict.
 **Spike, behind the `RequestSlot` interface:** implement the slot twice — plain, and
 Effect `Stream` + `Fiber` — for the **matching scan only**. Effect stays *inside* the
 implementation; nothing leaks into a public signature (ADR 0004 §7 — `core` is also
-`tgpu-htj2k`'s dependency root). **Kill criterion, agreed up front:** drop Effect
+`intraspatial`'s dependency root). **Kill criterion, agreed up front:** drop Effect
 unless it wins on *all three* of — supersession correctness under two concurrent
 scans; interruption that actually reaches the worker; fewer lines to set up a race in
 a test. A tie means the plain slot wins.
@@ -215,7 +215,7 @@ a test. A tie means the plain slot wins.
 >
 > Effect ties two and loses one, so by the agreed rule the plain `RequestSlot` wins.
 > The `RequestSlot` seam is deliberately shaped so a future reconsideration (e.g. if
-> `tgpu-htj2k`'s dependency-free stance is renegotiated) is a swap, not a rewrite.
+> `intraspatial`'s dependency-free stance is renegotiated) is a swap, not a rewrite.
 
 ---
 
@@ -292,7 +292,7 @@ loading requires no resolver change — it lives behind `loadInBounds()` inside 
    exported, documented, and **never passed** — so there is no zarr chunk cache at all
    today, and every tile re-fetches *and* re-decodes.
 
-`tgpu-htj2k`'s `TileCache<V>` (~100 lines, framework-free, byte-bounded LRU with a
+`intraspatial`'s `TileCache<V>` (~100 lines, framework-free, byte-bounded LRU with a
 `dispose` hook, generic over payload) is directly reusable for 2 and 3.
 
 **Stop at rung 3.** Rungs 4–5 (encoded tier, tiered `ResidencyReport`, Resource
@@ -335,7 +335,7 @@ Ceiling) wait for measurement. See ADR 0005 for why.
 
 - **Group Entry / blend compositing.** `CONTEXT.md` reserves it and says *"avoid:
   framebuffer layer until the rendering behavior exists."* That holds. `splatDensity.ts`
-  in `tgpu-htj2k` is a GPU splat-by-blending primitive, **not** a prototype of Render
+  in `intraspatial` is a GPU splat-by-blending primitive, **not** a prototype of Render
   Stack compositing — using it would mean adopting the whole WebGPU stack. A group
   layer-hierarchy is expected before long and may well be built on WebGPU; the Renderer
   Adapter seam is what makes it approachable. **Add no framebuffer hook in anticipation.**

--- a/packages/core/src/Vutils.ts
+++ b/packages/core/src/Vutils.ts
@@ -27,6 +27,20 @@ export function basename(path: string) {
   return result;
 }
 
+/**
+ * Resident-byte ceilings for the two parquet caches a source holds.
+ *
+ * Both default to values chosen to bound a leak, not to fit a measured working
+ * set — ADR 0005 is explicit that the numbers stay guesses until something
+ * measures them. Raise or lower them per source when you know better.
+ */
+export type ParquetCacheLimits = {
+  /** Ceiling for cached compressed parquet file bytes. */
+  encodedMaxBytes?: number;
+  /** Ceiling for cached decoded Arrow tables. */
+  decodedMaxBytes?: number;
+};
+
 export type DataSourceParams = {
   url?: string;
   /** Options to pass to fetch calls. */
@@ -35,4 +49,6 @@ export type DataSourceParams = {
   store?: Readable;
   /** The file type. */
   fileType: string; // '.zip' | '.h5ad' etc...
+  /** Optional overrides for the parquet cache byte ceilings. */
+  parquetCacheLimits?: ParquetCacheLimits;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@
 
 // Resource Resolver contracts (ADR 0004).
 export * from './engine/index.js';
+// Memory accounting (ADR 0005).
+export * from './memory/index.js';
 export * from './models/index.js';
 // The semantics that need the tree guards, not just the guards themselves: a
 // consumer enumerating obs columns has to know that a group might be a

--- a/packages/core/src/memory/byteLruCache.ts
+++ b/packages/core/src/memory/byteLruCache.ts
@@ -32,6 +32,24 @@ interface Entry<V> {
 }
 
 /**
+ * Reject a byte count that would corrupt the accounting rather than merely be wrong.
+ *
+ * `NaN` is the dangerous one: every `residentBytes > maxBytes` comparison against
+ * it is false, so a single `NaN` — from a ceiling passed through an unparsed
+ * config value, or from a `sizeOf` that met an unexpected payload — silently
+ * disables eviction for the lifetime of the cache. A bounded cache quietly
+ * becomes an unbounded one, which is the exact failure it exists to prevent.
+ * Infinity and negatives are the same class of mistake and equally cheap to
+ * refuse here, at the one place a bad number can enter.
+ */
+function assertByteCount(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${label} must be a finite, non-negative byte count; received ${value}`);
+  }
+  return value;
+}
+
+/**
  * A byte-bounded LRU cache that reports what it is holding.
  *
  * Framework-free and deliberately small — [ADR 0005](../../../../docs/adr/0005-memory-accounting-before-management.md)
@@ -67,9 +85,41 @@ export class ByteLruCache<V> implements MemoryReporting {
   private residentBytes = 0;
 
   constructor(options: ByteLruCacheOptions<V>) {
-    this.maxBytes = options.maxBytes;
+    this.maxBytes = assertByteCount(options.maxBytes, 'maxBytes');
     this.sizeOf = options.sizeOf;
     this.onDispose = options.onDispose;
+  }
+
+  /** `sizeOf`, with the result checked before it can reach the running total. */
+  private measure(value: V): number {
+    return assertByteCount(this.sizeOf(value), 'sizeOf(value)');
+  }
+
+  /**
+   * Run `onDispose`, returning what it threw instead of throwing.
+   *
+   * Disposal is a courtesy at the end of a removal that has already happened;
+   * letting it propagate mid-loop would abandon an eviction pass partway and
+   * leave the cache over budget, or skip the rest of a `clear`. Callers finish
+   * the structural work, then rethrow.
+   */
+  private disposeQuietly(value: V, key: string): unknown {
+    if (!this.onDispose) {
+      return undefined;
+    }
+    try {
+      this.onDispose(value, key);
+    } catch (error) {
+      return error;
+    }
+    return undefined;
+  }
+
+  /** Drop an entry and its bytes, returning any error `onDispose` threw. */
+  private removeEntry(key: string, entry: Entry<V>): unknown {
+    this.entries.delete(key);
+    this.residentBytes -= entry.bytes;
+    return this.disposeQuietly(entry.value, key);
   }
 
   /** Resident bytes, maintained incrementally — never a scan of the residents. */
@@ -120,13 +170,14 @@ export class ByteLruCache<V> implements MemoryReporting {
       this.entries.delete(key);
       this.residentBytes -= previous.bytes;
     }
-    const bytes = this.sizeOf(value);
+    const bytes = this.measure(value);
     this.entries.set(key, { value, bytes });
     this.residentBytes += bytes;
-    if (previous) {
-      this.onDispose?.(previous.value, key);
-    }
+    const disposeError = previous ? this.disposeQuietly(previous.value, key) : undefined;
     this.evictToBudget();
+    if (disposeError !== undefined) {
+      throw disposeError;
+    }
   }
 
   /**
@@ -142,7 +193,7 @@ export class ByteLruCache<V> implements MemoryReporting {
     if (!entry) {
       return;
     }
-    const bytes = this.sizeOf(entry.value);
+    const bytes = this.measure(entry.value);
     this.residentBytes += bytes - entry.bytes;
     entry.bytes = bytes;
     this.entries.delete(key);
@@ -156,35 +207,62 @@ export class ByteLruCache<V> implements MemoryReporting {
     if (!entry) {
       return false;
     }
-    this.entries.delete(key);
-    this.residentBytes -= entry.bytes;
-    this.onDispose?.(entry.value, key);
+    const disposeError = this.removeEntry(key, entry);
+    if (disposeError !== undefined) {
+      throw disposeError;
+    }
     return true;
   }
 
-  /** Drop everything, disposing each entry. */
+  /**
+   * Drop everything, disposing each entry.
+   *
+   * Every entry is disposed even if one of them throws; the first error is
+   * rethrown once the cache is empty, so a single bad payload cannot strand the
+   * rest.
+   */
   clear(): void {
     const disposing = [...this.entries];
     this.entries.clear();
     this.residentBytes = 0;
-    if (this.onDispose) {
-      for (const [key, entry] of disposing) {
-        this.onDispose(entry.value, key);
+    let firstError: unknown;
+    for (const [key, entry] of disposing) {
+      const error = this.disposeQuietly(entry.value, key);
+      if (firstError === undefined) {
+        firstError = error;
       }
+    }
+    if (firstError !== undefined) {
+      throw firstError;
     }
   }
 
   /**
    * Evict from the least-recently-used end until within budget, stopping while
    * one entry remains so that an oversized value is kept rather than refused.
+   *
+   * A throwing `onDispose` does not stop the pass — abandoning it halfway would
+   * leave the cache over its ceiling, which is worse than the failed disposal.
+   * The first error surfaces once the cache is back within budget.
    */
   private evictToBudget(): void {
+    let firstError: unknown;
     while (this.residentBytes > this.maxBytes && this.entries.size > 1) {
       const oldest = this.entries.keys().next();
       if (oldest.done) {
-        return;
+        break;
       }
-      this.delete(oldest.value);
+      const entry = this.entries.get(oldest.value);
+      if (!entry) {
+        break;
+      }
+      const error = this.removeEntry(oldest.value, entry);
+      if (firstError === undefined) {
+        firstError = error;
+      }
+    }
+    if (firstError !== undefined) {
+      throw firstError;
     }
   }
 }

--- a/packages/core/src/memory/byteLruCache.ts
+++ b/packages/core/src/memory/byteLruCache.ts
@@ -165,12 +165,17 @@ export class ByteLruCache<V> implements MemoryReporting {
    * an upsert without leaking the previous payload.
    */
   set(key: string, value: V): void {
+    // Measured before anything is mutated. `measure` rejects a size that would
+    // corrupt the accounting, and a `set` that fails has to leave the cache as
+    // it found it: measuring after the displaced entry was removed dropped that
+    // entry on the way out — unreported and undisposed — so a rejected size
+    // silently cost the caller a value the cache had been holding fine.
+    const bytes = this.measure(value);
     const previous = this.entries.get(key);
     if (previous) {
       this.entries.delete(key);
       this.residentBytes -= previous.bytes;
     }
-    const bytes = this.measure(value);
     this.entries.set(key, { value, bytes });
     this.residentBytes += bytes;
     const disposeError = previous ? this.disposeQuietly(previous.value, key) : undefined;

--- a/packages/core/src/memory/byteLruCache.ts
+++ b/packages/core/src/memory/byteLruCache.ts
@@ -1,0 +1,190 @@
+import type { MemoryReporting } from './memoryReporting.js';
+
+export interface ByteLruCacheOptions<V> {
+  /**
+   * Resident-byte ceiling. Enforced after every insertion and every
+   * {@link ByteLruCache.recount}, by dropping least-recently-used entries.
+   *
+   * Not an absolute guarantee — see {@link ByteLruCache} on oversized values.
+   */
+  maxBytes: number;
+  /**
+   * Bytes held by a value.
+   *
+   * Called once per insertion and once per {@link ByteLruCache.recount}, never
+   * per read: the cache keeps a running total instead, which is the obligation
+   * {@link MemoryReporting} takes on.
+   */
+  sizeOf: (value: V) => number;
+  /**
+   * Called as an entry leaves — evicted, overwritten, deleted or cleared —
+   * exactly once per departure, after the cache's own bookkeeping is settled.
+   *
+   * For releasing something a garbage collector will not: a GPU buffer, a worker
+   * handle. Plain typed arrays need nothing here.
+   */
+  onDispose?: (value: V, key: string) => void;
+}
+
+interface Entry<V> {
+  value: V;
+  bytes: number;
+}
+
+/**
+ * A byte-bounded LRU cache that reports what it is holding.
+ *
+ * Framework-free and deliberately small — [ADR 0005](../../../../docs/adr/0005-memory-accounting-before-management.md)
+ * rung 2 is *fixing a leak, not building an architecture*. It exists because the
+ * two parquet caches in `VTableSource` were plain `Record`s that grew until the
+ * source was discarded, and because filling fizarrita's chunk-cache seam needs
+ * something bounded to fill it with.
+ *
+ * Recency is `Map` insertion order: re-inserting a key moves it to the tail, and
+ * eviction takes from the head. {@link get} and {@link recount} count as uses;
+ * {@link peek} and {@link has} do not.
+ *
+ * ### Oversized values are admitted, not refused
+ *
+ * If a single value exceeds `maxBytes`, it is stored anyway and left as the sole
+ * resident — so the effective bound is *`maxBytes`, or one entry, whichever is
+ * larger*. Refusing it would be the worse failure: `loadParquetBytes` is called
+ * roughly twenty times per points load, so a value that can never be admitted
+ * becomes twenty refetches of the very file that was too big to fetch once.
+ *
+ * ### Sizes that are not known at insertion
+ *
+ * A cache of in-flight promises cannot be sized when the entry goes in. Insert
+ * it at whatever `sizeOf` can say (zero), and call {@link recount} once the real
+ * size is knowable. That is why sizing is a callback the cache re-runs on demand
+ * rather than a number captured at insertion.
+ */
+export class ByteLruCache<V> implements MemoryReporting {
+  readonly maxBytes: number;
+  private readonly sizeOf: (value: V) => number;
+  private readonly onDispose?: (value: V, key: string) => void;
+  private readonly entries = new Map<string, Entry<V>>();
+  private residentBytes = 0;
+
+  constructor(options: ByteLruCacheOptions<V>) {
+    this.maxBytes = options.maxBytes;
+    this.sizeOf = options.sizeOf;
+    this.onDispose = options.onDispose;
+  }
+
+  /** Resident bytes, maintained incrementally — never a scan of the residents. */
+  get byteLength(): number {
+    return this.residentBytes;
+  }
+
+  /** Number of resident entries. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Read a value, counting the read as a use. */
+  get(key: string): V | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.value;
+  }
+
+  /** Read a value *without* counting it as a use. */
+  peek(key: string): V | undefined {
+    return this.entries.get(key)?.value;
+  }
+
+  /** Whether a key is resident. Not a use. */
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  /** Resident keys, least-recently-used first. */
+  keys(): IterableIterator<string> {
+    return this.entries.keys();
+  }
+
+  /**
+   * Insert or replace a value, then evict down to budget.
+   *
+   * Replacing a key disposes the value it displaced, so `set` is safe to use as
+   * an upsert without leaking the previous payload.
+   */
+  set(key: string, value: V): void {
+    const previous = this.entries.get(key);
+    if (previous) {
+      this.entries.delete(key);
+      this.residentBytes -= previous.bytes;
+    }
+    const bytes = this.sizeOf(value);
+    this.entries.set(key, { value, bytes });
+    this.residentBytes += bytes;
+    if (previous) {
+      this.onDispose?.(previous.value, key);
+    }
+    this.evictToBudget();
+  }
+
+  /**
+   * Re-ask `sizeOf` for a resident value whose size has changed since insertion,
+   * then evict down to budget. A no-op for a key that is no longer resident.
+   *
+   * Counts as a use: the size becoming knowable — a decode landing, a payload
+   * being filled in — is the moment the entry is most worth keeping, and the
+   * eviction pass this triggers would otherwise be liable to drop it.
+   */
+  recount(key: string): void {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return;
+    }
+    const bytes = this.sizeOf(entry.value);
+    this.residentBytes += bytes - entry.bytes;
+    entry.bytes = bytes;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    this.evictToBudget();
+  }
+
+  /** Drop a key. Returns whether it was resident. */
+  delete(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return false;
+    }
+    this.entries.delete(key);
+    this.residentBytes -= entry.bytes;
+    this.onDispose?.(entry.value, key);
+    return true;
+  }
+
+  /** Drop everything, disposing each entry. */
+  clear(): void {
+    const disposing = [...this.entries];
+    this.entries.clear();
+    this.residentBytes = 0;
+    if (this.onDispose) {
+      for (const [key, entry] of disposing) {
+        this.onDispose(entry.value, key);
+      }
+    }
+  }
+
+  /**
+   * Evict from the least-recently-used end until within budget, stopping while
+   * one entry remains so that an oversized value is kept rather than refused.
+   */
+  private evictToBudget(): void {
+    while (this.residentBytes > this.maxBytes && this.entries.size > 1) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) {
+        return;
+      }
+      this.delete(oldest.value);
+    }
+  }
+}

--- a/packages/core/src/memory/byteLruCache.ts
+++ b/packages/core/src/memory/byteLruCache.ts
@@ -206,6 +206,40 @@ export class ByteLruCache<V> implements MemoryReporting {
     this.evictToBudget();
   }
 
+  /**
+   * Drop `key`, but only if it still holds `value`.
+   *
+   * The guard is the whole point. An entry that settles late — a decode that
+   * failed after its key was re-requested, or after eviction made room — must
+   * not reach in and remove whatever took its place; without the identity check
+   * a stale failure silently deletes a live, valid entry. `VTableSource`'s
+   * `evictIfCurrent` is the same rule for its promise-keyed `Map`s; this is the
+   * spelling for a cache whose reads carry recency, which is why it compares
+   * through {@link peek} rather than {@link get}.
+   *
+   * Returns whether anything was dropped.
+   */
+  deleteIf(key: string, value: V): boolean {
+    if (this.peek(key) !== value) {
+      return false;
+    }
+    return this.delete(key);
+  }
+
+  /**
+   * Re-measure `key`, but only if it still holds `value`. See {@link deleteIf}
+   * for why the identity check is not optional.
+   *
+   * Returns whether anything was re-measured.
+   */
+  recountIf(key: string, value: V): boolean {
+    if (this.peek(key) !== value) {
+      return false;
+    }
+    this.recount(key);
+    return true;
+  }
+
   /** Drop a key. Returns whether it was resident. */
   delete(key: string): boolean {
     const entry = this.entries.get(key);

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Memory accounting for resident caches.
+ *
+ * See [ADR 0005](../../../../docs/adr/0005-memory-accounting-before-management.md):
+ * accounting first, management only where something is already unbounded.
+ */
+
+export type { MemoryReporting } from './memoryReporting.js';

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -5,4 +5,6 @@
  * accounting first, management only where something is already unbounded.
  */
 
+export type { ByteLruCacheOptions } from './byteLruCache.js';
+export { ByteLruCache } from './byteLruCache.js';
 export type { MemoryReporting } from './memoryReporting.js';

--- a/packages/core/src/memory/memoryReporting.ts
+++ b/packages/core/src/memory/memoryReporting.ts
@@ -1,0 +1,42 @@
+/**
+ * Memory accounting — the scalar, and nothing else.
+ *
+ * See [ADR 0005](../../../../docs/adr/0005-memory-accounting-before-management.md).
+ * Deliberately one number: no tiers, no policy, no eviction, no ceiling. Those
+ * are later rungs, and the ADR gates every one of them on this existing first.
+ */
+
+/**
+ * Anything holding resident host memory can report it in bytes.
+ *
+ * The name is the design. `byteLength` is what `TypedArray`, `ArrayBuffer` and
+ * `DataView` already call this, so all of them satisfy this interface
+ * structurally — for free, with no wrapper and no import:
+ *
+ * ```ts
+ * const resident: MemoryReporting = new Uint8Array(1024); // 1024
+ * ```
+ *
+ * That is what makes it cheap enough to put on every cache: the payloads we
+ * actually hold are mostly typed arrays already, and the containers around them
+ * only have to keep a running total.
+ *
+ * ### The obligation this creates
+ *
+ * Keep it cheap. A cache implementing this must maintain a running total across
+ * insert and evict rather than scanning its residents on every read — callers
+ * are expected to be free to poll it (a HUD, a test assertion, a decision about
+ * what to drop next) without that being a performance question.
+ *
+ * ### What it deliberately cannot express
+ *
+ * A scalar cannot distinguish an encoded tier from a decoded one, and it cannot
+ * see a worker heap that a synchronous getter has no access to. Both are real
+ * for SpatialData.ts, and both are deferred: the tiered `ResidencyReport` is
+ * ADR 0005 rung 5, and the ADR's position is that it should not be built until
+ * something needs to *act* on the difference between tiers.
+ */
+export interface MemoryReporting {
+  /** Resident bytes held by this object, right now. */
+  readonly byteLength: number;
+}

--- a/packages/core/src/models/VTableSource.ts
+++ b/packages/core/src/models/VTableSource.ts
@@ -1049,12 +1049,29 @@ export default class SpatialDataTableSource extends AnnDataSource {
       return this.parquetTableCache[parquetPath];
     }
 
-    const tablePromise = this._loadParquetTableUncached(parquetPath, columns);
-
-    if (!columns?.length) {
-      this.parquetTableCache[parquetPath] = tablePromise;
+    const uncached = this._loadParquetTableUncached(parquetPath, columns);
+    if (columns?.length) {
+      return uncached;
     }
 
+    // Cached BEFORE it settles, so concurrent callers share one WASM decode — but
+    // what they share must not be a rejection kept forever. Uncleaned, a single
+    // transient fetch failure pins a rejected promise at this path for the
+    // lifetime of the source, and every later read replays a network error that
+    // cleared long ago.
+    //
+    // This is a cache-liveness fix, not a change to the skip-vs-fail policy in
+    // `docs/plans/parquet-io-error-handling.md`: the rejection still propagates
+    // unchanged to this caller, it just stops being the answer for the next one.
+    const tablePromise = uncached.catch((error: unknown) => {
+      // Only if still current — a retry that superseded this entry must not be
+      // clobbered by this promise's late rejection (see {@link evictIfCurrent}).
+      if (this.parquetTableCache[parquetPath] === tablePromise) {
+        delete this.parquetTableCache[parquetPath];
+      }
+      throw error;
+    });
+    this.parquetTableCache[parquetPath] = tablePromise;
     return tablePromise;
   }
 

--- a/packages/core/src/models/VTableSource.ts
+++ b/packages/core/src/models/VTableSource.ts
@@ -1,6 +1,7 @@
 // this is a direct copy of the Vitessce implementation, with changes mostly to make it more normal TypeScript.
 
 import { type Table as ArrowTable, tableFromIPC } from 'apache-arrow';
+import { ByteLruCache } from '../memory/byteLruCache.js';
 import {
   getParquetModule,
   type ParquetModule,
@@ -13,6 +14,42 @@ import type { DataSourceParams } from '../Vutils';
 import AnnDataSource from './VAnnDataSource';
 
 export type { ParquetRowGroupReadOptions };
+
+/**
+ * Default ceiling for the encoded (compressed parquet bytes) tier, per source.
+ *
+ * A guess that bounds a leak, not a measured working set — ADR 0005 defers the
+ * numbers until something measures them. It is deliberately the smaller of the
+ * two: compressed bytes are only needed until they have been decoded, whereas a
+ * decoded table is what callers actually hold on to.
+ */
+export const DEFAULT_PARQUET_ENCODED_MAX_BYTES = 128 * 1024 * 1024;
+
+/** Default ceiling for the decoded (Arrow table) tier, per source. */
+export const DEFAULT_PARQUET_DECODED_MAX_BYTES = 256 * 1024 * 1024;
+
+/**
+ * A decoded-table cache entry.
+ *
+ * The promise is cached before it settles — that is the in-flight dedup — so the
+ * byte count starts at zero and is filled in once the table exists. Holding it
+ * on the entry rather than re-deriving it keeps {@link ByteLruCache.byteLength}
+ * a running total: `Data.byteLength` in Arrow walks the whole child tree on every
+ * read, so it is asked exactly once per table.
+ */
+export interface CachedParquetTable {
+  readonly promise: Promise<ArrowTable>;
+  byteLength: number;
+}
+
+/** Resident bytes of a decoded Arrow table, children included. */
+function arrowTableByteLength(table: ArrowTable): number {
+  let bytes = 0;
+  for (const data of table.data) {
+    bytes += data.byteLength;
+  }
+  return bytes;
+}
 
 function parquetColumnValueToNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -176,15 +213,28 @@ export default class SpatialDataTableSource extends AnnDataSource {
   rootAttrs: { softwareVersion: string; formatVersion: string } | null;
   // biome-ignore lint/suspicious/noExplicitAny: elementAttrs type should be a tree-ish thing
   elementAttrs: Record<string, any>;
-  parquetTableBytes: Record<string, Uint8Array>;
+  /**
+   * Cache of compressed parquet file bytes — the encoded tier.
+   *
+   * Byte-bounded (ADR 0005 rung 2): it was a plain `Record` that grew for the
+   * lifetime of the source, holding every parquet file any caller ever touched,
+   * *simultaneously with* the decoded tier below. Read `.byteLength` for what it
+   * is currently holding.
+   */
+  parquetTableBytes: ByteLruCache<Uint8Array>;
   /**
    * Cache of fully-parsed Arrow tables for paths requested without a column
    * filter.  Avoids repeating the WASM `readParquet` + `tableFromIPC` decode
    * when the same parquet file is needed by multiple callers in sequence (e.g.
    * `inferShapesGeometryKindFromParquet`, `loadShapesIndex`, and
    * `loadPolygonShapes` all target the same file).
+   *
+   * Byte-bounded like the encoded tier, with one wrinkle: an entry is inserted
+   * while its decode is still in flight — that is what makes the dedup work — so
+   * it is sized at zero until the table exists and {@link ByteLruCache.recount}
+   * can be told the real number.
    */
-  parquetTableCache: Record<string, Promise<ArrowTable>>;
+  parquetTableCache: ByteLruCache<CachedParquetTable>;
   /**
    * Remembers parquet part layout per path — single file vs. `part.N.parquet`
    * directory, and the per-part metadata — so the probe sequence (see
@@ -217,8 +267,14 @@ export default class SpatialDataTableSource extends AnnDataSource {
     this.elementAttrs = {};
 
     // TODO: change to column-specific storage.
-    this.parquetTableBytes = {};
-    this.parquetTableCache = {};
+    this.parquetTableBytes = new ByteLruCache({
+      maxBytes: params.parquetCacheLimits?.encodedMaxBytes ?? DEFAULT_PARQUET_ENCODED_MAX_BYTES,
+      sizeOf: (bytes) => bytes.byteLength,
+    });
+    this.parquetTableCache = new ByteLruCache({
+      maxBytes: params.parquetCacheLimits?.decodedMaxBytes ?? DEFAULT_PARQUET_DECODED_MAX_BYTES,
+      sizeOf: (entry) => entry.byteLength,
+    });
     this.parquetDatasetMetadataCache = new Map();
     this.parquetPartPathsCache = new Map();
     this.rowGroupColumnExtentCache = new Map();
@@ -325,9 +381,10 @@ export default class SpatialDataTableSource extends AnnDataSource {
   }
 
   async loadParquetBytes(parquetPath: string) {
-    if (this.parquetTableBytes[parquetPath]) {
+    const cachedBytes = this.parquetTableBytes.get(parquetPath);
+    if (cachedBytes) {
       // Return the cached bytes.
-      return this.parquetTableBytes[parquetPath];
+      return cachedBytes;
     }
 
     for (const candidatePath of await this.orderedParquetCandidatePaths(parquetPath)) {
@@ -340,7 +397,7 @@ export default class SpatialDataTableSource extends AnnDataSource {
           continue;
         }
         // Cache the parquet bytes.
-        this.parquetTableBytes[parquetPath] = normalizedBytes;
+        this.parquetTableBytes.set(parquetPath, normalizedBytes);
         return normalizedBytes;
       } catch {
         // Keep probing candidate parquet paths.
@@ -1045,8 +1102,11 @@ export default class SpatialDataTableSource extends AnnDataSource {
   async loadParquetTable(parquetPath: string, columns?: string[]): Promise<ArrowTable> {
     // When no column filter is requested, return a shared promise so that
     // concurrent or sequential callers for the same file share one WASM decode.
-    if (!columns?.length && parquetPath in this.parquetTableCache) {
-      return this.parquetTableCache[parquetPath];
+    if (!columns?.length) {
+      const cached = this.parquetTableCache.get(parquetPath);
+      if (cached) {
+        return cached.promise;
+      }
     }
 
     const uncached = this._loadParquetTableUncached(parquetPath, columns);
@@ -1054,25 +1114,39 @@ export default class SpatialDataTableSource extends AnnDataSource {
       return uncached;
     }
 
-    // Cached BEFORE it settles, so concurrent callers share one WASM decode — but
-    // what they share must not be a rejection kept forever. Uncleaned, a single
-    // transient fetch failure pins a rejected promise at this path for the
-    // lifetime of the source, and every later read replays a network error that
-    // cleared long ago.
+    // Cached BEFORE it settles, so concurrent callers share one WASM decode.
+    const entry: CachedParquetTable = { promise: uncached, byteLength: 0 };
+    this.parquetTableCache.set(parquetPath, entry);
+
+    // Bookkeeping, deliberately kept OFF the caller's chain: this branch settles
+    // the entry's byte count, or drops a poisoned entry, and can do neither to
+    // what the caller sees. It swallows the rejection rather than rethrowing for
+    // the same reason — rethrowing here would surface as an unhandled rejection
+    // on a promise nobody awaits, while the caller's own `uncached` still throws.
     //
-    // This is a cache-liveness fix, not a change to the skip-vs-fail policy in
-    // `docs/plans/parquet-io-error-handling.md`: the rejection still propagates
-    // unchanged to this caller, it just stops being the answer for the next one.
-    const tablePromise = uncached.catch((error: unknown) => {
-      // Only if still current — a retry that superseded this entry must not be
-      // clobbered by this promise's late rejection (see {@link evictIfCurrent}).
-      if (this.parquetTableCache[parquetPath] === tablePromise) {
-        delete this.parquetTableCache[parquetPath];
+    // Dropping on rejection is the point: uncleaned, a single transient fetch
+    // failure pins a rejected promise at this path for the lifetime of the
+    // source, and every later read replays a network error that cleared long
+    // ago. It is a cache-liveness fix, not a change to the skip-vs-fail policy in
+    // `docs/plans/parquet-io-error-handling.md`.
+    void uncached.then(
+      (table) => {
+        entry.byteLength = arrowTableByteLength(table);
+        // Only if still current — a retry, or an eviction, may already have
+        // replaced us, and that entry must not be resized or dropped by ours
+        // (the same reasoning as {@link evictIfCurrent}).
+        if (this.parquetTableCache.peek(parquetPath) === entry) {
+          this.parquetTableCache.recount(parquetPath);
+        }
+      },
+      () => {
+        if (this.parquetTableCache.peek(parquetPath) === entry) {
+          this.parquetTableCache.delete(parquetPath);
+        }
       }
-      throw error;
-    });
-    this.parquetTableCache[parquetPath] = tablePromise;
-    return tablePromise;
+    );
+
+    return uncached;
   }
 
   /**

--- a/packages/core/src/models/VTableSource.ts
+++ b/packages/core/src/models/VTableSource.ts
@@ -687,7 +687,11 @@ export default class SpatialDataTableSource extends AnnDataSource {
 
   /** Drop a cache entry only if it still holds `promise` — a later call that
    * superseded it (e.g. after an eviction) must not be clobbered by an earlier
-   * promise's late resolution. */
+   * promise's late resolution.
+   *
+   * For the byte-bounded caches the same rule is spelled
+   * {@link ByteLruCache.deleteIf} / {@link ByteLruCache.recountIf}, which compare
+   * without disturbing recency. This form stays for the plain `Map`s. */
   private evictIfCurrent<V>(
     cache: Map<string, Promise<V>>,
     key: string,
@@ -1129,20 +1133,19 @@ export default class SpatialDataTableSource extends AnnDataSource {
     // source, and every later read replays a network error that cleared long
     // ago. It is a cache-liveness fix, not a change to the skip-vs-fail policy in
     // `docs/plans/parquet-io-error-handling.md`.
+    //
+    // Both handlers act through the `…If` forms, which no-op unless the entry is
+    // still the one they inserted: a retry, or an eviction, may already have
+    // replaced it, and a late settlement must not resize or delete whatever took
+    // its place. That is the same rule {@link evictIfCurrent} applies to the
+    // promise-keyed `Map`s in this class.
     void uncached.then(
       (table) => {
         entry.byteLength = arrowTableByteLength(table);
-        // Only if still current — a retry, or an eviction, may already have
-        // replaced us, and that entry must not be resized or dropped by ours
-        // (the same reasoning as {@link evictIfCurrent}).
-        if (this.parquetTableCache.peek(parquetPath) === entry) {
-          this.parquetTableCache.recount(parquetPath);
-        }
+        this.parquetTableCache.recountIf(parquetPath, entry);
       },
       () => {
-        if (this.parquetTableCache.peek(parquetPath) === entry) {
-          this.parquetTableCache.delete(parquetPath);
-        }
+        this.parquetTableCache.deleteIf(parquetPath, entry);
       }
     );
 

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -442,6 +442,7 @@ abstract class RasterElement<T extends 'images' | 'labels'> extends AbstractSpat
   RasterAttrs
 > {
   readonly attrs: RasterAttrs;
+  private prefixedStore?: zarr.AsyncReadable;
 
   constructor(params: ElementParams<T>) {
     super(params);
@@ -487,9 +488,18 @@ abstract class RasterElement<T extends 'images' | 'labels'> extends AbstractSpat
    *
    * Consumers that need codec-aware array loading should use this instead of
    * reconstructing a URL and letting downstream libraries create their own store.
+   *
+   * Memoized, and that matters beyond saving an object allocation: the chunk
+   * cache downstream is keyed **by store instance**. fizarrita assigns each store
+   * object an id from a `WeakMap` and builds keys as `store_N:{path}:{chunkKey}`,
+   * while `createPrefixedStore` returns a fresh object literal every call — so
+   * handing out a new view per caller would give the same chunk a different key
+   * per view, and the cache would fill with duplicates that never hit. One stable
+   * view per element is what makes the cache a cache.
    */
   getStore(): zarr.AsyncReadable {
-    return createPrefixedStore(this.sdata.rootStore.zarritaStore, this.path);
+    this.prefixedStore ??= createPrefixedStore(this.sdata.rootStore.zarritaStore, this.path);
+    return this.prefixedStore;
   }
 
   /**

--- a/packages/core/tests/byteLruCache.spec.ts
+++ b/packages/core/tests/byteLruCache.spec.ts
@@ -143,6 +143,54 @@ describe('ByteLruCache', () => {
     expect(cache.byteLength).toBe(100);
   });
 
+  it('refuses a ceiling that would disable eviction', () => {
+    // NaN is the one that matters: every `resident > max` comparison against it
+    // is false, so the cache would report nonsense and never evict again.
+    expect(() => bytesCache(Number.NaN)).toThrow(RangeError);
+    expect(() => bytesCache(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+    expect(() => bytesCache(-1)).toThrow(RangeError);
+  });
+
+  it('refuses a size that would corrupt the running total', () => {
+    const cache = new ByteLruCache<string>({ maxBytes: 100, sizeOf: () => Number.NaN });
+
+    expect(() => cache.set('a', 'x')).toThrow(RangeError);
+    expect(cache.byteLength).toBe(0);
+  });
+
+  it('finishes evicting even when disposal throws', () => {
+    const disposed: string[] = [];
+    const cache = bytesCache(200, (_value, key) => {
+      disposed.push(key);
+      throw new Error(`dispose failed for ${key}`);
+    });
+    cache.set('a', new Uint8Array(100));
+    cache.set('b', new Uint8Array(100));
+
+    // Admitting 500 bytes has to evict both 100-byte entries to get under 200.
+    expect(() => cache.set('c', new Uint8Array(500))).toThrow('dispose failed for a');
+
+    expect(disposed).toEqual(['a', 'b']);
+    expect(cache.size).toBe(1);
+    expect(cache.byteLength).toBe(500);
+  });
+
+  it('finishes clearing even when disposal throws', () => {
+    const disposed: string[] = [];
+    const cache = bytesCache(1000, (_value, key) => {
+      disposed.push(key);
+      throw new Error(`dispose failed for ${key}`);
+    });
+    cache.set('a', new Uint8Array(10));
+    cache.set('b', new Uint8Array(10));
+
+    expect(() => cache.clear()).toThrow('dispose failed for a');
+
+    expect(disposed).toEqual(['a', 'b']);
+    expect(cache.size).toBe(0);
+    expect(cache.byteLength).toBe(0);
+  });
+
   it('satisfies MemoryReporting', () => {
     const cache: MemoryReporting = bytesCache(100);
     expect(cache.byteLength).toBe(0);

--- a/packages/core/tests/byteLruCache.spec.ts
+++ b/packages/core/tests/byteLruCache.spec.ts
@@ -158,6 +158,28 @@ describe('ByteLruCache', () => {
     expect(cache.byteLength).toBe(0);
   });
 
+  it('leaves a resident entry untouched when the replacement size is rejected', () => {
+    const onDispose = vi.fn();
+    const first = new Uint8Array(100);
+    let reject = false;
+    const cache = new ByteLruCache<Uint8Array>({
+      maxBytes: 1000,
+      sizeOf: (value) => (reject ? Number.NaN : value.byteLength),
+      onDispose,
+    });
+    cache.set('a', first);
+
+    reject = true;
+    expect(() => cache.set('a', new Uint8Array(400))).toThrow(RangeError);
+
+    // A failed set must not be a silent delete: the displaced value is still
+    // there, still counted, and was never disposed.
+    expect(cache.peek('a')).toBe(first);
+    expect(cache.byteLength).toBe(100);
+    expect(cache.size).toBe(1);
+    expect(onDispose).not.toHaveBeenCalled();
+  });
+
   it('finishes evicting even when disposal throws', () => {
     const disposed: string[] = [];
     const cache = bytesCache(200, (_value, key) => {

--- a/packages/core/tests/byteLruCache.spec.ts
+++ b/packages/core/tests/byteLruCache.spec.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ByteLruCache } from '../src/memory/byteLruCache.js';
+import type { MemoryReporting } from '../src/memory/memoryReporting.js';
+
+/** The ergonomic claim ADR 0005 makes for `MemoryReporting`, as a compile-time check. */
+const _typedArrayReportsMemory: MemoryReporting = new Uint8Array(8);
+
+function bytesCache(maxBytes: number, onDispose?: (value: Uint8Array, key: string) => void) {
+  return new ByteLruCache<Uint8Array>({
+    maxBytes,
+    sizeOf: (value) => value.byteLength,
+    onDispose,
+  });
+}
+
+describe('ByteLruCache', () => {
+  it('reports resident bytes as a running total', () => {
+    const cache = bytesCache(1000);
+    expect(cache.byteLength).toBe(0);
+
+    cache.set('a', new Uint8Array(100));
+    cache.set('b', new Uint8Array(250));
+
+    expect(cache.byteLength).toBe(350);
+    expect(cache.size).toBe(2);
+  });
+
+  it('evicts least-recently-used entries until it fits', () => {
+    const cache = bytesCache(300);
+    cache.set('a', new Uint8Array(100));
+    cache.set('b', new Uint8Array(100));
+    cache.set('c', new Uint8Array(100));
+    expect(cache.byteLength).toBe(300);
+
+    cache.set('d', new Uint8Array(100));
+
+    expect(cache.has('a')).toBe(false);
+    expect([...cache.keys()]).toEqual(['b', 'c', 'd']);
+    expect(cache.byteLength).toBe(300);
+  });
+
+  it('counts a read as a use, so the read entry survives the next eviction', () => {
+    const cache = bytesCache(300);
+    cache.set('a', new Uint8Array(100));
+    cache.set('b', new Uint8Array(100));
+    cache.set('c', new Uint8Array(100));
+
+    expect(cache.get('a')).toBeDefined();
+    cache.set('d', new Uint8Array(100));
+
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+  });
+
+  it('does not count a peek as a use', () => {
+    const cache = bytesCache(300);
+    cache.set('a', new Uint8Array(100));
+    cache.set('b', new Uint8Array(100));
+    cache.set('c', new Uint8Array(100));
+
+    expect(cache.peek('a')).toBeDefined();
+    cache.set('d', new Uint8Array(100));
+
+    expect(cache.has('a')).toBe(false);
+  });
+
+  it('replaces rather than double-counts when a key is overwritten', () => {
+    const onDispose = vi.fn();
+    const cache = bytesCache(1000, onDispose);
+    const first = new Uint8Array(100);
+    cache.set('a', first);
+    cache.set('a', new Uint8Array(400));
+
+    expect(cache.size).toBe(1);
+    expect(cache.byteLength).toBe(400);
+    expect(onDispose).toHaveBeenCalledWith(first, 'a');
+  });
+
+  it('disposes evicted, deleted and cleared entries exactly once', () => {
+    const onDispose = vi.fn();
+    const cache = bytesCache(200, onDispose);
+    const evicted = new Uint8Array(100);
+    cache.set('evicted', evicted);
+    cache.set('deleted', new Uint8Array(100));
+    cache.set('cleared', new Uint8Array(100));
+    expect(onDispose).toHaveBeenCalledExactlyOnceWith(evicted, 'evicted');
+
+    cache.delete('deleted');
+    expect(cache.byteLength).toBe(100);
+
+    cache.clear();
+    expect(cache.byteLength).toBe(0);
+    expect(cache.size).toBe(0);
+    expect(onDispose).toHaveBeenCalledTimes(3);
+  });
+
+  it('picks up a size that only became known after insertion', () => {
+    // The parquet table cache's shape: the entry is inserted while the decode is
+    // still in flight, so its byte count is zero until the table exists.
+    const cache = new ByteLruCache<{ byteLength: number }>({
+      maxBytes: 300,
+      sizeOf: (value) => value.byteLength,
+    });
+    const pending = { byteLength: 0 };
+    cache.set('pending', pending);
+    cache.set('other', { byteLength: 100 });
+    expect(cache.byteLength).toBe(100);
+
+    pending.byteLength = 250;
+    cache.recount('pending');
+
+    expect(cache.byteLength).toBe(250);
+    // 350 would have been over budget, so the older entry went.
+    expect(cache.has('other')).toBe(false);
+    expect(cache.has('pending')).toBe(true);
+  });
+
+  it('ignores a recount for a key it no longer holds', () => {
+    const cache = bytesCache(1000);
+    cache.set('a', new Uint8Array(100));
+    cache.delete('a');
+
+    expect(() => cache.recount('a')).not.toThrow();
+    expect(cache.byteLength).toBe(0);
+  });
+
+  it('admits a value larger than the whole budget rather than reporting a miss', () => {
+    // Refusing it would be worse than exceeding the bound: `loadParquetBytes` is
+    // called ~20 times per points load, and a permanent miss means ~20 refetches
+    // of a file too big to fetch even once cheaply.
+    const cache = bytesCache(300);
+    cache.set('small', new Uint8Array(100));
+    const huge = new Uint8Array(5000);
+    cache.set('huge', huge);
+
+    expect(cache.get('huge')).toBe(huge);
+    expect(cache.size).toBe(1);
+    expect(cache.byteLength).toBe(5000);
+
+    // ...and it is the first thing to go once anything else arrives.
+    cache.set('next', new Uint8Array(100));
+    expect(cache.has('huge')).toBe(false);
+    expect(cache.byteLength).toBe(100);
+  });
+
+  it('satisfies MemoryReporting', () => {
+    const cache: MemoryReporting = bytesCache(100);
+    expect(cache.byteLength).toBe(0);
+    expect(_typedArrayReportsMemory.byteLength).toBe(8);
+  });
+});

--- a/packages/core/tests/byteLruCache.spec.ts
+++ b/packages/core/tests/byteLruCache.spec.ts
@@ -213,6 +213,63 @@ describe('ByteLruCache', () => {
     expect(cache.byteLength).toBe(0);
   });
 
+  it('deleteIf drops the entry only when it is still the one given', () => {
+    const onDispose = vi.fn();
+    const cache = bytesCache(1000, onDispose);
+    const mine = new Uint8Array(100);
+    cache.set('a', mine);
+
+    expect(cache.deleteIf('a', mine)).toBe(true);
+    expect(cache.has('a')).toBe(false);
+    expect(onDispose).toHaveBeenCalledOnce();
+  });
+
+  it('deleteIf leaves an entry that superseded the one given', () => {
+    // The bug this exists to make impossible: a late failure reaching in and
+    // deleting whatever replaced it.
+    const onDispose = vi.fn();
+    const cache = bytesCache(1000, onDispose);
+    const superseded = new Uint8Array(100);
+    const current = new Uint8Array(200);
+    cache.set('a', superseded);
+    onDispose.mockClear();
+    cache.set('a', current);
+    onDispose.mockClear();
+
+    expect(cache.deleteIf('a', superseded)).toBe(false);
+    expect(cache.peek('a')).toBe(current);
+    expect(cache.byteLength).toBe(200);
+    expect(onDispose).not.toHaveBeenCalled();
+  });
+
+  it('deleteIf is a no-op for a key that is gone entirely', () => {
+    const cache = bytesCache(1000);
+    const value = new Uint8Array(100);
+
+    expect(cache.deleteIf('missing', value)).toBe(false);
+    expect(cache.byteLength).toBe(0);
+  });
+
+  it('recountIf re-measures only the entry it was given', () => {
+    const cache = new ByteLruCache<{ byteLength: number }>({
+      maxBytes: 1000,
+      sizeOf: (value) => value.byteLength,
+    });
+    const superseded = { byteLength: 0 };
+    cache.set('a', superseded);
+    const current = { byteLength: 100 };
+    cache.set('a', current);
+
+    // A late settlement of the displaced entry must not resize the live one.
+    superseded.byteLength = 900;
+    expect(cache.recountIf('a', superseded)).toBe(false);
+    expect(cache.byteLength).toBe(100);
+
+    current.byteLength = 250;
+    expect(cache.recountIf('a', current)).toBe(true);
+    expect(cache.byteLength).toBe(250);
+  });
+
   it('satisfies MemoryReporting', () => {
     const cache: MemoryReporting = bytesCache(100);
     expect(cache.byteLength).toBe(0);

--- a/packages/core/tests/parquetTableCache.spec.ts
+++ b/packages/core/tests/parquetTableCache.spec.ts
@@ -1,0 +1,94 @@
+import { tableFromArrays, tableToIPC } from 'apache-arrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SpatialDataTableSource from '../src/models/VTableSource.js';
+
+const PARQUET_PATH = 'points/cells/points.parquet';
+
+function createParquetBytes() {
+  return new Uint8Array([0x50, 0x41, 0x52, 0x31, 0x00, 0x00, 0x00, 0x00, 0x50, 0x41, 0x52, 0x31]);
+}
+
+/**
+ * A parquet module whose `readParquet` returns a fixed three-row table.
+ *
+ * `readMetadata` is deliberately absent: without it `loadParquetDatasetMetadata`
+ * short-circuits to `null`, so these tests exercise the single-file path through
+ * `loadParquetBytes` without needing range support or real WASM.
+ */
+function createParquetModuleStub() {
+  const ipcBytes = tableToIPC(tableFromArrays({ x: Float32Array.from([1, 2, 3]) }));
+  const wasmTable = { intoIPCStream: () => ipcBytes };
+  return {
+    readParquet: vi.fn(() => wasmTable),
+    readSchema: vi.fn(() => wasmTable),
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the WASM module surface
+  } as any;
+}
+
+/** A store that fails `failures` times on the main parquet path, then succeeds. */
+function createFlakyStore(failures: number) {
+  const parquetBytes = createParquetBytes();
+  let remainingFailures = failures;
+  const get = vi.fn(async (path: string) => {
+    if (path === `/${PARQUET_PATH}`) {
+      if (remainingFailures > 0) {
+        remainingFailures -= 1;
+        throw new Error('transient network failure');
+      }
+      return parquetBytes;
+    }
+    return null;
+  });
+  return { get };
+}
+
+function createSource(store: { get: ReturnType<typeof vi.fn> }) {
+  return new SpatialDataTableSource({
+    // biome-ignore lint/suspicious/noExplicitAny: minimal zarr.Readable test double
+    store: store as any,
+    fileType: '.zarr',
+  });
+}
+
+describe('SpatialDataTableSource parquet table cache', () => {
+  beforeEach(() => {
+    SpatialDataTableSource.parquetModulePromise = Promise.resolve(createParquetModuleStub());
+  });
+
+  it('does not poison the cache with a rejected promise after a transient failure', async () => {
+    const store = createFlakyStore(1);
+    const source = createSource(store);
+
+    await expect(source.loadParquetTable(PARQUET_PATH)).rejects.toThrow(
+      'Failed to load parquet data from store.'
+    );
+
+    // The store works now. A retry must reach it again rather than replaying the
+    // cached rejection for the lifetime of the source.
+    const table = await source.loadParquetTable(PARQUET_PATH);
+    expect(table.numRows).toBe(3);
+    expect(store.get).toHaveBeenCalledWith(`/${PARQUET_PATH}`);
+  });
+
+  it('still dedupes concurrent unfiltered reads onto one decode', async () => {
+    const store = createFlakyStore(0);
+    const source = createSource(store);
+
+    const [first, second] = await Promise.all([
+      source.loadParquetTable(PARQUET_PATH),
+      source.loadParquetTable(PARQUET_PATH),
+    ]);
+
+    expect(first).toBe(second);
+  });
+
+  it('keeps a successful table cached across sequential reads', async () => {
+    const store = createFlakyStore(0);
+    const source = createSource(store);
+
+    const first = await source.loadParquetTable(PARQUET_PATH);
+    const second = await source.loadParquetTable(PARQUET_PATH);
+
+    expect(first).toBe(second);
+  });
+});

--- a/packages/core/tests/parquetTableCache.spec.ts
+++ b/packages/core/tests/parquetTableCache.spec.ts
@@ -1,7 +1,7 @@
 import { tableFromArrays, tableToIPC } from 'apache-arrow';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ParquetCacheLimits } from '../src/Vutils.js';
 import SpatialDataTableSource from '../src/models/VTableSource.js';
+import type { ParquetCacheLimits } from '../src/Vutils.js';
 
 const PARQUET_PATH = 'points/cells/points.parquet';
 const OTHER_PARQUET_PATH = 'points/nuclei/points.parquet';

--- a/packages/core/tests/parquetTableCache.spec.ts
+++ b/packages/core/tests/parquetTableCache.spec.ts
@@ -1,8 +1,12 @@
 import { tableFromArrays, tableToIPC } from 'apache-arrow';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParquetCacheLimits } from '../src/Vutils.js';
 import SpatialDataTableSource from '../src/models/VTableSource.js';
 
 const PARQUET_PATH = 'points/cells/points.parquet';
+const OTHER_PARQUET_PATH = 'points/nuclei/points.parquet';
+/** Length of the stub file bytes below — the unit the encoded-tier tests count in. */
+const PARQUET_BYTE_LENGTH = 12;
 
 function createParquetBytes() {
   return new Uint8Array([0x50, 0x41, 0x52, 0x31, 0x00, 0x00, 0x00, 0x00, 0x50, 0x41, 0x52, 0x31]);
@@ -25,9 +29,11 @@ function createParquetModuleStub() {
   } as any;
 }
 
-/** A store that fails `failures` times on the main parquet path, then succeeds. */
-function createFlakyStore(failures: number) {
-  const parquetBytes = createParquetBytes();
+/**
+ * A store serving parquet bytes at both test paths, failing the first `failures`
+ * reads of {@link PARQUET_PATH}.
+ */
+function createFlakyStore(failures = 0) {
   let remainingFailures = failures;
   const get = vi.fn(async (path: string) => {
     if (path === `/${PARQUET_PATH}`) {
@@ -35,18 +41,22 @@ function createFlakyStore(failures: number) {
         remainingFailures -= 1;
         throw new Error('transient network failure');
       }
-      return parquetBytes;
+      return createParquetBytes();
+    }
+    if (path === `/${OTHER_PARQUET_PATH}`) {
+      return createParquetBytes();
     }
     return null;
   });
   return { get };
 }
 
-function createSource(store: { get: ReturnType<typeof vi.fn> }) {
+function createSource(store: { get: ReturnType<typeof vi.fn> }, limits?: ParquetCacheLimits) {
   return new SpatialDataTableSource({
     // biome-ignore lint/suspicious/noExplicitAny: minimal zarr.Readable test double
     store: store as any,
     fileType: '.zarr',
+    parquetCacheLimits: limits,
   });
 }
 
@@ -62,6 +72,7 @@ describe('SpatialDataTableSource parquet table cache', () => {
     await expect(source.loadParquetTable(PARQUET_PATH)).rejects.toThrow(
       'Failed to load parquet data from store.'
     );
+    expect(source.parquetTableCache.size).toBe(0);
 
     // The store works now. A retry must reach it again rather than replaying the
     // cached rejection for the lifetime of the source.
@@ -71,8 +82,7 @@ describe('SpatialDataTableSource parquet table cache', () => {
   });
 
   it('still dedupes concurrent unfiltered reads onto one decode', async () => {
-    const store = createFlakyStore(0);
-    const source = createSource(store);
+    const source = createSource(createFlakyStore());
 
     const [first, second] = await Promise.all([
       source.loadParquetTable(PARQUET_PATH),
@@ -83,12 +93,51 @@ describe('SpatialDataTableSource parquet table cache', () => {
   });
 
   it('keeps a successful table cached across sequential reads', async () => {
-    const store = createFlakyStore(0);
-    const source = createSource(store);
+    const source = createSource(createFlakyStore());
 
     const first = await source.loadParquetTable(PARQUET_PATH);
     const second = await source.loadParquetTable(PARQUET_PATH);
 
     expect(first).toBe(second);
+  });
+
+  it('reports resident bytes for both tiers', async () => {
+    const source = createSource(createFlakyStore());
+    expect(source.parquetTableBytes.byteLength).toBe(0);
+    expect(source.parquetTableCache.byteLength).toBe(0);
+
+    await source.loadParquetTable(PARQUET_PATH);
+
+    expect(source.parquetTableBytes.byteLength).toBe(PARQUET_BYTE_LENGTH);
+    // Three float32 values plus Arrow's own buffers — the exact figure is Arrow's
+    // business; that it is counted at all is the point of ADR 0005 rung 1.
+    expect(source.parquetTableCache.byteLength).toBeGreaterThan(0);
+  });
+
+  it('bounds the encoded tier, and refetches what it evicted', async () => {
+    const store = createFlakyStore();
+    const source = createSource(store, { encodedMaxBytes: PARQUET_BYTE_LENGTH });
+
+    await source.loadParquetBytes(PARQUET_PATH);
+    expect(source.parquetTableBytes.byteLength).toBe(PARQUET_BYTE_LENGTH);
+
+    await source.loadParquetBytes(OTHER_PARQUET_PATH);
+    expect(source.parquetTableBytes.byteLength).toBe(PARQUET_BYTE_LENGTH);
+    expect(source.parquetTableBytes.has(PARQUET_PATH)).toBe(false);
+
+    store.get.mockClear();
+    await expect(source.loadParquetBytes(PARQUET_PATH)).resolves.toBeInstanceOf(Uint8Array);
+    expect(store.get).toHaveBeenCalledWith(`/${PARQUET_PATH}`);
+  });
+
+  it('bounds the decoded tier', async () => {
+    // One byte: every table is oversized, so each admission evicts the last.
+    const source = createSource(createFlakyStore(), { decodedMaxBytes: 1 });
+
+    await source.loadParquetTable(PARQUET_PATH);
+    await source.loadParquetTable(OTHER_PARQUET_PATH);
+
+    expect(source.parquetTableCache.size).toBe(1);
+    expect(source.parquetTableCache.has(OTHER_PARQUET_PATH)).toBe(true);
   });
 });

--- a/packages/core/tests/rasterElementStore.spec.ts
+++ b/packages/core/tests/rasterElementStore.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ATTRS_KEY } from 'zarrextra';
+import type * as zarr from 'zarrita';
 import { ImageElement } from '../src/models/index.js';
 
 /**
@@ -31,20 +32,27 @@ function createTree() {
   };
 }
 
-function createImageElement(zarritaStore: { get: (key: string) => Promise<null> } = fakeStore()) {
+/** The narrowest thing satisfying `ConsolidatedStore['zarritaStore']`. */
+function fakeStore() {
+  return {
+    get: vi.fn(async (_key: zarr.AbsolutePath): Promise<Uint8Array | undefined> => undefined),
+    contents: vi.fn((): { path: zarr.AbsolutePath; kind: 'array' | 'group' }[] => []),
+  };
+}
+
+function createImageElement(zarritaStore: ReturnType<typeof fakeStore> = fakeStore()) {
   return new ImageElement({
     sdata: {
+      source: 'test://sdata.zarr',
       rootStore: { tree: createTree(), zarritaStore },
-      // biome-ignore lint/suspicious/noExplicitAny: minimal SDataProps test double
-    } as any,
+    },
     name: 'images',
     key: 'morphology',
   });
 }
 
-function fakeStore() {
-  return { get: vi.fn(async () => null) };
-}
+/** A chunk key rooted at the element, in zarrita's branded absolute-path form. */
+const CHUNK_KEY: zarr.AbsolutePath = '/0/c/0/0';
 
 describe('RasterElement.getStore', () => {
   it('hands out one stable store view per element', () => {
@@ -54,15 +62,18 @@ describe('RasterElement.getStore', () => {
   });
 
   it('gives different elements different views', () => {
-    expect(createImageElement().getStore()).not.toBe(createImageElement().getStore());
+    // One backing store, so the assertion is about the per-element *view* rather
+    // than about the two elements happening to hold different stores.
+    const shared = fakeStore();
+
+    expect(createImageElement(shared).getStore()).not.toBe(createImageElement(shared).getStore());
   });
 
   it('still resolves keys under the element path', async () => {
     const store = fakeStore();
     const element = createImageElement(store);
 
-    // biome-ignore lint/suspicious/noExplicitAny: zarrita brands absolute paths
-    await element.getStore().get('/0/c/0/0' as any);
+    await element.getStore().get(CHUNK_KEY);
 
     expect(store.get).toHaveBeenCalledWith('/images/morphology/0/c/0/0', undefined);
   });

--- a/packages/core/tests/rasterElementStore.spec.ts
+++ b/packages/core/tests/rasterElementStore.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ATTRS_KEY } from 'zarrextra';
+import { ImageElement } from '../src/models/index.js';
+
+/**
+ * The store view a raster element hands out has to be *the same object* every
+ * time, because the decoded chunk cache is keyed by store instance: fizarrita
+ * assigns each store an id from a `WeakMap` and builds keys as
+ * `store_N:{array path}:{chunk key}`, while `createPrefixedStore` returns a fresh
+ * object literal per call. A view per caller would key the same chunk differently
+ * per view — a cache that fills with duplicates and never hits. See ADR 0005
+ * rung 3.
+ */
+function createTree() {
+  return {
+    images: {
+      morphology: {
+        [ATTRS_KEY]: {
+          multiscales: [
+            {
+              datasets: [{ path: '0' }],
+              axes: [
+                { name: 'y', type: 'space' },
+                { name: 'x', type: 'space' },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function createImageElement(zarritaStore: { get: (key: string) => Promise<null> } = fakeStore()) {
+  return new ImageElement({
+    sdata: {
+      rootStore: { tree: createTree(), zarritaStore },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal SDataProps test double
+    } as any,
+    name: 'images',
+    key: 'morphology',
+  });
+}
+
+function fakeStore() {
+  return { get: vi.fn(async () => null) };
+}
+
+describe('RasterElement.getStore', () => {
+  it('hands out one stable store view per element', () => {
+    const element = createImageElement();
+
+    expect(element.getStore()).toBe(element.getStore());
+  });
+
+  it('gives different elements different views', () => {
+    expect(createImageElement().getStore()).not.toBe(createImageElement().getStore());
+  });
+
+  it('still resolves keys under the element path', async () => {
+    const store = fakeStore();
+    const element = createImageElement(store);
+
+    // biome-ignore lint/suspicious/noExplicitAny: zarrita brands absolute paths
+    await element.getStore().get('/0/c/0/0' as any);
+
+    expect(store.get).toHaveBeenCalledWith('/images/morphology/0/c/0/0', undefined);
+  });
+});

--- a/packages/vis/src/codecWorkers.ts
+++ b/packages/vis/src/codecWorkers.ts
@@ -12,7 +12,14 @@ import type { Chunk, DataType } from 'zarrita';
 export const DEFAULT_CHUNK_CACHE_MAX_BYTES = 256 * 1024 * 1024;
 
 export type EnsureCodecWorkersOptions = {
-  /** Override {@link DEFAULT_CHUNK_CACHE_MAX_BYTES}. Only read on the first call. */
+  /**
+   * Override {@link DEFAULT_CHUNK_CACHE_MAX_BYTES}.
+   *
+   * Read on the first call that actually enables the workers, and ignored
+   * afterwards — calls that no-op because `Worker` is unavailable read nothing,
+   * so a later call in a worker-capable context still gets to set it. Must be a
+   * finite, non-negative byte count; `ByteLruCache` rejects anything else.
+   */
   chunkCacheMaxBytes?: number;
 };
 
@@ -22,11 +29,17 @@ let chunkCache: ByteLruCache<Chunk<DataType>> | undefined;
 /** Bytes a decoded chunk holds. */
 function chunkByteLength(chunk: Chunk<DataType>): number {
   // Numeric dtypes give a typed array, which reports `byteLength` for free —
-  // that structural match is the whole point of `MemoryReporting`. String dtypes
-  // give a plain array instead, and `length` is the conservative floor there: one
-  // byte per element at minimum. Reporting zero would make such entries invisible
-  // to the budget and so unevictable by size, which is the one way a bounded
-  // cache quietly goes back to being unbounded.
+  // that structural match is the whole point of `MemoryReporting`. And numeric
+  // is all this cache ever sees: the sole route in is zarrextra's
+  // `ZarrPixelSource`, i.e. OME-Zarr pixel data, which is rejected long before
+  // here if it is not a numeric raster.
+  //
+  // The `length` arm is therefore a floor for a payload that should not arrive
+  // rather than a real measurement of one — element count, not UTF-8 bytes. It
+  // exists because reporting zero would make such entries invisible to the
+  // budget and so unevictable by size, which is the one way a bounded cache
+  // quietly goes back to being unbounded. If string chunks ever do reach this
+  // cache, this needs to become a real measurement.
   const data: { byteLength?: number; length: number } = chunk.data;
   return typeof data.byteLength === 'number' ? data.byteLength : data.length;
 }

--- a/packages/vis/src/codecWorkers.ts
+++ b/packages/vis/src/codecWorkers.ts
@@ -28,18 +28,19 @@ let chunkCache: ByteLruCache<Chunk<DataType>> | undefined;
 
 /** Bytes a decoded chunk holds. */
 function chunkByteLength(chunk: Chunk<DataType>): number {
-  // Numeric dtypes give a typed array, which reports `byteLength` for free —
-  // that structural match is the whole point of `MemoryReporting`. And numeric
-  // is all this cache ever sees: the sole route in is zarrextra's
-  // `ZarrPixelSource`, i.e. OME-Zarr pixel data, which is rejected long before
-  // here if it is not a numeric raster.
+  // Everything zarrita actually hands back reports `byteLength` over its own
+  // backing buffer — typed arrays for numeric dtypes, and `ByteStringArray` /
+  // `UnicodeStringArray` for string ones, which are byte-backed too. So string
+  // chunks are measured in bytes here, not in elements, and that structural
+  // match costing nothing is the whole point of `MemoryReporting`.
   //
-  // The `length` arm is therefore a floor for a payload that should not arrive
-  // rather than a real measurement of one — element count, not UTF-8 bytes. It
-  // exists because reporting zero would make such entries invisible to the
-  // budget and so unevictable by size, which is the one way a bounded cache
-  // quietly goes back to being unbounded. If string chunks ever do reach this
-  // cache, this needs to become a real measurement.
+  // The `length` arm covers only a plain JS array, which is in the declared
+  // union but is not a shape zarrita produces — and which this cache could not
+  // reach anyway, its sole route in being zarrextra's `ZarrPixelSource`, i.e.
+  // OME-Zarr pixel data. It is a floor rather than a measurement, and it exists
+  // because reporting zero would make such an entry invisible to the budget and
+  // so unevictable by size, which is the one way a bounded cache quietly goes
+  // back to being unbounded.
   const data: { byteLength?: number; length: number } = chunk.data;
   return typeof data.byteLength === 'number' ? data.byteLength : data.length;
 }

--- a/packages/vis/src/codecWorkers.ts
+++ b/packages/vis/src/codecWorkers.ts
@@ -80,10 +80,12 @@ export function getChunkCache(): ByteLruCache<Chunk<DataType>> | undefined {
  *   zero-filled typed array for a missing chunk and caches that like any other,
  *   so a sparse array can spend real bytes on nothing. The byte bound is what
  *   makes that survivable rather than a leak.
- * - **This does not dedupe in-flight requests.** fizarrita consults the cache
- *   while building its task list and writes back only after the worker returns,
- *   so two concurrent requests for one chunk still both fetch and both decode.
- *   That is an upstream gap, not something this seam can close.
+ * - **Concurrent readers of one chunk share a single fetch and decode.**
+ *   fizarrita keys in-flight operations the same way it keys this cache, so the
+ *   window between "someone started fetching this" and "the result is
+ *   cacheable" no longer costs a duplicate round-trip and a duplicate decode.
+ *   It follows that this cache sees one `set` per chunk however many readers
+ *   wanted it, so the byte total counts each chunk once.
  *
  * Cache keys are `store_N:{array path}:{chunk key}`, where `N` identifies the
  * **store instance**. `RasterElement.getStore()` memoizes its prefixed view for

--- a/packages/vis/src/codecWorkers.ts
+++ b/packages/vis/src/codecWorkers.ts
@@ -1,6 +1,46 @@
+import { ByteLruCache } from '@spatialdata/core';
 import { enableWorkerChunkDecode } from 'zarrextra/workers';
+import type { Chunk, DataType } from 'zarrita';
+
+/**
+ * Default ceiling for the decoded zarr chunk cache, shared across every element.
+ *
+ * Sized to hold a working set rather than a history: a few screenfuls of tiles
+ * across the scale levels a pan touches. Like the parquet ceilings this is a
+ * guess that bounds a cache, not a measured working set — see ADR 0005.
+ */
+export const DEFAULT_CHUNK_CACHE_MAX_BYTES = 256 * 1024 * 1024;
+
+export type EnsureCodecWorkersOptions = {
+  /** Override {@link DEFAULT_CHUNK_CACHE_MAX_BYTES}. Only read on the first call. */
+  chunkCacheMaxBytes?: number;
+};
 
 let enabled = false;
+let chunkCache: ByteLruCache<Chunk<DataType>> | undefined;
+
+/** Bytes a decoded chunk holds. */
+function chunkByteLength(chunk: Chunk<DataType>): number {
+  // Numeric dtypes give a typed array, which reports `byteLength` for free —
+  // that structural match is the whole point of `MemoryReporting`. String dtypes
+  // give a plain array instead, and `length` is the conservative floor there: one
+  // byte per element at minimum. Reporting zero would make such entries invisible
+  // to the budget and so unevictable by size, which is the one way a bounded
+  // cache quietly goes back to being unbounded.
+  const data: { byteLength?: number; length: number } = chunk.data;
+  return typeof data.byteLength === 'number' ? data.byteLength : data.length;
+}
+
+/**
+ * The decoded chunk cache, once {@link ensureCodecWorkers} has built it.
+ *
+ * Exposed for inspection — `byteLength` is what it is holding right now — and for
+ * `clear()`, which is how a host releases imagery it knows it is done with.
+ * `undefined` before the workers are enabled.
+ */
+export function getChunkCache(): ByteLruCache<Chunk<DataType>> | undefined {
+  return chunkCache;
+}
 
 /**
  * Enable the bundled zarrextra codec worker once for browser-based vis components.
@@ -8,13 +48,45 @@ let enabled = false;
  * This is called automatically by SpatialCanvas renderer paths. It is exported for
  * hosts that want to opt in before mounting UI, without risking repeated worker
  * pool replacement.
+ *
+ * ### The chunk cache
+ *
+ * fizarrita has always accepted a `{ get, set }` cache here and we always passed
+ * nothing, so it fell back to its no-op and *there was no chunk cache at all* —
+ * every tile paid a network round-trip and a re-decode on every pan back across
+ * ground already covered. Filling the seam is ADR 0005 rung 3, and a pure win:
+ * there is nothing to trade off against a cache that did not exist.
+ *
+ * `ByteLruCache` satisfies fizarrita's `ChunkCache` structurally, so it is passed
+ * as-is — its `get` is the lookup *and* the recency update, which is exactly what
+ * that interface wants.
+ *
+ * Two things worth knowing about what ends up in here:
+ *
+ * - **Absent chunks are cached as data.** fizarrita materialises a full
+ *   zero-filled typed array for a missing chunk and caches that like any other,
+ *   so a sparse array can spend real bytes on nothing. The byte bound is what
+ *   makes that survivable rather than a leak.
+ * - **This does not dedupe in-flight requests.** fizarrita consults the cache
+ *   while building its task list and writes back only after the worker returns,
+ *   so two concurrent requests for one chunk still both fetch and both decode.
+ *   That is an upstream gap, not something this seam can close.
+ *
+ * Cache keys are `store_N:{array path}:{chunk key}`, where `N` identifies the
+ * **store instance**. `RasterElement.getStore()` memoizes its prefixed view for
+ * exactly that reason; a fresh view per caller would key the same chunk
+ * differently per view and fill the cache with duplicates that never hit.
  */
-export function ensureCodecWorkers(): boolean {
+export function ensureCodecWorkers(options?: EnsureCodecWorkersOptions): boolean {
   if (enabled || typeof Worker === 'undefined') {
     return enabled;
   }
 
-  enableWorkerChunkDecode();
+  chunkCache = new ByteLruCache<Chunk<DataType>>({
+    maxBytes: options?.chunkCacheMaxBytes ?? DEFAULT_CHUNK_CACHE_MAX_BYTES,
+    sizeOf: chunkByteLength,
+  });
+  enableWorkerChunkDecode({ cache: chunkCache });
   enabled = true;
   return enabled;
 }

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -21,7 +21,12 @@ export {
   SpatialLayer,
   spatialLayerPropsSchema,
 } from '@spatialdata/layers';
-export { ensureCodecWorkers } from './codecWorkers';
+export {
+  DEFAULT_CHUNK_CACHE_MAX_BYTES,
+  type EnsureCodecWorkersOptions,
+  ensureCodecWorkers,
+  getChunkCache,
+} from './codecWorkers';
 export { default as ImageView } from './ImageView';
 export { default as Shapes } from './Shapes';
 export { default as Sketch } from './Sketch';

--- a/packages/vis/tests/codecWorkers.spec.ts
+++ b/packages/vis/tests/codecWorkers.spec.ts
@@ -1,10 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Chunk, DataType } from 'zarrita';
 
 const enableWorkerChunkDecode = vi.hoisted(() => vi.fn());
 
 vi.mock('zarrextra/workers', () => ({
   enableWorkerChunkDecode,
 }));
+
+function installWorker() {
+  Object.defineProperty(globalThis, 'Worker', {
+    value: class TestWorker {},
+    configurable: true,
+  });
+}
+
+/** A decoded chunk of `bytes` bytes, shaped like whatever fizarrita hands back. */
+function chunkOf(bytes: number): Chunk<DataType> {
+  return {
+    data: new Uint8Array(bytes),
+    shape: [bytes],
+    stride: [1],
+  } as Chunk<DataType>;
+}
+
+/** The cache handed to fizarrita on the most recent call. */
+function passedCache() {
+  return enableWorkerChunkDecode.mock.calls.at(-1)?.[0]?.cache;
+}
 
 describe('ensureCodecWorkers', () => {
   beforeEach(() => {
@@ -14,22 +36,62 @@ describe('ensureCodecWorkers', () => {
   });
 
   it('does nothing outside browser worker environments', async () => {
-    const { ensureCodecWorkers } = await import('../src/codecWorkers');
+    const { ensureCodecWorkers, getChunkCache } = await import('../src/codecWorkers');
 
     expect(ensureCodecWorkers()).toBe(false);
     expect(enableWorkerChunkDecode).not.toHaveBeenCalled();
+    expect(getChunkCache()).toBeUndefined();
   });
 
   it('enables the bundled codec worker once', async () => {
-    Object.defineProperty(globalThis, 'Worker', {
-      value: class TestWorker {},
-      configurable: true,
-    });
+    installWorker();
     const { ensureCodecWorkers } = await import('../src/codecWorkers');
 
     expect(ensureCodecWorkers()).toBe(true);
     expect(ensureCodecWorkers()).toBe(true);
     expect(enableWorkerChunkDecode).toHaveBeenCalledOnce();
-    expect(enableWorkerChunkDecode).toHaveBeenCalledWith();
+  });
+
+  it('fills fizarrita chunk-cache seam, which was previously left empty', async () => {
+    installWorker();
+    const { ensureCodecWorkers, getChunkCache, DEFAULT_CHUNK_CACHE_MAX_BYTES } = await import(
+      '../src/codecWorkers'
+    );
+    ensureCodecWorkers();
+
+    const cache = passedCache();
+    expect(cache).toBeDefined();
+    expect(cache).toBe(getChunkCache());
+    expect(cache.maxBytes).toBe(DEFAULT_CHUNK_CACHE_MAX_BYTES);
+    // fizarrita's `ChunkCache` contract is exactly these two.
+    expect(typeof cache.get).toBe('function');
+    expect(typeof cache.set).toBe('function');
+  });
+
+  it('accounts for the decoded bytes it holds, and bounds them', async () => {
+    installWorker();
+    const { ensureCodecWorkers, getChunkCache } = await import('../src/codecWorkers');
+    ensureCodecWorkers({ chunkCacheMaxBytes: 100 });
+
+    const cache = getChunkCache();
+    expect(cache?.byteLength).toBe(0);
+
+    cache?.set('store_0:/0:c/0/0', chunkOf(60));
+    expect(cache?.byteLength).toBe(60);
+
+    cache?.set('store_0:/0:c/0/1', chunkOf(60));
+    expect(cache?.byteLength).toBe(60);
+    expect(cache?.has('store_0:/0:c/0/0')).toBe(false);
+    expect(cache?.get('store_0:/0:c/0/1')).toBeDefined();
+  });
+
+  it('reads the ceiling only on the call that builds the cache', async () => {
+    installWorker();
+    const { ensureCodecWorkers, getChunkCache } = await import('../src/codecWorkers');
+
+    ensureCodecWorkers({ chunkCacheMaxBytes: 100 });
+    ensureCodecWorkers({ chunkCacheMaxBytes: 999 });
+
+    expect(getChunkCache()?.maxBytes).toBe(100);
   });
 });

--- a/packages/vis/tests/codecWorkers.spec.ts
+++ b/packages/vis/tests/codecWorkers.spec.ts
@@ -20,7 +20,7 @@ function chunkOf(bytes: number): Chunk<DataType> {
     data: new Uint8Array(bytes),
     shape: [bytes],
     stride: [1],
-  } as Chunk<DataType>;
+  };
 }
 
 /** The cache handed to fizarrita on the most recent call. */

--- a/packages/vis/tests/codecWorkers.spec.ts
+++ b/packages/vis/tests/codecWorkers.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Chunk, DataType } from 'zarrita';
+import * as zarr from 'zarrita';
 
 const enableWorkerChunkDecode = vi.hoisted(() => vi.fn());
 
@@ -93,5 +94,50 @@ describe('ensureCodecWorkers', () => {
     ensureCodecWorkers({ chunkCacheMaxBytes: 999 });
 
     expect(getChunkCache()?.maxBytes).toBe(100);
+  });
+});
+
+describe('chunk cache accounting', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    enableWorkerChunkDecode.mockClear();
+    Reflect.deleteProperty(globalThis, 'Worker');
+  });
+
+  it('refuses a ceiling that would silently disable the bound', async () => {
+    installWorker();
+    const { ensureCodecWorkers, getChunkCache } = await import('../src/codecWorkers');
+
+    // `Infinity` and `NaN` are valid numbers that make every
+    // `resident > maxBytes` comparison false, so a host could turn the bound off
+    // by accident. `ByteLruCache` rejects them at construction, which is what
+    // makes the ceiling here safe to take from a caller unchecked.
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+      expect(() => ensureCodecWorkers({ chunkCacheMaxBytes: bad })).toThrow(RangeError);
+    }
+
+    // ...and a rejected ceiling leaves nothing half-enabled.
+    expect(getChunkCache()).toBeUndefined();
+    expect(enableWorkerChunkDecode).not.toHaveBeenCalled();
+  });
+
+  it('measures string chunks by their bytes, not their element count', async () => {
+    installWorker();
+    const { ensureCodecWorkers, getChunkCache } = await import('../src/codecWorkers');
+    ensureCodecWorkers();
+
+    // zarrita hands back its own string-array types for string dtypes, and they
+    // report a real `byteLength` over their backing buffer — so they take the
+    // typed-array branch. Element count would be 3 here; the bytes are far more.
+    const strings = new zarr.UnicodeStringArray(8, ['alpha', 'beta', 'gamma']);
+    const cache = getChunkCache();
+    cache?.set('store_0:/labels:c/0', {
+      data: strings,
+      shape: [3],
+      stride: [1],
+    } as unknown as Chunk<DataType>);
+
+    expect(strings.byteLength).toBeGreaterThan(strings.length);
+    expect(cache?.byteLength).toBe(strings.byteLength);
   });
 });

--- a/packages/zarrextra/package.json
+++ b/packages/zarrextra/package.json
@@ -35,8 +35,8 @@
     "zarrita": "catalog:"
   },
   "devDependencies": {
-    "@fideus-labs/fizarrita": "^1.4.1",
-    "@fideus-labs/worker-pool": "^1.0.0",
+    "@fideus-labs/fizarrita": "^2.1.0",
+    "@fideus-labs/worker-pool": "^2.1.0",
     "@types/node": "catalog:",
     "@typescript/native": "catalog:",
     "typescript": "catalog:",
@@ -52,7 +52,7 @@
   "optionalDependencies": {
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
     "openjph-wasm": "^0.1.0",
-    "@fideus-labs/fizarrita": "^1.4.1",
-    "@fideus-labs/worker-pool": "^1.0.0"
+    "@fideus-labs/fizarrita": "^2.1.0",
+    "@fideus-labs/worker-pool": "^2.1.0"
   }
 }

--- a/packages/zarrextra/src/chunkDecode.ts
+++ b/packages/zarrextra/src/chunkDecode.ts
@@ -46,11 +46,23 @@ export function setChunkDecodeBackend(backend: ChunkDecodeBackend): void {
   chunkDecodeBackend = backend;
 }
 
-type GetWorkerFn = (
-  arr: zarr.Array<zarr.DataType>,
+/**
+ * The shape of the injected `getWorker`.
+ *
+ * Generic over `D` so a chunk comes back typed to the array it was read from,
+ * rather than as `Chunk<DataType>` needing an assertion at the call site.
+ *
+ * It is narrower than fizarrita's own signature, deliberately. That one returns
+ * a *conditional* type — `Scalar<D>` when every dimension is integer-indexed,
+ * `Chunk<D>` otherwise — and this seam only ever passes a selection whose type
+ * admits `null`, which lands on the `Chunk<D>` branch. Restating that here keeps
+ * the scalar case out of a signature that could not produce it.
+ */
+type GetWorkerFn = <D extends zarr.DataType>(
+  arr: zarr.Array<D>,
   selection: Array<number | zarr.Slice | null> | null,
   options: FizarritaGetWorkerOptions
-) => Promise<zarr.Chunk<zarr.DataType>>;
+) => Promise<zarr.Chunk<D>>;
 
 let getWorkerImpl: GetWorkerFn | undefined;
 
@@ -83,10 +95,13 @@ export async function getZarrChunk<D extends zarr.DataType>(
       cache: backend.options?.cache,
       signal: opts?.signal,
     });
+    // Kept even though the type now promises a chunk: this is an injection seam,
+    // and the type says what a correct impl returns, not what one did. Deleting
+    // it as redundant would trade a named error for a downstream shape crash.
     if (typeof result !== 'object' || result === null || !('data' in result)) {
       throw new Error('Expected chunk object from fizarrita getWorker().');
     }
-    return result as zarr.Chunk<D>;
+    return result;
   }
 
   // zarrita takes `signal` as a first-class option: it forwards it to every

--- a/packages/zarrextra/src/chunkDecode.ts
+++ b/packages/zarrextra/src/chunkDecode.ts
@@ -3,12 +3,22 @@ import type { WorkerPool } from '@fideus-labs/worker-pool';
 import * as zarr from 'zarrita';
 
 export type ZarrGetOptions = {
+  /**
+   * Cancels the read.
+   *
+   * Both backends take this as a first-class option and act on it: fetches are
+   * aborted at the store, chunk work still queued on the worker pool is dropped
+   * rather than started, and the returned promise rejects with the signal's
+   * reason. A decode already running on a worker is not interrupted — its result
+   * is discarded — so this bounds what a cancelled read *starts*, not what it has
+   * already handed to a worker.
+   */
   signal?: AbortSignal;
 };
 
 export type FizarritaGetWorkerOptions = Pick<
   GetWorkerOptions,
-  'workerUrl' | 'useSharedArrayBuffer' | 'cache'
+  'workerUrl' | 'useSharedArrayBuffer' | 'cache' | 'signal'
 > & {
   pool: WorkerPool;
 };
@@ -18,7 +28,12 @@ export type ChunkDecodeBackend =
   | {
       kind: 'fizarrita';
       pool: WorkerPool;
-      options?: Omit<FizarritaGetWorkerOptions, 'pool'>;
+      /**
+       * Set once when the backend is enabled, so deliberately not `signal`:
+       * cancellation belongs to a single read, and a signal parked here would
+       * silently govern every read the backend ever serves.
+       */
+      options?: Omit<FizarritaGetWorkerOptions, 'pool' | 'signal'>;
     };
 
 let chunkDecodeBackend: ChunkDecodeBackend = { kind: 'main' };
@@ -43,31 +58,6 @@ export function setFizarritaGetWorker(impl: GetWorkerFn): void {
   getWorkerImpl = impl;
 }
 
-function rejectOnAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) {
-    return promise;
-  }
-  if (signal.aborted) {
-    return Promise.reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-  }
-  return new Promise((resolve, reject) => {
-    const onAbort = () => {
-      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-    };
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      (value) => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
-      }
-    );
-  });
-}
-
 export async function getZarrChunk<D extends zarr.DataType>(
   arr: zarr.Array<D>,
   selection: Array<number | zarr.Slice | null>,
@@ -81,21 +71,27 @@ export async function getZarrChunk<D extends zarr.DataType>(
           'Import from zarrextra/workers instead of setting the backend directly.'
       );
     }
-    const result = await rejectOnAbort(
-      getWorkerImpl(arr, selection, {
-        pool: backend.pool,
-        workerUrl: backend.options?.workerUrl,
-        useSharedArrayBuffer: backend.options?.useSharedArrayBuffer,
-        cache: backend.options?.cache,
-      }),
-      opts?.signal
-    );
+    // The signal goes to fizarrita rather than being watched here. Watching it
+    // here only ever stopped us *awaiting* a read: the fetch and the decode ran
+    // to completion regardless, so a pan that outran its tiles still paid full
+    // price for every one it had already abandoned. Handed over, it aborts the
+    // store requests and drops chunk tasks still queued on the pool.
+    const result = await getWorkerImpl(arr, selection, {
+      pool: backend.pool,
+      workerUrl: backend.options?.workerUrl,
+      useSharedArrayBuffer: backend.options?.useSharedArrayBuffer,
+      cache: backend.options?.cache,
+      signal: opts?.signal,
+    });
     if (typeof result !== 'object' || result === null || !('data' in result)) {
       throw new Error('Expected chunk object from fizarrita getWorker().');
     }
     return result as zarr.Chunk<D>;
   }
 
+  // zarrita takes `signal` as a first-class option: it forwards it to every
+  // `store.get` and re-checks it between chunks, so a multi-chunk read stops
+  // early rather than running the rest out. `opts` passes straight through.
   const result = await zarr.get(arr, selection, opts);
   if (typeof result !== 'object' || result === null || !('data' in result)) {
     throw new Error('Expected chunk object from zarr.get().');

--- a/packages/zarrextra/src/chunkDecode.ts
+++ b/packages/zarrextra/src/chunkDecode.ts
@@ -54,9 +54,13 @@ export function setChunkDecodeBackend(backend: ChunkDecodeBackend): void {
  *
  * It is narrower than fizarrita's own signature, deliberately. That one returns
  * a *conditional* type — `Scalar<D>` when every dimension is integer-indexed,
- * `Chunk<D>` otherwise — and this seam only ever passes a selection whose type
- * admits `null`, which lands on the `Chunk<D>` branch. Restating that here keeps
- * the scalar case out of a signature that could not produce it.
+ * `Chunk<D>` otherwise — and this seam only ever passes a selection whose *type*
+ * admits `null`, so the conditional resolves on the `Chunk<D>` branch anyway.
+ * Restating it here spares the call site an assertion.
+ *
+ * That resolution is static, though. A selection that happens to hold only
+ * numbers still indexes a point and still comes back as a scalar, which is what
+ * {@link assertChunk} is there to catch.
  */
 type GetWorkerFn = <D extends zarr.DataType>(
   arr: zarr.Array<D>,
@@ -68,6 +72,27 @@ let getWorkerImpl: GetWorkerFn | undefined;
 
 export function setFizarritaGetWorker(impl: GetWorkerFn): void {
   getWorkerImpl = impl;
+}
+
+/**
+ * Guard that a read really produced a chunk rather than a scalar.
+ *
+ * Both backends are typed here as returning `Chunk<D>`, and both can be wrong at
+ * runtime for the same reason. `selection` is declared as
+ * `Array<number | zarr.Slice | null>`, so zarrita's conditional return type
+ * resolves on its `null` branch and settles on `Chunk<D>` — but the branch taken
+ * at runtime depends on the *values*, and an all-number selection like
+ * `[0, 0, 0]` indexes a single point, which comes back as a bare `Scalar<D>`.
+ * That is the one place the static type lies, and it lies identically on both
+ * paths. The fizarrita path has a second reason on top: it is an injection seam,
+ * so its type says what a correct impl returns, not what one did.
+ *
+ * Cheap either way, and it trades a downstream shape crash for a named error.
+ */
+function assertChunk(result: unknown, source: string): void {
+  if (typeof result !== 'object' || result === null || !('data' in result)) {
+    throw new Error(`Expected chunk object from ${source}.`);
+  }
 }
 
 export async function getZarrChunk<D extends zarr.DataType>(
@@ -95,12 +120,7 @@ export async function getZarrChunk<D extends zarr.DataType>(
       cache: backend.options?.cache,
       signal: opts?.signal,
     });
-    // Kept even though the type now promises a chunk: this is an injection seam,
-    // and the type says what a correct impl returns, not what one did. Deleting
-    // it as redundant would trade a named error for a downstream shape crash.
-    if (typeof result !== 'object' || result === null || !('data' in result)) {
-      throw new Error('Expected chunk object from fizarrita getWorker().');
-    }
+    assertChunk(result, 'fizarrita getWorker()');
     return result;
   }
 
@@ -108,8 +128,6 @@ export async function getZarrChunk<D extends zarr.DataType>(
   // `store.get` and re-checks it between chunks, so a multi-chunk read stops
   // early rather than running the rest out. `opts` passes straight through.
   const result = await zarr.get(arr, selection, opts);
-  if (typeof result !== 'object' || result === null || !('data' in result)) {
-    throw new Error('Expected chunk object from zarr.get().');
-  }
-  return result as zarr.Chunk<D>;
+  assertChunk(result, 'zarr.get()');
+  return result;
 }

--- a/packages/zarrextra/tests/chunkDecode.spec.ts
+++ b/packages/zarrextra/tests/chunkDecode.spec.ts
@@ -74,3 +74,85 @@ describe('getZarrChunk', () => {
     expect(getChunkDecodeBackend()).toEqual({ kind: 'main' });
   });
 });
+
+describe('getZarrChunk cancellation', () => {
+  it('hands the caller signal to fizarrita rather than watching it here', async () => {
+    const controller = new AbortController();
+    const getWorker = vi.fn(async () => ({
+      data: new Uint8Array([1, 2, 3, 4]),
+      shape: [2, 2],
+      stride: [2, 1],
+    }));
+    setFizarritaGetWorker(getWorker as never);
+    setChunkDecodeBackend({ kind: 'fizarrita', pool: {} as never });
+
+    const store = createArrayStore();
+    const arr = await zarr.open(store as never, { kind: 'array' });
+    await getZarrChunk(arr, [null, null], { signal: controller.signal });
+
+    expect(getWorker).toHaveBeenCalledOnce();
+    expect(getWorker.mock.calls[0]?.[2]).toMatchObject({ signal: controller.signal });
+
+    setChunkDecodeBackend({ kind: 'main' });
+  });
+
+  it('omits the signal when the caller gives none', async () => {
+    const getWorker = vi.fn(async () => ({
+      data: new Uint8Array([1, 2, 3, 4]),
+      shape: [2, 2],
+      stride: [2, 1],
+    }));
+    setFizarritaGetWorker(getWorker as never);
+    setChunkDecodeBackend({ kind: 'fizarrita', pool: {} as never });
+
+    const store = createArrayStore();
+    const arr = await zarr.open(store as never, { kind: 'array' });
+    await getZarrChunk(arr, [null, null]);
+
+    expect(getWorker.mock.calls[0]?.[2]?.signal).toBeUndefined();
+
+    setChunkDecodeBackend({ kind: 'main' });
+  });
+
+  it('passes the signal down to the store on the main-thread path', async () => {
+    // The distinction this change is about: a cancelled read has to reach the
+    // work, not just stop us looking at it. What is ours to guarantee is that
+    // the signal arrives at `store.get` — whether the request then unwinds is
+    // the store's business (a `FetchStore` aborts; this fake ignores it, which
+    // is why the read below still resolves).
+    const backing = createArrayStore();
+    const controller = new AbortController();
+    let chunkReadSignal: AbortSignal | undefined;
+
+    const store = {
+      get: async (key: string, opts?: { signal?: AbortSignal }) => {
+        if (key === '/c/0/0') {
+          chunkReadSignal = opts?.signal;
+        }
+        return backing.get(key);
+      },
+    };
+
+    const arr = await zarr.open(store as never, { kind: 'array' });
+    await getZarrChunk(arr, [null, null], { signal: controller.signal });
+
+    expect(chunkReadSignal).toBe(controller.signal);
+  });
+
+  it('rejects an already-aborted read without touching the store', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled before it started'));
+
+    const get = vi.fn(async (key: string) => createArrayStore().get(key));
+    const metadataOnly = { get: async (key: string) => createArrayStore().get(key) };
+    const arr = await zarr.open(metadataOnly as never, { kind: 'array' });
+    // Swap in the counting store only after `open` has read the metadata, so
+    // the count reflects chunk reads alone.
+    (arr as unknown as { store: unknown }).store = { get };
+
+    await expect(getZarrChunk(arr, [null, null], { signal: controller.signal })).rejects.toThrow(
+      'cancelled before it started'
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zarrextra/tests/chunkDecode.spec.ts
+++ b/packages/zarrextra/tests/chunkDecode.spec.ts
@@ -45,6 +45,22 @@ describe('getZarrChunk', () => {
     expect(Array.from((chunk as zarr.Chunk<'uint8'>).data)).toEqual([1, 2, 3, 4]);
   });
 
+  it('rejects a point selection rather than returning a bare scalar', async () => {
+    // The one case where the static type lies. `selection` is declared as
+    // `Array<number | Slice | null>`, so zarrita's conditional return type
+    // resolves on its `null` branch and promises `Chunk<D>` — but the branch
+    // taken at runtime depends on the values, and an all-number selection
+    // indexes a single point, which zarrita unwraps to a scalar. Without the
+    // guard that scalar would be handed back typed as a chunk and crash on the
+    // first `.data` downstream.
+    setChunkDecodeBackend({ kind: 'main' });
+    const arr = await zarr.open(createArrayStore() as zarr.Readable, { kind: 'array' });
+
+    await expect(getZarrChunk(arr, [0, 0])).rejects.toThrow(
+      'Expected chunk object from zarr.get().'
+    );
+  });
+
   it('delegates to fizarrita getWorker when that backend is enabled', async () => {
     const getWorker = vi.fn(async () => ({
       data: new Uint8Array([9, 8, 7, 6]),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,11 +535,11 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@fideus-labs/fizarrita':
-        specifier: ^1.4.1
-        version: 1.4.1(zarrita@0.7.3)
+        specifier: ^2.1.0
+        version: 2.1.0(zarrita@0.7.3)
       '@fideus-labs/worker-pool':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       openjph-wasm:
         specifier: ^0.1.0
         version: 0.1.0
@@ -2132,13 +2132,13 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fideus-labs/fizarrita@1.4.1':
-    resolution: {integrity: sha512-71HTW4cTDeUnm2f3MU3352MMlpzUAFHhDmEajaASpUywVDe7RdY8ImjeXwRllKjvfPcukfz/aEmdPs67esSngA==}
+  '@fideus-labs/fizarrita@2.1.0':
+    resolution: {integrity: sha512-HWGFW09TwGfj1ZiEmS93z8gchzvaWKKymlF5WTj7KYO5IByvg6P0afHUtmbgszXhzi0bEyyGOIlY83pSKSajng==}
     peerDependencies:
       zarrita: '>=0.6.0'
 
-  '@fideus-labs/worker-pool@1.0.0':
-    resolution: {integrity: sha512-Mwx8fFKKpTUcEtR7w45MQJ/RnZFUPBtefEvGTZGlZMAVSfD7W61rpB8ZdgS4V0CXfppwcb90BF7F/aANWvupnA==}
+  '@fideus-labs/worker-pool@2.1.0':
+    resolution: {integrity: sha512-X/rmGDKS8HbTvWVrUxUn5dUrtolaJYNXM477CxStNupFMOGBEZcUD3CRqE1kVVNiQhN/W6+K/lwIKN/bsGKThw==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -11519,13 +11519,13 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@fideus-labs/fizarrita@1.4.1(zarrita@0.7.3)':
+  '@fideus-labs/fizarrita@2.1.0(zarrita@0.7.3)':
     dependencies:
-      '@fideus-labs/worker-pool': 1.0.0
+      '@fideus-labs/worker-pool': 2.1.0
       zarrita: 0.7.3
     optional: true
 
-  '@fideus-labs/worker-pool@1.0.0':
+  '@fideus-labs/worker-pool@2.1.0':
     optional: true
 
   '@floating-ui/core@1.7.5':


### PR DESCRIPTION
Implements rungs 1–3 of [ADR 0005](docs/adr/0005-memory-accounting-before-management.md). Rungs 4–5 are deliberately **not** built — the ADR defers them until measurement justifies them, and this leaves that intact.

The repo had a memory *policy* and no memory *accounting*: `DEFAULT_POINTS_MEMORY_CAP` is a row count applied to one element kind, and nothing anywhere could answer "how many bytes are resident?". These four commits fix the three things that are broken today and stop there.

Each commit stands alone and is separately reviewable.

### `06dd876` — rung 2b: rejected parquet promises evict themselves

`parquetTableCache` caches the table promise before it settles — genuine in-flight dedup — but never cleaned up a rejection, so **one transient fetch failure pinned a rejected promise at that path for the lifetime of the source**, and every later read replayed a network error that had cleared long ago. The only recovery was a new source.

Reproduced first, then fixed with the `evictIfCurrent` discipline already used by the dataset-metadata and part-path caches. The rejection still propagates unchanged to the caller that provoked it, so the deliberate skip-vs-fail policy in `docs/plans/parquet-io-error-handling.md` is untouched — it just stops being the answer for the next caller. Tests cover the retry plus the two behaviours that had to survive it: concurrent dedup, and successful tables staying cached.

### `7d8592f` — rung 1: the `MemoryReporting` scalar

`{ readonly byteLength: number }`. No policy, no eviction, no tiers.

The name is the design: `byteLength` is what `TypedArray`, `ArrayBuffer` and `DataView` already call this, so every payload we hold satisfies it structurally — no wrapper, no import. That is what makes it cheap enough to put on every cache rather than a chosen few. Implementors take on one obligation: keep the number cheap to read (running total on insert/evict, never a scan per read).

### `5118184` — rung 2: both parquet tiers bounded

`parquetTableBytes` (compressed bytes) and `parquetTableCache` (decoded Arrow) were plain `Record`s with no eviction of any kind. A source held **both tiers of every parquet file any caller had ever touched, simultaneously**, until it was discarded — double memory for zero eviction benefit. Fixing a leak, not building an architecture.

Adds `ByteLruCache` (framework-free, byte-bounded, `MemoryReporting`, dispose hook) and puts both tiers behind it. Two semantics the tests pin:

- **An oversized value is admitted, not refused**, and left sole resident. Refusing it is the worse failure: `loadParquetBytes` runs ~20 times per points load, so a file that can never be admitted becomes ~20 refetches of the file that was already too big to fetch once.
- **Sizes need not be known at insertion.** The decoded cache holds the in-flight promise (that *is* the dedup), so it enters at zero bytes and is recounted when the table lands. Arrow's `Data.byteLength` walks the whole child tree, so it is asked exactly once per table.

Ceilings default to 128 MB encoded / 256 MB decoded, overridable per source via `DataSourceParams.parquetCacheLimits`. The numbers bound a leak; they are not a measured working set, which is why they are an option rather than a constant you would have to fork to change.

**Breaking** for direct readers of those two public fields — `source.parquetTableBytes[path]` becomes `.get(path)`. Nothing outside `VTableSource` touched either.

### `7f3c3d9` — rung 3: the chunk-cache seam, filled

fizarrita has always accepted a `{ get, set }` cache and `zarrextra` has always plumbed it through, but `ensureCodecWorkers()` called `enableWorkerChunkDecode()` with no options — so `cache` was `undefined` and fizarrita fell back to its no-op. **There was no chunk cache at all**, not an undersized one. Every tile paid a network round-trip *and* a re-decode on every pan back over ground already covered. Pure win: nothing to trade against a cache that did not exist.

`ByteLruCache` satisfies fizarrita's `ChunkCache` structurally, so it is passed as-is — its `get` is the lookup *and* the recency update, exactly what that interface wants. Default 256 MB, overridable on the first call; `getChunkCache()` exposes it for inspection and `clear()`.

`RasterElement.getStore()` is now memoized, and that is load-bearing rather than tidiness: fizarrita keys chunks `store_N:{path}:{chunkKey}` with `N` from a `WeakMap` on the **store instance**, while `createPrefixedStore` returns a fresh object literal per call. A view per caller would key one chunk differently per view and fill the cache with duplicates that never hit.

Two upstream gaps left standing, and documented at the call site rather than silently inherited: absent chunks are cached as full zero-filled arrays (bounded now, but still real bytes), and the chunk path still has no in-flight dedup. Both are filed upstream.

## Verification

- Full unit suite green: 99 files / 825 tests. `biome ci` and `lint:react` clean. All packages build.
- **Verified live in the vis demo** against the remote Visium HD dataset: the chunk cache is wired end to end through fizarrita — 256 MB ceiling, one decoded chunk resident at 95.7 MB under key `store_0:/0:0/0/0`. Before this branch there was no cache object to inspect at all.

One thing I could **not** demonstrate in-app: the duplicate-key counterfactual for the `getStore()` memoization. Removing the memoization and toggling the layer still produced a single `store_0` entry, because the app caches the image loader so `getStore()` is not called again on a toggle. The memoization is correct and is what the ADR asks for, but the only direct evidence is the unit test that it returns a stable instance — there is no in-app repro of the failure it prevents.

## Not in scope

Rungs 4 (encoded tier / evict-decoded-keep-encoded) and 5 (tiered `ResidencyReport`, global ceiling, degrade-to-fit) are untouched by design. The ADR's own rationale — `tgpu-htj2k` built and unit-tested a budget solver it then never called in production — is the reason.

The ADR still reads `Status: proposed`. Rungs 1–3 landing does not by itself settle 4–5, so that felt like a call to make separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added byte-limited LRU caching for Parquet data and decoded Zarr chunks.
  * Added configurable cache limits, memory usage reporting, and cache inspection/clearing APIs.
  * Added stable store reuse for raster data access.
  * Added cancellation support for Zarr chunk reads.

* **Bug Fixes**
  * Failed Parquet loads can now be retried safely.
  * In-flight data requests are deduplicated while successful results remain cached.
  * Cache entries are evicted automatically to respect configured memory limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->