### PR TITLE
Export the feature-row classification alongside the points feature state

### DIFF
--- a/.changeset/export-feature-row-classification.md
+++ b/.changeset/export-feature-row-classification.md
@@ -1,0 +1,18 @@
+---
+'@spatialdata/vis': minor
+---
+
+Export the feature-row classification alongside the points feature state.
+
+`usePointsFeatureState` returns raw engine signals — `residentCodes`,
+`loadedMatchingCodes`, `matchingLoadState`, `supportsOnDemandLoad` — and
+`describeFeatureRowState` is what turns them into a row's rendered state: whether
+it is dimmed, a short label, and a sentence explaining why. Only the former was
+reachable from the package entry, so an embedder building its own feature list had
+the data but not the reading of it, and had to re-derive a precedence order
+(resident/rendered beat selection and scan state) that is easy to get subtly wrong
+— the failure mode being a panel that greys a feature the canvas is drawing.
+
+Adds `describeFeatureRowState` and `featureRowOpacity`, plus the types
+`FeatureRowState`, `FeatureRowStateInput` and `FeatureRowTone`. No behaviour
+change; these already backed the built-in `PointsFeatureFilterPanel`.

--- a/packages/vis/src/SpatialCanvas/public.ts
+++ b/packages/vis/src/SpatialCanvas/public.ts
@@ -15,6 +15,14 @@ export type {
   FeatureColorResolver,
   FeatureColorResolverContext,
 } from './featureColorResolver';
+export type { FeatureRowState, FeatureRowStateInput, FeatureRowTone } from './featureRowState';
+// Feature-row classification. Exported because it is the other half of
+// `usePointsFeatureState`: the hook hands back raw engine signals (resident,
+// rendered, scanning…) and this turns them into the dimming + the sentence that
+// explains it. An embedder building its own feature list would otherwise have to
+// re-derive that precedence, and any drift shows up as a panel telling the user
+// something different from what the canvas is doing.
+export { describeFeatureRowState, featureRowOpacity } from './featureRowState';
 export { useSpatialViewState, useViewStateUrl } from './hooks';
 export type { ImageLayerContextValue } from './ImageLayerContext';
 export { ImageLayerContextProvider, useImageLayerContext } from './ImageLayerContext';

--- a/packages/vis/src/index.ts
+++ b/packages/vis/src/index.ts
@@ -33,6 +33,9 @@ export type {
   ElementsByType,
   FeatureColorResolver,
   FeatureColorResolverContext,
+  FeatureRowState,
+  FeatureRowStateInput,
+  FeatureRowTone,
   HoverTooltipMode,
   ImageLayerContextValue,
   ImageLoaderData,
@@ -75,6 +78,8 @@ export type {
 export {
   composeSpatialDeckLayers,
   createSpatialCanvasStore,
+  describeFeatureRowState,
+  featureRowOpacity,
   ImageLayerContextProvider,
   layerConfig,
   mergeLayerChannelState,


### PR DESCRIPTION
Follow-on to #144, found while building the equivalent points feature UI in MDV against the published `0.7.0`.

## The gap

#144 exported `usePointsFeatureState`, which returns the raw engine signals for a layer: `residentCodes`, `loadedMatchingCodes`, `matchingLoadState`, `supportsOnDemandLoad`. What it does not export is the thing that *reads* those signals.

`describeFeatureRowState` takes the six booleans a feature list already has and returns the row's rendered state — `greyed`, a short `label`, and a sentence explaining why — with a precedence that is not obvious from the outside:

- `resident` / `rendered` (its points are in memory) beat selection and scan state;
- a deselected-but-loaded feature is `cached`, not dropped, because deselecting filters the in-memory batch rather than re-scanning;
- `!residentKnown` means "can't distinguish", which has to read as *shown*, not as *not loaded*.

Get that order wrong and the panel greys a feature the canvas is currently drawing. That is exactly the class of divergence the built-in panel's comment calls out ("drives both the dimming and the diagnostic tooltip so they can never disagree") — but only for consumers who can reach the function.

## What this adds

Values: `describeFeatureRowState`, `featureRowOpacity`.
Types: `FeatureRowState`, `FeatureRowStateInput`, `FeatureRowTone`.

Both were already exported from `featureRowState.ts`; this re-exports them through `SpatialCanvas/public.ts` and the package entry, which is the only route out (the package publishes just a `"."` export). No behaviour change — `PointsFeatureFilterPanel` is already the caller.

The module was deliberately split out of the panel file so it exports no component (a mixed component + plain-function export breaks Fast Refresh for that file). Re-exporting through `public.ts` keeps that split intact.

## Verification

- `pnpm --filter @spatialdata/vis build`, then imported the built `dist/index.js`: both values resolve as functions, and calling `describeFeatureRowState` with a selected+scanning row returns `{tone: "loading", greyed: true, …}` with `featureRowOpacity` 0.6. Types present in `dist/index.d.ts`.
- `pnpm --filter @spatialdata/vis test` — 149 tests, 16 files, passing.
- Biome clean.

Minor changeset included.
