### PR TITLE
Emit the workers and points-worker entries as ES modules

### DIFF
--- a/.changeset/fix-worker-entry-module-format.md
+++ b/.changeset/fix-worker-entry-module-format.md
@@ -1,0 +1,24 @@
+---
+'@spatialdata/core': patch
+---
+
+Emit the `workers` and `points-worker` entries as ES modules.
+
+The lib `fileName` named only `index` per format; every other entry got
+`${entryName}.js` from BOTH the es and cjs passes, so the cjs output silently
+overwrote the es one. `dist/workers.js` and `dist/points-worker.js` therefore
+shipped as CommonJS under a `.js` extension inside a `"type": "module"` package —
+files nothing can load.
+
+`enablePointsWorker` constructs the worker with `new Worker(url, { type: 'module' })`,
+so loading the published `points-worker.js` failed with `ReferenceError: require is
+not defined` and the worker never answered. That made the points worker impossible
+to start outside this repo, and with it the feature-index scan: a points selection
+whose rows fall beyond the memory cap could not be fetched at all, because
+`loadPointsMatchingFeatureCodes` throws rather than falling back to the main thread.
+The demo did not catch it because it imports the worker's TypeScript source by
+relative path.
+
+Every entry now names its format, and `./workers` gains explicit `import`/`require`
+conditions. A packaging test asserts each `exports` target really is in the module
+system its extension and the package `type` imply.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
     },
     "./workers": {
       "types": "./dist/workers/index.d.ts",
-      "default": "./dist/workers.js"
+      "import": "./dist/workers.js",
+      "require": "./dist/workers.cjs"
     },
     "./points-worker": {
       "default": "./dist/points-worker.js"

--- a/packages/core/tests/distEntryFormats.spec.ts
+++ b/packages/core/tests/distEntryFormats.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Packaging guard: every `exports` target must actually be in the module system its
+ * extension and the package `type` imply.
+ *
+ * This exists because the failure mode is completely silent. `points-worker` and
+ * `workers` were both emitted twice under the same `.js` name (the lib `fileName`
+ * ignored `format`), so the cjs pass overwrote the es one and shipped CommonJS under
+ * `.js` in a `"type": "module"` package. The build succeeded, the files existed, and
+ * the types were right — it only surfaced in a consumer, as
+ * `ReferenceError: require is not defined` inside a Worker that then never answered.
+ * Nothing in the repo caught it because the demo imports the worker's TS source.
+ *
+ * Skips when `dist` is absent so a plain `vitest run` on a fresh clone doesn't fail;
+ * CI builds before testing, and the assertions run there.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')) as {
+  type?: string;
+  exports: Record<string, Record<string, string>>;
+};
+
+/** Every JS file named by an `exports` condition, as [condition path, file path]. */
+function exportedJsTargets(): Array<{ subpath: string; condition: string; file: string }> {
+  const targets: Array<{ subpath: string; condition: string; file: string }> = [];
+  for (const [subpath, conditions] of Object.entries(packageJson.exports)) {
+    for (const [condition, target] of Object.entries(conditions)) {
+      if (condition === 'types') continue;
+      if (!/\.(js|cjs|mjs)$/.test(target)) continue;
+      targets.push({ subpath, condition, file: resolve(packageRoot, target) });
+    }
+  }
+  return targets;
+}
+
+/** CommonJS markers that cannot appear at the top level of an ES module. */
+const COMMONJS_PATTERN = /(^|[^.\w])(require\(|exports\.|module\.exports)/;
+/** ESM markers that cannot appear in a CommonJS file. */
+const ESM_PATTERN = /(^|\n)\s*(import\s|export\s|export\{)/;
+
+describe('published entry formats', () => {
+  const targets = exportedJsTargets();
+
+  it('declares the package as an ES module', () => {
+    expect(packageJson.type).toBe('module');
+  });
+
+  it('names at least the three known entries', () => {
+    expect(Object.keys(packageJson.exports).sort()).toEqual(['.', './points-worker', './workers']);
+  });
+
+  for (const { subpath, condition, file } of targets) {
+    const label = `${subpath} (${condition}) -> ${file.slice(packageRoot.length + 1)}`;
+
+    it(`${label} exists`, (ctx) => {
+      if (!existsSync(resolve(packageRoot, 'dist'))) return ctx.skip();
+      expect(existsSync(file)).toBe(true);
+    });
+
+    it(`${label} is in the right module system`, (ctx) => {
+      if (!existsSync(file)) return ctx.skip();
+      const source = readFileSync(file, 'utf8');
+      // `.js` in a `"type": "module"` package is ESM; `.cjs` is always CommonJS.
+      const expectsEsm =
+        file.endsWith('.mjs') || (file.endsWith('.js') && packageJson.type === 'module');
+      if (expectsEsm) {
+        expect(
+          COMMONJS_PATTERN.test(source),
+          `${label} contains CommonJS syntax but must be an ES module. The lib \`fileName\` ` +
+            `probably names this entry without its format, so the cjs pass overwrote the es one.`
+        ).toBe(false);
+      } else {
+        expect(ESM_PATTERN.test(source), `${label} must be CommonJS`).toBe(false);
+      }
+    });
+  }
+
+  it('gives the points worker an ES module, which is the only thing new Worker({type:"module"}) can load', (ctx) => {
+    const worker = resolve(packageRoot, 'dist/points-worker.js');
+    if (!existsSync(worker)) return ctx.skip();
+    const source = readFileSync(worker, 'utf8');
+    expect(COMMONJS_PATTERN.test(source)).toBe(false);
+    expect(ESM_PATTERN.test(source)).toBe(true);
+  });
+});

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -64,12 +64,15 @@ export default defineConfig({
       },
       name: 'SpatialDataCore',
       formats: ['es', 'cjs'],
-      fileName: (format, entryName) => {
-        if (entryName === 'index') {
-          return `index.${format === 'es' ? 'js' : 'cjs'}`;
-        }
-        return `${entryName}.js`;
-      },
+      // EVERY entry must name its format, not just `index`. Both passes write to the
+      // same directory, so a name that ignores `format` is claimed twice and the cjs
+      // pass silently overwrites the es one — leaving a CommonJS file under a `.js`
+      // extension in a `"type": "module"` package, which nothing can load. That is how
+      // `points-worker.js` shipped: `new Worker(url, { type: 'module' })` died on
+      // `require is not defined`, so no consumer could ever start the points worker,
+      // and the feature-index scan (its only caller with no main-thread fallback) was
+      // unreachable outside this repo. See `tests/distEntryFormats.spec.ts`.
+      fileName: (format, entryName) => `${entryName}.${format === 'es' ? 'js' : 'cjs'}`,
     },
     rollupOptions: {
       external: (id) => {


### PR DESCRIPTION
Fixes #148.

## The bug

The lib `fileName` disambiguated the two output formats for `index` only:

```ts
fileName: (format, entryName) => {
  if (entryName === 'index') {
    return `index.${format === 'es' ? 'js' : 'cjs'}`;
  }
  return `${entryName}.js`;   // both passes claim this name
},
```

With `formats: ['es', 'cjs']`, `workers` and `points-worker` were each written twice to the same path and the cjs pass won. So `dist/workers.js` and `dist/points-worker.js` shipped as CommonJS under a `.js` extension inside a `"type": "module"` package — files that neither Node nor a browser will load.

```
$ head -c 90 dist/points-worker.js       # before
const e=require("./shapesPolygonTessellate-DA2WL45U.cjs"),t=require("./pointsTiling-…

$ head -c 90 dist/points-worker.js       # after
import { n as e, r as t, t as n } from "./shapesPolygonTessellate-CZ8c5JYn.js";
```

`enablePointsWorker` is the only way to turn the worker on and it builds it as an ES module (`new Worker(url, { type: 'module' })`), so the published artifact failed with `ReferenceError: require is not defined` and the worker never answered a request.

Most worker paths fall back to the main thread, so they only lost performance. `loadPointsMatchingFeatureCodes` has no fallback — it throws:

> Feature-filtered points loading requires the points worker and parquet part bytes.

That is the feature-index scan, which means **selecting a points feature whose rows lie beyond the memory cap could not fetch them in any embedding app**. The selection silently rendered whatever subset happened to fall inside the cap.

The demo never hit it because it imports the worker's TypeScript *source* by relative path (`../../../core/src/workers/points-worker.ts?worker&url`) — an in-repo path no consumer can write. So the demo has always had a working points worker and the published package has never had one.

## The change

- Every entry names its format: `` `${entryName}.${format === 'es' ? 'js' : 'cjs'}` ``.
- `./workers` gains explicit `import`/`require` conditions, now that both formats actually exist. `./points-worker` keeps a single `default` — it is loaded as a Worker URL, and that file is now ESM.
- `packages/core/tests/distEntryFormats.spec.ts` asserts every `exports` target is in the module system its extension and the package `type` imply.

The test exists because this failure is silent in every place you would normally look: the build was green, the files were present, the `.d.ts` were correct, and it only surfaced inside a Worker in someone else's application. I confirmed it fails against the old config before keeping it — 4 failures, all the right ones (`workers.js` wrong format, `workers.cjs` missing, `points-worker.js` wrong format, and the explicit worker check).

## Verification

Built `core`, then linked MDV against this build and ran the real app on Xenium pancreas transcripts — 8,073,840 points at the 4M default cap, so half the dataset is out of memory.

Selecting `AMY2A` alone:

```
matchingLoadState  { loading: false, matchedRows: 1182402, scannedRows: 1182402, settled: true }
truncation         { loaded: 1182402, filtered: true, truncated: false }
```

1,182,402 is AMY2A's full dataset count, fetched from beyond the cap. Before this change the same selection left the `matching` slot at `status: "failed"` with the guard error and showed only the in-cap subset.

`pnpm --filter @spatialdata/core test` — 391 tests, 52 files, passing. Biome clean. Patch changeset included.

## Follow-on

The scan failing was invisible to the UI for as long as it was broken — `getMatchingLoadState` returns `undefined` for a failed slot exactly as it does for "no scan has run", and there is no error accessor. That is #149, and worth doing separately: the next cause of a failed scan will be just as quiet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package exports so worker modules resolve correctly for both ES module and CommonJS consumers.
  * Ensured built entry points use unambiguous file extensions and are not overwritten during packaging.

* **Tests**
  * Added packaging checks to verify export targets exist and match their declared module formats.
  * Added validation that the points worker is emitted as an ES module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->