### PR TITLE
Fix the docs typecheck script, and gate the docs site on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
       - run: |
           pnpm install --frozen-lockfile
           pnpm build
+          pnpm --filter docs typecheck
           pnpm docs:build
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,45 @@ jobs:
       - name: Biome lint/format (packages/*/src)
         run: pnpm lint:biome
 
+  docs-typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # The docs site is excluded from `pnpm build` and `pnpm test`, so nothing on a
+    # PR used to compile it. Its own `typecheck` script was broken for long enough
+    # to go unnoticed (it called `tsc`, which the TS 6 compat package does not
+    # provide), and the Docs workflow that would have caught it only runs on main —
+    # by which point a type error is already deploying.
+    steps:
+      - name: Check out repository (docs-typecheck)
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.14.1'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Required, not incidental: docs imports `@spatialdata/vis`, and the
+      # workspace packages resolve types through `dist/index.d.ts`, which only
+      # exists after their build. Without this the typecheck fails on a bare
+      # "Cannot find module '@spatialdata/vis'".
+      - name: Build packages
+        run: pnpm build
+
+      - name: Typecheck docs site
+        run: pnpm --filter docs typecheck
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Biome lint/format (packages/*/src)
         run: pnpm lint:biome
 
-  docs-typecheck:
+  docs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,9 +88,11 @@ jobs:
     # PR used to compile it. Its own `typecheck` script was broken for long enough
     # to go unnoticed (it called `tsc`, which the TS 6 compat package does not
     # provide), and the Docs workflow that would have caught it only runs on main —
-    # by which point a type error is already deploying.
+    # by which point the failure is already blocking a Pages deploy. This job is
+    # that workflow's Build steps minus the deploy, so the same breakage fails on
+    # the PR instead.
     steps:
-      - name: Check out repository (docs-typecheck)
+      - name: Check out repository (docs)
         uses: actions/checkout@v7
         with:
           persist-credentials: false
@@ -118,6 +120,12 @@ jobs:
 
       - name: Typecheck docs site
         run: pnpm --filter docs typecheck
+
+      # Catches what the typecheck cannot: broken MDX, dead internal links, and
+      # Docusaurus config/plugin regressions. Kept after the typecheck so the
+      # cheap check reports first. Same order as the Docs workflow's Build job.
+      - name: Build docs site
+        run: pnpm docs:build
 
   test:
     runs-on: ubuntu-latest

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc6"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",
@@ -33,6 +33,7 @@
     "@docusaurus/module-type-aliases": "3.10.2",
     "@docusaurus/tsconfig": "3.10.2",
     "@docusaurus/types": "3.10.2",
+    "@types/react": "catalog:",
     "typescript": "catalog:"
   },
   "browserslist": {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,12 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    // `baseUrl` is what anchors the inherited `@site/*` path mapping to this
+    // directory, so it has to stay until @docusaurus/tsconfig drops its own
+    // `baseUrl`. TS 6 deprecates the option (TS 7 removes it outright), hence the
+    // opt-out below and the `tsc6` typecheck script.
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
   },
   "exclude": [".docusaurus", "build"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@docusaurus/types':
         specifier: 3.10.2
         version: 3.10.2(@swc/core@1.15.47)(@swc/html@1.15.47)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.18
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'


### PR DESCRIPTION
`docs/package.json` had `"typecheck": "tsc"`, but the workspace catalog maps `typescript` to `npm:@typescript/typescript6`, whose bin is `tsc6`. The script had never once run — it failed with `sh: tsc: command not found`. Nothing in `.github/workflows/docs.yml` invoked it, which is why that went unnoticed.

Pre-existing; unrelated to the Docusaurus 3.10 upgrade in #139, just found next to it.

## Why `tsc6` and not TS 7

`@docusaurus/tsconfig@3.10.2` sets `baseUrl` in its own compilerOptions, and TS 7 removed the option outright:

```
tsconfig.json(4,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
```

An inherited option can't be unset, only overridden, so using `@typescript/native` here would mean dropping `extends` and inlining Docusaurus's config — a hand-copied snapshot of their `target`/`lib`/`moduleResolution` that silently stops tracking upstream, in exchange for nothing on a `noEmit` check that publishes no declarations. `tsc6` also matches the catalog's stated split: TS 6 for tooling, `@typescript/native` for declaration emit.

I did verify TS 7 works: with the config inlined it typechecks the site with zero errors, and `@site/*` resolves correctly under paths-without-`baseUrl`. It's deliberately left for the Docusaurus v4 upgrade, where it costs nothing — upstream removed `baseUrl` in facebook/docusaurus#11915 (merged, v4 milestone, not in 3.x), moving the `@site` alias and excludes into the base config. At that point `docs/tsconfig.json` collapses to `{ "extends": "@docusaurus/tsconfig" }`, the `ignoreDeprecations` line goes away, and the script moves to `tsc` with no local fork of upstream's config at any point.

## Real errors the working script surfaced

- `TS7016` on `react` — docs depends on `react` but never declared `@types/react`. Added from the catalog. (`@types/react-dom` turned out not to be needed; checked, left out.)
- `TS2307` on `@spatialdata/vis` — the workspace packages resolve types through `dist/index.d.ts`, so the typecheck needs `pnpm build` first. That's why the new steps are ordered the way they are, and it is not incidental: on a bare install the check cannot run at all.

`baseUrl` has to stay in `docs/tsconfig.json` — it is what anchors the inherited `@site/*` mapping to `docs/` rather than to the `@docusaurus/tsconfig` package directory. TS 6 only deprecates it, so `ignoreDeprecations: "6.0"` covers the gap.

## Gating

The Docs workflow triggers only on push to main, so a failure there is already blocking a Pages deploy by the time anyone sees it — and `pnpm build` and `pnpm test` both filter docs out, so no PR check compiled the site at all. That is how the 3.10 upgrade got validated.

New `docs` job in the Test workflow, which runs on `pull_request`. It is the Docs workflow's Build job minus the deploy: install → `pnpm build` → typecheck → `pnpm docs:build`. The site build catches what the typecheck cannot — broken MDX, dead internal links, Docusaurus config and plugin regressions — and reuses the `pnpm build` already in the job, so the marginal cost is the Docusaurus build alone. Typecheck runs first so the cheap check reports first.

## Verification

- `pnpm --filter docs typecheck` — exit 0
- `pnpm docs:build` — exit 0, `[SUCCESS] Generated static files`
- actionlint 1.7.12 on all workflow files — exit 0, same pin the Workflow Lint job uses

The one warning in the docs build output is the pre-existing `web-worker` critical-dependency notice, unchanged by any of this.

## Note for whoever merges

If branch protection lists required checks by name, the new `docs` check won't be required until it's added to that set — it will run and can fail without blocking merge. That's a repo-settings change, not something in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation build validation by adding type checking before site generation.
  * Added automated checks to build and verify the documentation site in CI.

* **Chores**
  * Updated documentation tooling for TypeScript 6 compatibility.
  * Added required React type definitions and adjusted TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->