### PR TITLE
Report a failed feature-index scan instead of going quiet

### DIFF
--- a/.changeset/surface-failed-feature-scan.md
+++ b/.changeset/surface-failed-feature-scan.md
@@ -1,0 +1,20 @@
+---
+'@spatialdata/core': minor
+'@spatialdata/vis': minor
+---
+
+Report a failed feature-index scan instead of going quiet.
+
+`getMatchingLoadState` returned `undefined` for a failed `matching` slot — exactly
+what it returns for "no scan has ever run" — and nothing else exposed the error. So
+a scan that failed looked identical to one that had not started, while the render
+path carried on filtering the resident batch. The panel showed whichever part of the
+selection happened to be inside the memory cap and presented it as the complete
+answer.
+
+`PointsMatchingLoadState` gains `failed` and `error`, reported for the selection the
+failed scan would have covered (and only that one — a stale failure for a selection
+the user has since changed is not attributed to the new one, and a retained good
+batch no longer masks it). `usePointsFeatureState` gains `retryFailedLoads`, and the
+built-in feature filter panel now says the load failed, says the canvas is showing
+only what was already in memory, and offers Retry when the error is retryable.

--- a/packages/core/src/engine/PointsResolver.ts
+++ b/packages/core/src/engine/PointsResolver.ts
@@ -3,7 +3,7 @@ import { featureCodeMapFromCatalog, remapRowFeatureCodes } from '../pointsFeatur
 import { DEFAULT_POINTS_MEMORY_CAP } from '../pointsLimits.js';
 import type { PointsLoadProgress, PointsLoadResult } from '../pointsLoadOptions.js';
 import type { PointsFeatureCatalog } from '../pointsTiling.js';
-import type { EntryNotice } from './errors.js';
+import type { EntryNotice, SpatialEntryError } from './errors.js';
 import { RequestSlot } from './RequestSlot.js';
 import { Resolution } from './resolution.js';
 import type { EntryResources, ResolveContext, ResolveTask, ResourceResolver } from './resolver.js';
@@ -169,6 +169,17 @@ export interface PointsMatchingLoadState {
   settled: boolean;
   /** The selection is served by filtering a larger in-memory batch (no scan ran). */
   covered?: boolean;
+  /**
+   * The scan that would have loaded this selection failed.
+   *
+   * Reported because the alternative is worse than an error: the render path falls
+   * back to filtering the resident batch, so a failed scan still draws *something* —
+   * whichever subset of the selection happened to be inside the memory cap — and a
+   * panel with no failure signal presents that partial view as the whole answer.
+   * `error.retryable` gates a retry affordance; `PointsResolver.retry(key)` re-runs it.
+   */
+  failed?: true;
+  error?: SpatialEntryError;
 }
 
 export class PointsResolver implements ResourceResolver<PointsResolveConfig, PointsElement> {
@@ -910,6 +921,37 @@ export class PointsResolver implements ResourceResolver<PointsResolveConfig, Poi
           matchedRows: progress?.done ?? 0,
           scannedRows: progress?.scanned ?? 0,
           settled: false,
+        };
+      }
+    }
+
+    // The scan that would have covered this selection failed. Checked BEFORE the
+    // last-good branch: a failure retains the previous batch as `stale`, so reading
+    // `lastGood` first would answer with a settled state for whatever was loaded
+    // before — the panel would then report a healthy older selection while the one
+    // the user is actually looking at silently never loaded.
+    //
+    // Coverage, not equality, for the same reason the reuse path uses it: a scan for
+    // {A,B} that failed was going to supply {A} too, so shrinking the selection does
+    // not make the failure irrelevant. A superseding scan for the smaller selection
+    // moves the slot to `loading`, and the branch above wins.
+    const failedKey = slot.failedKey;
+    if (failedKey !== undefined && slot.resolution.status === 'failed') {
+      const failed = PointsResolver.parseMatchingKey(failedKey);
+      const wouldHaveCovered = PointsResolver.coveredCodes(failed.signature);
+      if (
+        failed.signature === signature ||
+        (wouldHaveCovered.size > 0 && featureCodes.every((code) => wouldHaveCovered.has(code)))
+      ) {
+        return {
+          loading: false,
+          // Nothing landed for this selection; reporting the stale batch's row count
+          // here is exactly the misreading this branch exists to prevent.
+          matchedRows: 0,
+          scannedRows: 0,
+          settled: true,
+          failed: true,
+          error: slot.resolution.error,
         };
       }
     }

--- a/packages/core/src/engine/RequestSlot.ts
+++ b/packages/core/src/engine/RequestSlot.ts
@@ -162,6 +162,18 @@ export class RequestSlot<K, V> {
     return this._resolution.status === 'ready' ? this.readyKey : undefined;
   }
 
+  /**
+   * The key of the request that failed, if `failed`.
+   *
+   * A slot is per-element but its requests are per-selection, so "did this fail?" is
+   * not answerable without knowing *what* failed: a stale failure for a selection the
+   * user has since changed must not be reported against the current one. `pendingKey`
+   * and `settledKey` answer the same question for the other two states.
+   */
+  get failedKey(): K | undefined {
+    return this._resolution.status === 'failed' ? this.lastRequest?.key : undefined;
+  }
+
   /** The in-flight promise, if any — for awaiting or returning from a dedup. */
   get pending(): Promise<void> | undefined {
     return this.current?.promise;

--- a/packages/core/tests/pointsResolver.spec.ts
+++ b/packages/core/tests/pointsResolver.spec.ts
@@ -686,3 +686,102 @@ describe('progressive preload (D3)', () => {
     );
   });
 });
+
+describe('getMatchingLoadState() — a failed scan is reportable', () => {
+  // The gap this closes: a failed scan used to be indistinguishable from "no scan
+  // has run" (both `undefined`), while the render path kept drawing the resident
+  // subset. The panel therefore presented a partial view as the complete answer,
+  // with no error anywhere. See #149.
+  const failing = (message = 'scan exploded') =>
+    element({
+      loadPointsMatchingFeatureCodes: vi.fn(async () => {
+        throw new Error(message);
+      }),
+    });
+
+  it('reports the failure, its message, and no rows', async () => {
+    const resolver = new PointsResolver();
+    const el = failing();
+
+    await resolver.ensureMatchingFeaturesLoaded(
+      { key: 'transcripts', layerId: 'l', element: el },
+      [1]
+    );
+
+    const state = resolver.getMatchingLoadState('transcripts', [1]);
+    expect(state?.failed).toBe(true);
+    expect(state?.settled).toBe(true);
+    expect(state?.loading).toBe(false);
+    // Not the stale batch's row count — nothing landed for THIS selection.
+    expect(state?.matchedRows).toBe(0);
+    expect(state?.error?.message).toContain('scan exploded');
+  });
+
+  it('reports the failure for a subset of the selection that failed', async () => {
+    const resolver = new PointsResolver();
+
+    await resolver.ensureMatchingFeaturesLoaded(
+      { key: 'transcripts', layerId: 'l', element: failing() },
+      [1, 2]
+    );
+
+    // A scan for {1,2} was going to supply {1}, so shrinking the selection does not
+    // make the failure irrelevant — those points are still not loaded.
+    expect(resolver.getMatchingLoadState('transcripts', [1])?.failed).toBe(true);
+  });
+
+  it('does not report a failure against an unrelated selection', async () => {
+    const resolver = new PointsResolver();
+
+    await resolver.ensureMatchingFeaturesLoaded(
+      { key: 'transcripts', layerId: 'l', element: failing() },
+      [1]
+    );
+
+    // {7} was never part of the failed scan; claiming it failed would be as wrong as
+    // staying silent about {1}.
+    expect(resolver.getMatchingLoadState('transcripts', [7])).toBeUndefined();
+  });
+
+  it('does not let a stale good batch mask the failure', async () => {
+    const resolver = new PointsResolver();
+    const target = { key: 'transcripts', layerId: 'l', element: element() };
+
+    // A good scan for {1} first, so the slot retains it as `stale`...
+    await resolver.ensureMatchingFeaturesLoaded(target, [1]);
+    expect(resolver.getMatchingLoadState('transcripts', [1])?.failed).toBeUndefined();
+
+    // ...then a failing scan for {2}. Reading `lastGood` first would answer with the
+    // {1} batch and call {2} settled.
+    await resolver.ensureMatchingFeaturesLoaded(
+      { key: 'transcripts', layerId: 'l', element: failing() },
+      [2]
+    );
+    expect(resolver.getMatchingLoadState('transcripts', [2])?.failed).toBe(true);
+  });
+
+  it('clears the failure when a retry succeeds', async () => {
+    const resolver = new PointsResolver();
+    let shouldFail = true;
+    const el = element({
+      loadPointsMatchingFeatureCodes: vi.fn(async () => {
+        if (shouldFail) throw new Error('transient');
+        return batch(2);
+      }),
+    });
+
+    await resolver.ensureMatchingFeaturesLoaded(
+      { key: 'transcripts', layerId: 'l', element: el },
+      [1]
+    );
+    expect(resolver.getMatchingLoadState('transcripts', [1])?.failed).toBe(true);
+    expect(resolver.getMatchingLoadState('transcripts', [1])?.error?.retryable).toBe(true);
+
+    shouldFail = false;
+    await resolver.retry('transcripts');
+
+    const state = resolver.getMatchingLoadState('transcripts', [1]);
+    expect(state?.failed).toBeUndefined();
+    expect(state?.matchedRows).toBe(2);
+  });
+});

--- a/packages/vis/src/SpatialCanvas/PointsFeatureFilterPanel.tsx
+++ b/packages/vis/src/SpatialCanvas/PointsFeatureFilterPanel.tsx
@@ -102,6 +102,15 @@ const loadingStatStyle: CSSProperties = {
   fontSize: '11px',
 };
 
+const errorStatStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: 4,
+  color: '#e2a0a0',
+  fontSize: '11px',
+};
+
 const countStyle: CSSProperties = {
   color: '#888',
   fontSize: '11px',
@@ -165,6 +174,7 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
     residentFeatureCounts,
     requestCatalog,
     setHighlightedFeature,
+    retryFailedLoads,
   } = usePointsFeatureState(config);
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -391,7 +401,25 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
             : "not in the loaded sample (greyed below) — this dataset has no feature index, so they can't be shown until the row cap is raised or it's rewritten with one."}
         </div>
       ) : null}
-      {matchingLoadState ? (
+      {matchingLoadState?.failed ? (
+        // A failed scan still DRAWS: the render path falls back to filtering the
+        // resident batch, so the canvas shows whichever part of the selection was
+        // inside the memory cap. Saying so matters more than the error text — without
+        // it the partial view reads as the complete answer.
+        <div style={errorStatStyle}>
+          Could not load the selected features
+          {matchingLoadState.error ? `: ${matchingLoadState.error.message}` : '.'}
+          <div style={helperStyle}>
+            Showing only the selected points already in memory.
+            {matchingLoadState.error?.retryable === false ? '' : ' Retrying will re-run the scan.'}
+          </div>
+          {matchingLoadState.error?.retryable === false ? null : (
+            <button type="button" style={buttonStyle} onClick={() => retryFailedLoads()}>
+              Retry
+            </button>
+          )}
+        </div>
+      ) : matchingLoadState ? (
         <div style={matchingLoadState.loading ? loadingStatStyle : helperStyle}>
           {matchingLoadState.loading
             ? `Loading selected features… ${matchingLoadState.matchedRows.toLocaleString()} points so far`

--- a/packages/vis/src/SpatialCanvas/PointsFeatureState.tsx
+++ b/packages/vis/src/SpatialCanvas/PointsFeatureState.tsx
@@ -131,11 +131,14 @@ export interface PointsFeatureState {
   /** Stable callback — set (or clear, with null) the hover-highlighted feature code
    * for this layer, so its points are emphasised on the canvas. */
   setHighlightedFeature: (featureCode: number | null) => void;
+  /** Stable callback — re-run this element's failed loads (the retry affordance
+   * behind `matchingLoadState.failed`). No-op when nothing has failed. */
+  retryFailedLoads: () => void;
 }
 
 const EMPTY_POINTS_FEATURE_STATE: Omit<
   PointsFeatureState,
-  'requestCatalog' | 'setHighlightedFeature'
+  'requestCatalog' | 'setHighlightedFeature' | 'retryFailedLoads'
 > = {
   catalog: undefined,
   catalogLoading: false,
@@ -172,9 +175,17 @@ export function usePointsFeatureState(
     },
     [engine, target]
   );
+  const retryFailedLoads = useCallback(() => {
+    if (target) void engine.retry(target.key);
+  }, [engine, target]);
 
   if (!target) {
-    return { ...EMPTY_POINTS_FEATURE_STATE, requestCatalog, setHighlightedFeature };
+    return {
+      ...EMPTY_POINTS_FEATURE_STATE,
+      requestCatalog,
+      setHighlightedFeature,
+      retryFailedLoads,
+    };
   }
   const key = target.key;
   const scannable = engine.supportsFeatureScan(key);
@@ -203,5 +214,6 @@ export function usePointsFeatureState(
     residentFeatureCounts: engine.getResidentFeatureCounts(key),
     requestCatalog,
     setHighlightedFeature,
+    retryFailedLoads,
   };
 }


### PR DESCRIPTION
Fixes #149. Independent of #150 — different files, either can merge first.

## The gap

`getMatchingLoadState` returned `undefined` for a failed `matching` slot, which is exactly what it returns for "no scan has ever run":

```ts
const matched = slot.lastGood;
if (!matched) {
  return undefined;   // failed and never-ran are indistinguishable
}
```

Nothing else exposed the error, so no consumer could tell them apart. That would be merely unhelpful if a failed scan drew nothing — but it doesn't. The render path falls back to filtering the resident batch, so a failed scan still paints **whichever part of the selection happened to be inside the memory cap**, and the panel presents that partial view as the complete answer.

This is how #148 stayed hidden. The published points worker could not start at all, so every feature-index scan in an embedding app failed at its guard — and the only symptom was "selecting a feature doesn't load its points". No error, a healthy-looking feature list, correct dataset counts, and a `matching` slot sitting at `status: "failed"` that nothing could read.

## What this adds

`PointsMatchingLoadState` gains `failed` and `error`. Two things the reporting has to get right, both pinned by tests:

- **Attributed by coverage, not equality.** A scan for `{A,B}` that failed was going to supply `{A}`, so shrinking the selection doesn't make the failure irrelevant — those points still aren't loaded. An unrelated `{C}` must not inherit it. (A superseding scan for the smaller selection moves the slot to `loading` and that branch wins, so this only reports a genuinely dead selection.)
- **Checked before `lastGood`.** A failure retains the previous batch as `stale`, so reading the good value first answers with a settled state for whatever was loaded *before* — the same misreading in a new place. The failed branch also reports `matchedRows: 0` rather than the stale batch's count, for the same reason.

`RequestSlot` gains `failedKey` — the missing third member of `pendingKey`/`settledKey`. A slot is per-element but its requests are per-selection, so "did this fail?" isn't answerable without knowing *what* failed.

`usePointsFeatureState` gains `retryFailedLoads`, and `PointsFeatureFilterPanel` now names the failure, says the canvas is showing only what was already in memory, and offers Retry when the error is retryable — which is what `SpatialEntryError.retryable` and `RequestSlot.retry()` were always for ("Failure is a state", ADR 0004 §3).

## Verification

Five tests in `pointsResolver.spec.ts`; I confirmed 4 of them fail against the old code before keeping them (the fifth — "does not report a failure against an unrelated selection" — passes either way by construction, and is there to stop the coverage rule over-reporting).

End to end in the demo, against Xenium pancreas transcripts (8,073,840 points, 4M cap) with the points worker switched off, which reproduces #148's failure exactly. Selecting `AMY2A`:

> **Could not load the selected features: Feature-filtered points loading requires the points worker and parquet part bytes.**
> Showing only the selected points already in memory. Retrying will re-run the scan.
> `[Retry]`

Before this change that area of the panel was empty. Retry is wired and re-runs the scan (it fails again here, correctly, because the cause is still present); the failure→retry→**success** transition is covered by unit test rather than by hand, since removing the live cause needs a reload.

`core` 383 tests / 51 files, `layers` 236 / 19, `vis` 149 / 16 — all passing. Biome clean. Minor changeset for both packages.

## Note on scope

The issue also raised that `resident` means "≥1 point inside the cap", not "all of this feature is loaded" — so on a truncated element every feature reads as resident and nothing greys while half the dataset is absent. That needs per-feature resident-vs-dataset counts to fix properly and is a bigger change; left out deliberately rather than half-done.
