### PR TITLE
Make the parquet worker wireable from webpack, wire the docs demo, and guard import.meta in cjs

### DIFF
--- a/.changeset/import-meta-cjs-guards.md
+++ b/.changeset/import-meta-cjs-guards.md
@@ -1,0 +1,27 @@
+---
+"@spatialdata/core": patch
+---
+
+Stop the cjs build's `import.meta` replacement from being a latent crash.
+
+The cjs pass replaces `import.meta` with `{}`, so `import.meta.url` is `undefined`
+there. Two call sites used it unguarded, and both were in code meant to serve Node —
+the one runtime the cjs build exists for:
+
+- the parquet-wasm loader's Node branch called `fileURLToPath(undefined)`, a
+  `TypeError`, on the first parquet read;
+- `defaultWorkerUrl()` called `new URL('./parquet-worker.js', undefined)`, which throws
+  `Invalid URL`, so `enableParquetWorker()` with no `workerUrl` threw instead of
+  falling back.
+
+Both now read `import.meta.url` into a variable and check it. The loader falls through
+to the async init; `enableParquetWorker` warns that a CommonJS host must pass
+`workerUrl` or `createWorker`, and leaves the worker off rather than throwing.
+
+Two caveats worth knowing. The build still emits `EMPTY_IMPORT_META` twice — that is
+now expected and is commented as such in `packages/core/vite.config.ts`; rolldown's
+suggested `transform.define` suppression is not reachable through Vite 8's config.
+And the cjs entry cannot currently be `require`d at all, for an unrelated reason:
+`anndata.js` publishes no CommonJS export, so `require('@spatialdata/core')` fails
+before any of this is reached. These guards are correctness for when that is fixed,
+not a claim that the cjs build works today.

--- a/.changeset/parquet-worker-create-worker.md
+++ b/.changeset/parquet-worker-create-worker.md
@@ -1,0 +1,25 @@
+---
+"@spatialdata/core": minor
+"@spatialdata/vis": minor
+---
+
+`enableParquetWorker` and `ensureWorkers` accept a `createWorker` factory, for
+bundlers that cannot hand back a URL for a *bundled* worker.
+
+webpack is the case this exists for. It only builds a worker when it can see the
+`new Worker(new URL(...))` form literally, so there is no URL to import ahead of
+time; `workerUrl` has no answer for it, and the "Other bundlers" row of the bundling
+page was advice nobody could follow.
+
+```ts
+ensureWorkers({
+  parquet: {
+    createWorker: () =>
+      new Worker(new URL('./myWorkerEntry.ts', import.meta.url), { type: 'module' }),
+  },
+});
+```
+
+A factory rather than a `Worker`, because enabling tears down and rebuilds — an
+instance could only be used once. Takes precedence over `workerUrl`; Vite hosts keep
+using the `?worker&url` import and are unaffected.

--- a/.changeset/parquet-worker-create-worker.md
+++ b/.changeset/parquet-worker-create-worker.md
@@ -12,6 +12,11 @@ time; `workerUrl` has no answer for it, and the "Other bundlers" row of the bund
 page was advice nobody could follow.
 
 ```ts
+// myWorkerEntry.ts — one line, in your own source
+import '@spatialdata/core/parquet-worker';
+```
+
+```ts
 ensureWorkers({
   parquet: {
     createWorker: () =>
@@ -19,6 +24,16 @@ ensureWorkers({
   },
 });
 ```
+
+The local entry file is load-bearing: pointing the URL at the bare
+`@spatialdata/core/parquet-worker` specifier makes webpack emit this package's published
+worker entry as an unbundled static asset, 9kB whose every import 404s.
+
+Constructing the worker is also now failure-tolerant. A `createWorker` factory is host
+code and can throw, and `new Worker` itself throws on a URL the browser rejects or under
+a CSP that forbids it; either used to propagate out of `enableParquetWorker` and take the
+caller's render with it. Both are now caught, warned about, and left switched off, which
+is how every other worker failure here already behaves.
 
 A factory rather than a `Worker`, because enabling tears down and rebuilds — an
 instance could only be used once. Takes precedence over `workerUrl`; Vite hosts keep

--- a/.changeset/points-preload-main-thread-comment.md
+++ b/.changeset/points-preload-main-thread-comment.md
@@ -7,9 +7,13 @@ worker: the per-batch work is a dictionary lookup and a typed-array copy".
 
 It is not. `streamPointsWithFeaturesByUrl` drives parquet-wasm's `ParquetFile` and
 `tableFromIPC` itself, on the main thread, and it is tried *before* the
-`isParquetWorkerEnabled()` gate — so on any element with a feature key and a progress
-callback (the normal case for a coloured points layer) the whole preload decodes on
-the main thread and the parquet worker never sees it.
+`isParquetWorkerEnabled()` gate.
+
+Scope matters here: that path is only taken where the store can serve streaming range
+reads. Where it cannot, the method bails and the worker path runs as normal. So the
+claim is not "points never use the worker" — it is that on a streaming-capable store,
+an element with a feature key and a progress callback (the normal case for a coloured
+points layer) decodes its whole preload on the main thread, worker enabled or not.
 
 Measured on a 4M-row capped preload of a five-part Xenium transcripts element: five
 ~700ms decodes, ~4.4s of long tasks, and zero `decodeParquetGeometryCapped` requests

--- a/.changeset/points-preload-main-thread-comment.md
+++ b/.changeset/points-preload-main-thread-comment.md
@@ -1,0 +1,18 @@
+---
+"@spatialdata/core": patch
+---
+
+Correct the comment on the progressive points preload, which claimed it "needs no
+worker: the per-batch work is a dictionary lookup and a typed-array copy".
+
+It is not. `streamPointsWithFeaturesByUrl` drives parquet-wasm's `ParquetFile` and
+`tableFromIPC` itself, on the main thread, and it is tried *before* the
+`isParquetWorkerEnabled()` gate — so on any element with a feature key and a progress
+callback (the normal case for a coloured points layer) the whole preload decodes on
+the main thread and the parquet worker never sees it.
+
+Measured on a 4M-row capped preload of a five-part Xenium transcripts element: five
+~700ms decodes, ~4.4s of long tasks, and zero `decodeParquetGeometryCapped` requests
+posted. Behaviour is unchanged here — this has been the shape since #89 — but the
+comment actively misled anyone looking for why enabling the worker does not stop a
+points layer blocking.

--- a/docs/docs/bundling.mdx
+++ b/docs/docs/bundling.mdx
@@ -117,11 +117,44 @@ upgrade.
 
 ## Other bundlers
 
-| Bundler       | How to get the worker URL                                                                                                                                                                                                  |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Vite / Rollup | `import workerUrl from '@spatialdata/core/parquet-worker?worker&url'` — verified in CI against a real production build                                                                                                        |
-| Others        | Use whatever your bundler provides for building a worker from a module (`new Worker(new URL(...))`, a worker rule, a plugin), then pass the URL it yields. Not exercised by our CI; check the worker and a `.wasm` both appear in your output. |
-| No bundler    | Nothing. `ensureWorkers()` with no `workerUrl` already resolves.                                                                                                                                                            |
+| Bundler       | How to wire it                                                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Vite / Rollup | `import workerUrl from '@spatialdata/core/parquet-worker?worker&url'`, then `ensureWorkers({ parquet: { workerUrl } })` — verified in CI against a real production build                                  |
+| webpack       | `createWorker` with a **local** entry file, below. This docs site does it, so every docs build exercises it.                                                                                             |
+| Others        | Whatever your bundler provides for building a worker from a module, then pass either a URL (`workerUrl`) or a factory (`createWorker`). Check the worker and a `.wasm` both appear in your output.        |
+| No bundler    | Nothing. `ensureWorkers()` with no options already resolves.                                                                                                                                            |
+
+### webpack, and `createWorker`
+
+webpack cannot hand you a URL for a *bundled* worker ahead of time: it only builds one
+when it can see the `new Worker(new URL(...))` form literally. So give it a factory
+instead of a URL:
+
+```ts
+ensureWorkers({
+  parquet: {
+    createWorker: () =>
+      new Worker(new URL('./parquetWorkerEntry.ts', import.meta.url), { type: 'module' }),
+  },
+});
+```
+
+That URL must point at a **local file in your own source**, which is one line:
+
+```ts
+// parquetWorkerEntry.ts
+import '@spatialdata/core/parquet-worker';
+```
+
+Pointing it straight at the bare specifier — `new URL('@spatialdata/core/parquet-worker',
+import.meta.url)` — does **not** work. webpack resolves it to core's published
+`dist/parquet-worker.js` and emits that file as a static asset, still carrying its
+relative imports to sibling chunks and a bare `apache-arrow`: 9 kB whose every import
+404s, the same shape of failure as copying the worker. Going through a local file makes
+webpack treat it as a worker entry and bundle the graph behind it.
+
+`createWorker` takes precedence over `workerUrl`. It is a factory rather than a `Worker`
+because enabling tears down and rebuilds — an instance could only be used once.
 
 ## Checking your build
 

--- a/docs/src/components/Sketch/index.tsx
+++ b/docs/src/components/Sketch/index.tsx
@@ -1,4 +1,33 @@
-import { Sketch } from '@spatialdata/vis';
+import { ensureWorkers, Sketch } from '@spatialdata/vis';
+
+/**
+ * The docs demo, with the parquet worker actually wired up.
+ *
+ * This site is the one place the "Bundling into an application" page is describing,
+ * so it should follow it. It did not: nothing called `ensureWorkers`, so every
+ * parquet decode on this page ran on the main thread — 4.1s of long tasks on the
+ * demo's shapes layer, 2.8s of it in a single task. With the worker wired that is
+ * 1.9s across 3 tasks, and `decodeShapesGeometry` goes off-thread.
+ *
+ * `createWorker` rather than `workerUrl` because Docusaurus builds with webpack, and
+ * webpack only *builds* a worker when it can see the `new Worker(new URL(...))` form
+ * literally — and only when the URL points at a local source file. Pointing it at the
+ * bare `@spatialdata/core/parquet-worker` specifier emits core's unbundled worker entry
+ * as a static asset instead, 9kB whose every import 404s, which is the failure the
+ * bundling page warns about. Hence the one-line `parquetWorkerEntry.ts` next door.
+ *
+ * Module-scope, not an effect: `ensureWorkers` is idempotent and attempts the worker
+ * once per page, and this component is already behind `<BrowserOnly>`, so there is no
+ * server render to guard against.
+ */
+ensureWorkers({
+  parquet: {
+    createWorker: () =>
+      new Worker(new URL('./parquetWorkerEntry.ts', import.meta.url), {
+        type: 'module',
+      }),
+  },
+});
 
 export default function DocsSketch() {
   return <Sketch />;

--- a/docs/src/components/Sketch/parquetWorkerEntry.ts
+++ b/docs/src/components/Sketch/parquetWorkerEntry.ts
@@ -1,0 +1,12 @@
+/**
+ * Worker entry for the docs site, existing only so webpack bundles core's parquet
+ * worker instead of copying it.
+ *
+ * `new Worker(new URL('@spatialdata/core/parquet-worker', import.meta.url))` does NOT
+ * work: webpack resolves the bare specifier to core's published `dist/parquet-worker.js`
+ * and emits that file as a static asset, still carrying its relative imports to sibling
+ * chunks and a bare `apache-arrow` — 9kB whose every import 404s. Pointing the URL at a
+ * *local source file* instead makes webpack treat it as a worker entry and bundle the
+ * graph behind it, parquet-wasm included.
+ */
+import '@spatialdata/core/parquet-worker';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,6 +99,7 @@ export * from './tooltip.js';
 export * from './types.js';
 export {
   disableParquetWorker,
+  type EnableParquetWorkerOptions,
   enableParquetWorker,
   ensureParquetWorker,
   filterColumnarByFeatureCodesInWorker,

--- a/packages/core/src/models/VPointsSource.ts
+++ b/packages/core/src/models/VPointsSource.ts
@@ -940,11 +940,26 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       }
     }
 
-    // Preferred progressive preload: stream geometry AND the feature column in the
-    // same batches, so points paint already coloured. Tried before the row-group
-    // path because that one cannot read a dictionary feature column at all — the
-    // case where colour otherwise waits for a whole separate decode. Needs no
-    // worker: the per-batch work is a dictionary lookup and a typed-array copy.
+    // Progressive preload: stream geometry AND the feature column in the same
+    // batches, so points paint already coloured. Tried before the row-group path
+    // because that one cannot read a dictionary feature column at all — the case
+    // where colour otherwise waits for a whole separate decode.
+    //
+    // WARNING: this runs BEFORE the worker gate below and decodes ON THE MAIN
+    // THREAD. `streamPointsWithFeaturesByUrl` drives parquet-wasm's `ParquetFile`
+    // and `tableFromIPC` itself; only the per-batch *bookkeeping* after that is the
+    // dictionary lookup and typed-array copy this comment used to claim was all of
+    // it. So on any element with a feature key and a progress callback — the normal
+    // case for a coloured points layer — the whole preload decodes on the main
+    // thread and the parquet worker never sees it, enabled or not.
+    //
+    // Measured on a 4M-row capped preload of a 5-part Xenium transcripts element:
+    // five ~700ms decodes, ~4.4s of long tasks, zero `decodeParquetGeometryCapped`
+    // requests posted. Not a regression — this has been the shape since #89 — but
+    // it is why enabling the worker does not make a points layer stop blocking.
+    // Fixing it means decoding these batches in the worker or gating this path on
+    // the worker being unavailable; both change what paints when, so neither is a
+    // drive-by. See the investigation in this branch before changing the order.
     if (options.onProgress && featureKey) {
       try {
         const streamed = await this.streamPointsWithFeaturesByUrl(parquetPath, {

--- a/packages/core/src/models/VPointsSource.ts
+++ b/packages/core/src/models/VPointsSource.ts
@@ -945,20 +945,28 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
     // because that one cannot read a dictionary feature column at all — the case
     // where colour otherwise waits for a whole separate decode.
     //
-    // WARNING: this runs BEFORE the worker gate below and decodes ON THE MAIN
-    // THREAD. `streamPointsWithFeaturesByUrl` drives parquet-wasm's `ParquetFile`
-    // and `tableFromIPC` itself; only the per-batch *bookkeeping* after that is the
-    // dictionary lookup and typed-array copy this comment used to claim was all of
-    // it. So on any element with a feature key and a progress callback — the normal
-    // case for a coloured points layer — the whole preload decodes on the main
-    // thread and the parquet worker never sees it, enabled or not.
+    // WARNING: when this path is TAKEN it runs BEFORE the worker gate below and
+    // decodes ON THE MAIN THREAD. `streamPointsWithFeaturesByUrl` drives
+    // parquet-wasm's `ParquetFile` and `tableFromIPC` itself; only the per-batch
+    // *bookkeeping* after that is the dictionary lookup and typed-array copy this
+    // comment used to claim was all of it.
     //
-    // Measured on a 4M-row capped preload of a 5-part Xenium transcripts element:
-    // five ~700ms decodes, ~4.4s of long tasks, zero `decodeParquetGeometryCapped`
-    // requests posted. Not a regression — this has been the shape since #89 — but
-    // it is why enabling the worker does not make a points layer stop blocking.
-    // Fixing it means decoding these batches in the worker or gating this path on
-    // the worker being unavailable; both change what paints when, so neither is a
+    // It is taken only where the store can serve streaming range reads — see the
+    // four `return null` bails at the top of that method (no url-streaming support,
+    // no parts, a part whose URL will not range-read, no `ParquetFile`). Anywhere it
+    // bails, control falls through and the worker path below runs normally. So this
+    // is not "the worker is never used for points"; it is "on a store that supports
+    // streaming, an element with a feature key and a progress callback — the normal
+    // case for a coloured points layer — decodes its whole preload on the main
+    // thread, whether or not the worker is enabled".
+    //
+    // Measured on such a store, a 4M-row capped preload of a 5-part Xenium
+    // transcripts element: five ~700ms decodes, ~4.4s of long tasks, zero
+    // `decodeParquetGeometryCapped` requests posted. Not a regression — this has
+    // been the shape since #89 — but it is why enabling the worker does not make
+    // that points layer stop blocking. Fixing it means decoding these batches in
+    // the worker; gating this path on the worker instead only trades a frozen tab
+    // for a blank one, since the progressive paint is what it buys. Neither is a
     // drive-by. See the investigation in this branch before changing the order.
     if (options.onProgress && featureKey) {
       try {

--- a/packages/core/src/parquetWasmLoader.ts
+++ b/packages/core/src/parquetWasmLoader.ts
@@ -149,8 +149,8 @@ async function initializeParquetModule(module: unknown) {
   // throws a TypeError — in the very build that exists to serve Node. Fall through to
   // the async init instead of crashing. (The CJS build also resolves `node:*` to
   // browser stubs, so this branch could not have worked there regardless.)
-  const moduleUrl: string | undefined = (import.meta as { url?: string }).url;
-  if (isNodeRuntime && typeof initSync === 'function' && moduleUrl) {
+  const moduleUrl: unknown = import.meta.url;
+  if (isNodeRuntime && typeof initSync === 'function' && typeof moduleUrl === 'string') {
     const [{ readFileSync }, { fileURLToPath }, { dirname, join }] = await Promise.all([
       import('node:fs'),
       import('node:url'),

--- a/packages/core/src/parquetWasmLoader.ts
+++ b/packages/core/src/parquetWasmLoader.ts
@@ -144,14 +144,20 @@ async function initializeParquetModule(module: unknown) {
     process.versions?.node != null &&
     typeof window === 'undefined';
 
-  if (isNodeRuntime && typeof initSync === 'function') {
+  // No base URL, no disk path. This package's CJS output has `import.meta` replaced
+  // with `{}`, so `import.meta.url` is `undefined` there and `fileURLToPath(undefined)`
+  // throws a TypeError — in the very build that exists to serve Node. Fall through to
+  // the async init instead of crashing. (The CJS build also resolves `node:*` to
+  // browser stubs, so this branch could not have worked there regardless.)
+  const moduleUrl: string | undefined = (import.meta as { url?: string }).url;
+  if (isNodeRuntime && typeof initSync === 'function' && moduleUrl) {
     const [{ readFileSync }, { fileURLToPath }, { dirname, join }] = await Promise.all([
       import('node:fs'),
       import('node:url'),
       import('node:path'),
     ]);
     const wasmPath = join(
-      dirname(fileURLToPath(import.meta.url)),
+      dirname(fileURLToPath(moduleUrl)),
       '../vendor/parquet-wasm/parquet_wasm_bg.wasm'
     );
     initSync({ module: readFileSync(wasmPath) });

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -7,6 +7,7 @@ export {
   decodeParquetRowFeatureCodesInWorker,
   decodeShapesGeometryInWorker,
   disableParquetWorker,
+  type EnableParquetWorkerOptions,
   enableParquetWorker,
   ensureParquetWorker,
   filterColumnarByFeatureCodesInWorker,

--- a/packages/core/src/workers/parquetWorkerClient.ts
+++ b/packages/core/src/workers/parquetWorkerClient.ts
@@ -191,6 +191,38 @@ function transferablesForRequest(request: ParquetWorkerRequest): Transferable[] 
   return [];
 }
 
+export type EnableParquetWorkerOptions = {
+  /**
+   * Where the worker bundle lives, from an import your bundler resolves. In Vite:
+   * `import workerUrl from '@spatialdata/core/parquet-worker?worker&url'`.
+   *
+   * Omit only when core is loaded as published ESM without being re-bundled — a dev
+   * server, an import map, a CDN — where `dist/parquet-worker.js` really does sit
+   * next to the chunk asking for it.
+   */
+  workerUrl?: string | URL;
+  /**
+   * Build the Worker yourself, for bundlers that cannot hand back a URL for a
+   * *bundled* worker. webpack is the case this exists for: it only builds a worker
+   * when it can see the `new Worker(new URL(...))` form, and a bare `new URL()` on a
+   * module emits the unbundled source as a static asset instead — 11kB whose every
+   * import 404s.
+   *
+   * ```ts
+   * enableParquetWorker({
+   *   createWorker: () =>
+   *     new Worker(new URL('@spatialdata/core/parquet-worker', import.meta.url), {
+   *       type: 'module',
+   *     }),
+   * });
+   * ```
+   *
+   * A factory rather than a `Worker`, because enabling tears down and rebuilds: an
+   * instance could only be used once. Takes precedence over {@link workerUrl}.
+   */
+  createWorker?: () => Worker;
+};
+
 /**
  * The published `dist/parquet-worker.js`, resolved at runtime — correct wherever core
  * is loaded as published ESM (dev server, import map, CDN). A bundled application
@@ -231,7 +263,7 @@ export function isParquetWorkerEnabled(): boolean {
  * `loadPointsMatchingFeatureCodes`, which has no main-thread fallback and throws.
  * Gate any UI for it on {@link isParquetWorkerEnabled}.
  */
-export function enableParquetWorker(options: { workerUrl?: string | URL } = {}) {
+export function enableParquetWorker(options: EnableParquetWorkerOptions = {}) {
   if (typeof Worker === 'undefined') {
     return;
   }
@@ -241,7 +273,9 @@ export function enableParquetWorker(options: { workerUrl?: string | URL } = {}) 
   // A fresh attempt, even after a dead worker latched `ensureParquetWorker` off.
   startupFailed = false;
   workerHasAnswered = false;
-  if (options.workerUrl) {
+  if (options.createWorker) {
+    worker = options.createWorker();
+  } else if (options.workerUrl) {
     worker = new Worker(options.workerUrl, { type: 'module' });
   } else {
     worker = new Worker(defaultWorkerUrl(), { type: 'module' });
@@ -273,7 +307,7 @@ export function setParquetWorkerDefaultEnabled(value: boolean) {
   defaultEnabled = value;
 }
 
-export function ensureParquetWorker(options: { workerUrl?: string | URL } = {}) {
+export function ensureParquetWorker(options: EnableParquetWorkerOptions = {}) {
   if (!enabled && defaultEnabled && !startupFailed) {
     enableParquetWorker(options);
   }

--- a/packages/core/src/workers/parquetWorkerClient.ts
+++ b/packages/core/src/workers/parquetWorkerClient.ts
@@ -204,18 +204,28 @@ export type EnableParquetWorkerOptions = {
   /**
    * Build the Worker yourself, for bundlers that cannot hand back a URL for a
    * *bundled* worker. webpack is the case this exists for: it only builds a worker
-   * when it can see the `new Worker(new URL(...))` form, and a bare `new URL()` on a
-   * module emits the unbundled source as a static asset instead — 11kB whose every
-   * import 404s.
+   * when it can see the `new Worker(new URL(...))` form literally, and only when that
+   * URL points at a file in your own source.
+   *
+   * ```ts
+   * // parquetWorkerEntry.ts — one line, in YOUR source tree
+   * import '@spatialdata/core/parquet-worker';
+   * ```
    *
    * ```ts
    * enableParquetWorker({
    *   createWorker: () =>
-   *     new Worker(new URL('@spatialdata/core/parquet-worker', import.meta.url), {
+   *     new Worker(new URL('./parquetWorkerEntry.ts', import.meta.url), {
    *       type: 'module',
    *     }),
    * });
    * ```
+   *
+   * The local file is not ceremony. Pointing the URL straight at the bare specifier —
+   * `new URL('@spatialdata/core/parquet-worker', import.meta.url)` — resolves to this
+   * package's published `dist/parquet-worker.js` and makes webpack emit *that file* as
+   * a static asset, still carrying its relative imports to sibling chunks and a bare
+   * `apache-arrow`: 9kB whose every import 404s. Measured, not theorised.
    *
    * A factory rather than a `Worker`, because enabling tears down and rebuilds: an
    * instance could only be used once. Takes precedence over {@link workerUrl}.
@@ -240,8 +250,11 @@ function defaultWorkerUrl(): URL | undefined {
   // `import.meta` is replaced with `{}` in this package's CJS output, so there is no
   // base to resolve against and `new URL(x, undefined)` throws `Invalid URL`. A CJS
   // host has to pass `workerUrl` or `createWorker`; say so rather than throw.
-  const base: string | undefined = (import.meta as { url?: string }).url;
-  if (!base) {
+  // Read through `unknown` rather than asserting a shape: the cjs build replaces
+  // `import.meta` with `{}`, so this genuinely may not be a string at runtime and the
+  // type should say so rather than be talked out of it.
+  const base: unknown = import.meta.url;
+  if (typeof base !== 'string') {
     return undefined;
   }
   return new URL(/* @vite-ignore */ './parquet-worker.js', base);
@@ -280,22 +293,39 @@ export function enableParquetWorker(options: EnableParquetWorkerOptions = {}) {
   // A fresh attempt, even after a dead worker latched `ensureParquetWorker` off.
   startupFailed = false;
   workerHasAnswered = false;
-  if (options.createWorker) {
-    worker = options.createWorker();
-  } else if (options.workerUrl) {
-    worker = new Worker(options.workerUrl, { type: 'module' });
-  } else {
-    const url = defaultWorkerUrl();
-    if (!url) {
-      startupFailed = true;
-      console.warn(
-        '[@spatialdata/core] no default parquet worker URL is available in a CommonJS ' +
-          'build; pass enableParquetWorker({ workerUrl }) or ({ createWorker }). ' +
-          'Continuing on the main thread.'
-      );
-      return;
+  // Constructing a Worker can throw synchronously — a `createWorker` factory is host
+  // code, and `new Worker` itself throws on a URL the browser rejects or a CSP that
+  // forbids it. Everything else here treats a bad worker as a performance cost rather
+  // than a failure, and a throw would break that promise by taking out the caller's
+  // render instead. Degrade the same way a dead worker does.
+  try {
+    if (options.createWorker) {
+      worker = options.createWorker();
+    } else if (options.workerUrl) {
+      worker = new Worker(options.workerUrl, { type: 'module' });
+    } else {
+      const url = defaultWorkerUrl();
+      if (!url) {
+        startupFailed = true;
+        console.warn(
+          '[@spatialdata/core] no default parquet worker URL is available in a CommonJS ' +
+            'build; pass enableParquetWorker({ workerUrl }) or ({ createWorker }). ' +
+            'Continuing on the main thread.'
+        );
+        return;
+      }
+      worker = new Worker(url, { type: 'module' });
     }
-    worker = new Worker(url, { type: 'module' });
+  } catch (error) {
+    worker = undefined;
+    enabled = false;
+    startupFailed = true;
+    console.warn(
+      `[@spatialdata/core] parquet worker could not be constructed (${
+        error instanceof Error ? error.message : String(error)
+      }); continuing on the main thread.`
+    );
+    return;
   }
   ensureWorkerListener();
   enabled = true;

--- a/packages/core/src/workers/parquetWorkerClient.ts
+++ b/packages/core/src/workers/parquetWorkerClient.ts
@@ -236,8 +236,15 @@ export type EnableParquetWorkerOptions = {
  * a self-contained worker. This one imports sibling chunks and bare `apache-arrow`,
  * so it emitted 11.5kB whose every import 404s.
  */
-function defaultWorkerUrl(): URL {
-  return new URL(/* @vite-ignore */ './parquet-worker.js', import.meta.url);
+function defaultWorkerUrl(): URL | undefined {
+  // `import.meta` is replaced with `{}` in this package's CJS output, so there is no
+  // base to resolve against and `new URL(x, undefined)` throws `Invalid URL`. A CJS
+  // host has to pass `workerUrl` or `createWorker`; say so rather than throw.
+  const base: string | undefined = (import.meta as { url?: string }).url;
+  if (!base) {
+    return undefined;
+  }
+  return new URL(/* @vite-ignore */ './parquet-worker.js', base);
 }
 
 export function isParquetWorkerEnabled(): boolean {
@@ -278,7 +285,17 @@ export function enableParquetWorker(options: EnableParquetWorkerOptions = {}) {
   } else if (options.workerUrl) {
     worker = new Worker(options.workerUrl, { type: 'module' });
   } else {
-    worker = new Worker(defaultWorkerUrl(), { type: 'module' });
+    const url = defaultWorkerUrl();
+    if (!url) {
+      startupFailed = true;
+      console.warn(
+        '[@spatialdata/core] no default parquet worker URL is available in a CommonJS ' +
+          'build; pass enableParquetWorker({ workerUrl }) or ({ createWorker }). ' +
+          'Continuing on the main thread.'
+      );
+      return;
+    }
+    worker = new Worker(url, { type: 'module' });
   }
   ensureWorkerListener();
   enabled = true;

--- a/packages/core/tests/parquetWorkerConstruction.spec.ts
+++ b/packages/core/tests/parquetWorkerConstruction.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  disableParquetWorker,
+  enableParquetWorker,
+  isParquetWorkerEnabled,
+} from '../src/workers/parquetWorkerClient.js';
+
+/**
+ * Constructing a Worker can throw synchronously, and everything else in this client
+ * treats a bad worker as a performance cost rather than a failure — a dead worker is
+ * detected, switched off, and callers take their main-thread fallbacks.
+ *
+ * A throwing constructor used to break that promise by propagating out of
+ * `enableParquetWorker`, and therefore out of `ensureWorkers`, taking the caller's
+ * render with it. Two ways it happens in practice: a host `createWorker` factory that
+ * throws, and `new Worker` itself rejecting a URL or being refused by CSP.
+ */
+const g = globalThis as unknown as Record<string, unknown>;
+
+afterEach(() => {
+  disableParquetWorker();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('enableParquetWorker construction failures', () => {
+  it('does not throw when a createWorker factory throws', () => {
+    vi.stubGlobal(
+      'Worker',
+      class {
+        terminate() {}
+      }
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() =>
+      enableParquetWorker({
+        createWorker: () => {
+          throw new Error('bundler produced no worker');
+        },
+      })
+    ).not.toThrow();
+
+    expect(isParquetWorkerEnabled()).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    // The reason has to survive into the message, or this is undebuggable.
+    expect(String(warn.mock.calls[0]?.[0])).toContain('bundler produced no worker');
+  });
+
+  it('does not throw when the Worker constructor itself throws', () => {
+    vi.stubGlobal(
+      'Worker',
+      class {
+        constructor() {
+          throw new Error('refused by CSP');
+        }
+      }
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => enableParquetWorker({ workerUrl: 'https://example.invalid/w.js' })).not.toThrow();
+
+    expect(isParquetWorkerEnabled()).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('leaves the worker off rather than half-enabled', () => {
+    vi.stubGlobal(
+      'Worker',
+      class {
+        constructor() {
+          throw new Error('nope');
+        }
+      }
+    );
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    enableParquetWorker({ createWorker: () => new (g.Worker as new () => Worker)() });
+
+    // `isParquetWorkerEnabled` is `enabled && worker !== undefined`; a construction
+    // failure must clear both, so callers with no fallback fail fast and loudly
+    // instead of posting into a worker that is not there.
+    expect(isParquetWorkerEnabled()).toBe(false);
+  });
+});

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -64,6 +64,12 @@ export default defineConfig({
   resolve: {
     alias: createWorkspaceSourceAliases(resolve(__dirname, '../..')),
   },
+  // NOTE: the cjs pass warns EMPTY_IMPORT_META twice, and that is expected. It
+  // replaces `import.meta` with `{}`, which both call sites now rely on: each reads
+  // `import.meta.url` into a variable and checks it, so `undefined` there means "no
+  // module URL in this build" rather than a crash. Rolldown's suggested
+  // `transform.define` suppression is not reachable through Vite's config in v8 —
+  // passing it here changes nothing — so the warning stays until it is.
   build: {
     lib: {
       entry: {

--- a/packages/vis/src/workers.ts
+++ b/packages/vis/src/workers.ts
@@ -19,11 +19,20 @@ export type EnsureParquetWorkerOptions = {
    * *bundled* worker — webpack is the case this exists for. Takes precedence over
    * {@link workerUrl}; see `enableParquetWorker` in core for the why.
    *
+   * The URL must point at a one-line entry file in YOUR source, not at the bare
+   * `@spatialdata/core/parquet-worker` specifier — that makes webpack emit core's
+   * published worker entry as an unbundled static asset whose every import 404s.
+   *
+   * ```ts
+   * // parquetWorkerEntry.ts
+   * import '@spatialdata/core/parquet-worker';
+   * ```
+   *
    * ```ts
    * ensureWorkers({
    *   parquet: {
    *     createWorker: () =>
-   *       new Worker(new URL('@spatialdata/core/parquet-worker', import.meta.url), {
+   *       new Worker(new URL('./parquetWorkerEntry.ts', import.meta.url), {
    *         type: 'module',
    *       }),
    *   },

--- a/packages/vis/src/workers.ts
+++ b/packages/vis/src/workers.ts
@@ -15,6 +15,23 @@ export type EnsureParquetWorkerOptions = {
    */
   workerUrl?: string | URL;
   /**
+   * Build the Worker yourself, for bundlers that cannot hand back a URL for a
+   * *bundled* worker — webpack is the case this exists for. Takes precedence over
+   * {@link workerUrl}; see `enableParquetWorker` in core for the why.
+   *
+   * ```ts
+   * ensureWorkers({
+   *   parquet: {
+   *     createWorker: () =>
+   *       new Worker(new URL('@spatialdata/core/parquet-worker', import.meta.url), {
+   *         type: 'module',
+   *       }),
+   *   },
+   * });
+   * ```
+   */
+  createWorker?: () => Worker;
+  /**
    * Per-request budget before a silent worker is treated as stuck and the caller
    * falls back to the main thread. Defaults to 30s; a large transcripts decode
    * legitimately runs longer than that.
@@ -51,7 +68,10 @@ function ensureParquetWorker(options: EnsureParquetWorkerOptions): boolean {
   }
   if (!parquetAttempted) {
     parquetAttempted = true;
-    enableParquetWorker({ workerUrl: options.workerUrl });
+    enableParquetWorker({
+      ...(options.workerUrl ? { workerUrl: options.workerUrl } : {}),
+      ...(options.createWorker ? { createWorker: options.createWorker } : {}),
+    });
     if (options.requestTimeoutMs !== undefined) {
       setParquetWorkerRequestTimeout(options.requestTimeoutMs);
     }


### PR DESCRIPTION
Three fixes that came out of diagnosing why enabling the parquet worker does not stop a points layer blocking the main thread. None of them changes what the library computes; two of them change what a consumer can actually wire up.

## `createWorker`

`enableParquetWorker` / `ensureWorkers` now accept a worker factory as well as a URL.

webpack only builds a worker when it can see the `new Worker(new URL(...))` form literally, so there is no URL to hand back ahead of time — `workerUrl` had no answer for it, and the "Other bundlers" row of `bundling.mdx` was advice nobody could follow. A factory rather than a `Worker` because enabling tears down and rebuilds; an instance could only be used once. It takes precedence over `workerUrl`, and Vite hosts keep the `?worker&url` import unchanged.

## The docs demo now starts the worker

It never has. Nothing on the site called `ensureWorkers`, so the one application the bundling page is describing ran **every parquet decode on the main thread**. `git log -S` confirms this was never wired, so it is long-standing rather than a regression.

Measured on the demo's `square_008um` shapes layer, before → after:

| | before | after |
|---|---|---|
| long tasks | 4,140 ms / 2 tasks | **1,939 ms / 3 tasks** |
| worst single task | 2,780 ms | **1,627 ms** |
| worker requests | 0 | `decodeShapesGeometry` |
| warnings | — | none |

The URL has to point at a **local** one-line entry file. Pointing it at the bare `@spatialdata/core/parquet-worker` specifier makes webpack emit core's published worker entry as a static asset, still carrying its relative sibling imports and a bare `apache-arrow` — 9 kB whose every import 404s, the same shape of failure as copying the worker. `bundling.mdx` documents both, and gains a webpack row and a `createWorker` section.

Because the docs build runs in CI, the webpack path is now exercised on every build rather than being untested advice.

## `import.meta` in the cjs build

The cjs pass replaces `import.meta` with `{}`, so `import.meta.url` is `undefined`. Two sites used it unguarded, both in code that exists to serve Node — the one runtime the cjs build is for:

- the parquet-wasm loader's Node branch called `fileURLToPath(undefined)` — a `TypeError` on the first parquet read;
- `defaultWorkerUrl()` called `new URL('./parquet-worker.js', undefined)`, so `enableParquetWorker()` with no `workerUrl` threw `Invalid URL` instead of using its default.

Both now read the URL into a variable and check it. Verified against the built cjs: `{}.url` no longer appears in the output.

Two things this does **not** do. `EMPTY_IMPORT_META` still warns twice — that is now the expected, handled case, and rolldown's suggested `transform.define` suppression is not reachable through Vite 8's config (passing it changes nothing), so it is a comment in `packages/core/vite.config.ts` rather than dead config. And the cjs entry still cannot be `require`d at all: `anndata.js` publishes no CommonJS export, so resolution fails long before any of this. These guards are correctness for when that is fixed, not a claim that the cjs build works today.

## A comment that was actively misleading

`loadPoints` tries `streamPointsWithFeaturesByUrl` **before** the `isParquetWorkerEnabled()` gate, under a comment claiming it "needs no worker: the per-batch work is a dictionary lookup and a typed-array copy". It drives parquet-wasm's `ParquetFile` and `tableFromIPC` itself, on the main thread.

Measured two ways, both on a 4M-row capped preload of a Xenium transcripts element.

In a consumer app: five ~700 ms decodes, ~4.4 s of long tasks, zero `decodeParquetGeometryCapped` requests posted.

And in **this repo's own demo**, once the worker is wired by this PR — so the worker is provably up, and `decodeShapesGeometry` routes to it normally — enabling the points layer gives **48,661 ms of main-thread blocking across 20 long tasks** (worst: 13,215 / 9,032 / 5,261 / 4,631 / 4,311 ms) and **one** worker request, `decodeParquetRowFeatureCodes`, at the very end. Roughly the first 24 s is this path; the rest is the unvirtualized feature list, split out as #172.

That is why enabling the worker does not make a points layer stop blocking: the preload simply goes around it.

**Behaviour is deliberately unchanged here** — `git diff` against the 0.8.0 release shows this path is untouched since #89, so it is not a regression and not something to change quietly. Fixing it for real means either decoding those batches in the worker or gating the path on the worker being unavailable, and both change what paints when. The comment now says what the code does, with the measurement, so the next person does not lose an afternoon to it.

Worth noting one option that looks tempting and is not: simply moving the block below the worker gate. That trades a frozen tab for a blank one — today `onProgress` paints coloured points after roughly one part (~1-2 s), and a single `decodeGeometryWithFeaturesInWorker` over the whole capped payload would show nothing until it finishes. The fix without a trade is for the worker to do the range-streaming and post batches back, which the current protocol cannot express (`pending` is one response per request). That deserves its own PR.

## Verification

- 1,022 tests green (zarrextra 39, avivatorish 38, core 501, react 7, layers 258, vis 179)
- full monorepo build green; docs build green
- docs demo verified in a real local production build: worker chunk emitted, loaded at runtime, `decodeShapesGeometry` routed to it, console clean
- biome clean
- consumer-side smoke test: MDV built against this branch via `pnpm link:spatialdata` — one hashed `parquet_wasm_bg.wasm`, the `parquet-worker` chunk, no `vendor/`

Three changesets: `minor` for core + vis (`createWorker`), `patch` for core (the comment), `patch` for core (the import.meta guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom worker factories, improving Parquet worker setup with webpack and other bundlers.
  * Added public configuration types for worker URLs and worker creation.
* **Bug Fixes**
  * Improved CommonJS compatibility by safely handling unavailable `import.meta.url` values and falling back to asynchronous initialization.
* **Documentation**
  * Updated bundling guidance for Vite, webpack, other bundlers, and no-bundler setups.
  * Clarified progressive points preload behavior and main-thread decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
