### PR TITLE
Stream the points preload in the parquet worker

### DIFF
--- a/.changeset/parquet-worker-streaming-preload.md
+++ b/.changeset/parquet-worker-streaming-preload.md
@@ -6,29 +6,39 @@ Stream the progressive points preload in the parquet worker
 
 A points layer coloured by feature took its preload through
 `streamPointsWithFeaturesByUrl`, which drives parquet-wasm's `ParquetFile.stream()`
-and `tableFromIPC` **on the main thread** — and did so from above the worker gate, so
-enabling the parquet worker made no difference to it. On a 4M-row Xenium transcripts
-element that is five ~700ms decodes and ~4.4s of long tasks on a small panel, and
-tens of seconds of them on a wide one, with zero requests reaching the worker.
+and `tableFromIPC` **on the main thread** — from above the worker gate, so enabling
+the parquet worker made no difference to it.
 
-The same stream now runs end to end in the worker: it range-fetches each part
-itself and posts batches back as it decodes them, so the progressive coloured paint
-is preserved while the main thread only copies each batch into its accumulator. The
-main-thread stream stays as the fallback for hosts that have not wired a worker
-bundle, and for a stream that fails part way through.
+Measured in the docs demo on a 4.83M-row Xenium transcripts element with a
+12,448-feature panel, capped at 4M rows:
 
-This needed the worker protocol to carry more than one message per request, which is
-new:
+| | before | after |
+| --- | --- | --- |
+| worker requests | **zero** | 62 batches, 4M rows |
+| preload completes | **never** (9.4 min, still going) | 75 s |
+| worst single task | 113 s / 93 s / 90 s | ~4.2 s |
+| long tasks to that point | 543 s and climbing | 63 s |
 
-- `ParquetWorkerMessage` gains a `direction: 'stream'` interim variant, alongside the
-  terminal `response` every request type already posts. Interim messages do not
-  settle the request.
+The same stream now runs end to end in the worker: it range-fetches each part itself
+and posts batches back as it decodes them, so the progressive coloured paint is
+preserved while the main thread only copies each batch into its accumulator. The
+main-thread stream stays as the fallback for hosts without a worker bundle, and for a
+stream that fails part way through.
+
+Necessary but not sufficient for that dataset: the feature column is a dictionary, so
+batch one already names all 12,448 features, and every progress tick then re-renders
+the unvirtualized feature list of #172, which dominates what is left.
+
+This needed the worker protocol to carry more than one message per request:
+
+- `ParquetWorkerMessage` gains a `direction: 'stream'` interim variant alongside the
+  terminal `response`. Interim messages do not settle the request.
 - The per-request timeout (`setParquetWorkerRequestTimeout`) now measures time since
   the **last message** rather than time to the only response. Unchanged for
   request/response types, where exactly one message ever arrives; without it a
   minutes-long stream would look stuck.
-- A new `cancelParquetStream` request stops the worker fetching when a load is
-  superseded or the client gives up, instead of only stopping the client listening.
+- A new `cancelParquetStream` request stops the worker *fetching* when a load is
+  superseded or the client gives up, not just the client listening.
 
 A stream that fails after delivering batches rejects rather than reporting a partial
 as success — nothing downstream can tell a truncated preload from a complete one —

--- a/.changeset/parquet-worker-streaming-preload.md
+++ b/.changeset/parquet-worker-streaming-preload.md
@@ -1,0 +1,35 @@
+---
+'@spatialdata/core': minor
+---
+
+Stream the progressive points preload in the parquet worker
+
+A points layer coloured by feature took its preload through
+`streamPointsWithFeaturesByUrl`, which drives parquet-wasm's `ParquetFile.stream()`
+and `tableFromIPC` **on the main thread** — and did so from above the worker gate, so
+enabling the parquet worker made no difference to it. On a 4M-row Xenium transcripts
+element that is five ~700ms decodes and ~4.4s of long tasks on a small panel, and
+tens of seconds of them on a wide one, with zero requests reaching the worker.
+
+The same stream now runs end to end in the worker: it range-fetches each part
+itself and posts batches back as it decodes them, so the progressive coloured paint
+is preserved while the main thread only copies each batch into its accumulator. The
+main-thread stream stays as the fallback for hosts that have not wired a worker
+bundle, and for a stream that fails part way through.
+
+This needed the worker protocol to carry more than one message per request, which is
+new:
+
+- `ParquetWorkerMessage` gains a `direction: 'stream'` interim variant, alongside the
+  terminal `response` every request type already posts. Interim messages do not
+  settle the request.
+- The per-request timeout (`setParquetWorkerRequestTimeout`) now measures time since
+  the **last message** rather than time to the only response. Unchanged for
+  request/response types, where exactly one message ever arrives; without it a
+  minutes-long stream would look stuck.
+- A new `cancelParquetStream` request stops the worker fetching when a load is
+  superseded or the client gives up, instead of only stopping the client listening.
+
+A stream that fails after delivering batches rejects rather than reporting a partial
+as success — nothing downstream can tell a truncated preload from a complete one —
+and the caller restarts on the main thread.

--- a/.changeset/parquet-worker-streaming-preload.md
+++ b/.changeset/parquet-worker-streaming-preload.md
@@ -4,42 +4,38 @@
 
 Stream the progressive points preload in the parquet worker
 
-A points layer coloured by feature took its preload through
-`streamPointsWithFeaturesByUrl`, which drives parquet-wasm's `ParquetFile.stream()`
-and `tableFromIPC` **on the main thread** — from above the worker gate, so enabling
-the parquet worker made no difference to it.
+A points layer coloured by feature ran its preload through
+`streamPointsWithFeaturesByUrl` — parquet-wasm's `ParquetFile.stream()` and
+`tableFromIPC` **on the main thread**, from above the worker gate, so enabling the
+parquet worker made no difference to it. It now range-fetches and decodes in the
+worker, posting batches back as they land, so the progressive coloured paint survives
+while the main thread only copies each batch into its accumulator.
 
-Measured in the docs demo on a 4.83M-row Xenium transcripts element with a
-12,448-feature panel, capped at 4M rows:
+Docs demo, 4.83M-row Xenium transcripts element with a 12,448-feature panel, capped at
+4M rows:
 
 | | before | after |
 | --- | --- | --- |
 | worker requests | **zero** | 62 batches, 4M rows |
 | preload completes | **never** (9.4 min, still going) | 75 s |
-| worst single task | 113 s / 93 s / 90 s | ~4.2 s |
+| worst single task | 113 s | ~4.2 s |
 | long tasks to that point | 543 s and climbing | 63 s |
 
-The same stream now runs end to end in the worker: it range-fetches each part itself
-and posts batches back as it decodes them, so the progressive coloured paint is
-preserved while the main thread only copies each batch into its accumulator. The
-main-thread stream stays as the fallback for hosts without a worker bundle, and for a
-stream that fails part way through.
+Not sufficient on its own: the dictionary feature column names all 12,448 features in
+batch one, so every progress tick re-renders the unvirtualized feature list of #172,
+which dominates what is left.
 
-Necessary but not sufficient for that dataset: the feature column is a dictionary, so
-batch one already names all 12,448 features, and every progress tick then re-renders
-the unvirtualized feature list of #172, which dominates what is left.
-
-This needed the worker protocol to carry more than one message per request:
+New in the worker protocol, which now carries more than one message per request:
 
 - `ParquetWorkerMessage` gains a `direction: 'stream'` interim variant alongside the
   terminal `response`. Interim messages do not settle the request.
-- The per-request timeout (`setParquetWorkerRequestTimeout`) now measures time since
-  the **last message** rather than time to the only response. Unchanged for
-  request/response types, where exactly one message ever arrives; without it a
-  minutes-long stream would look stuck.
-- A new `cancelParquetStream` request stops the worker *fetching* when a load is
-  superseded or the client gives up, not just the client listening.
+- `setParquetWorkerRequestTimeout` now measures time since the **last message**, not
+  time to the only response — unchanged for request/response types, where one message
+  ever arrives, but without it a minutes-long stream looks stuck.
+- A new `cancelParquetStream` request stops the worker *fetching*, not just the client
+  listening.
 
-A stream that fails after delivering batches rejects rather than reporting a partial
-as success — nothing downstream can tell a truncated preload from a complete one —
-and the caller restarts on the main thread.
+The main-thread stream stays as the fallback for hosts without a worker bundle. A
+stream that fails after delivering batches rejects rather than reporting a partial as
+success — nothing downstream can tell a truncated preload from a complete one — and
+the caller restarts there from row 0.

--- a/packages/core/src/models/VPointsSource.ts
+++ b/packages/core/src/models/VPointsSource.ts
@@ -988,23 +988,22 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
     // the case where colour otherwise waits for a whole separate decode.
     //
     // Two implementations of the same stream, worker first. They produce the same
-    // result; the difference is only WHERE the parquet decode runs, and that
-    // difference is the point. The main-thread one drives `ParquetFile.stream()` and
-    // `tableFromIPC` on the UI thread. The worker one range-fetches and decodes
-    // off-thread and posts batches back, so the main thread only copies each batch
-    // into its accumulator.
+    // result; the difference is only WHERE the parquet decode runs. The main-thread
+    // one drives `ParquetFile.stream()` and `tableFromIPC` on the UI thread; the
+    // worker one range-fetches and decodes off-thread and posts batches back, so the
+    // main thread only copies each batch into its accumulator.
     //
-    // Measured on a 4-part Xenium transcripts element (12.2M rows, capped at 4M,
-    // 541-gene panel) in the docs demo: the main-thread stream reaches 4M rows at
-    // ~3.6s having spent ~2.8s of that window in long tasks — a thread ~78% busy —
-    // while the worker one delivers 62 batches and all 4M rows by ~1.6s for ~0.8s of
-    // long tasks. The load-phase blocking is the part this moves; total per-session
-    // blocking barely shifts, because what is left is downstream of the preload
-    // (feature-code settling, rendering 4M points, and the unvirtualized feature
-    // list of #172). On the wide panels where the reported freezes come from — 12k+
-    // features — the gap should be far larger, since the per-batch catalog rebuild
-    // this path used to do scales with the panel and is now memoised; that regime is
-    // NOT reproduced by any store to hand, so treat it as reasoning, not a reading.
+    // Measured in the docs demo on a 4.83M-row Xenium transcripts element with a
+    // 12,448-feature panel, capped at 4M rows. Main thread: the preload NEVER
+    // finishes — 543s of long tasks and still going at 9.4 minutes, in single tasks
+    // of 113s / 93s / 90s, with ZERO worker requests posted. Worker: 62 batches, 4M
+    // rows, done at 75s, in ~4.2s tasks.
+    //
+    // Necessary but not sufficient for that dataset. The feature column is a
+    // dictionary, so batch ONE already names all 12,448 features — every one of the
+    // 62 progress ticks then re-renders the unvirtualized feature list of #172
+    // (12,453 checkboxes in the DOM), which dominates what is left. There is no
+    // "before the catalog fills" window on this path to measure in.
     //
     // The main-thread version stays as the fallback rather than being deleted,
     // because it covers every host that has not wired a worker bundle — and because

--- a/packages/core/src/models/VPointsSource.ts
+++ b/packages/core/src/models/VPointsSource.ts
@@ -6,6 +6,7 @@ import {
 } from '../parquetFooterStats.js';
 import {
   buildFeatureCatalogFromColumns,
+  featureCatalogFromCodeMap,
   featureCodeMapFromCatalog,
   mergeFeatureCountsIntoCatalog,
   resolveRowFeatureCodesFromTable,
@@ -16,6 +17,7 @@ import type {
   PointsLoadProgress,
   PointsLoadResult,
 } from '../pointsLoadOptions.js';
+import { PointsStreamAccumulator } from '../pointsStreamAccumulator.js';
 import { basename } from '../Vutils';
 import {
   decodeGeometryWithFeaturesInWorker,
@@ -27,7 +29,9 @@ import {
   scanParquetByFeatureCodesInWorker,
   scanParquetFeatureCatalogInWorker,
   scanParquetFeatureCountsInWorker,
+  streamGeometryWithFeaturesInWorker,
 } from '../workers/parquetWorkerClient.js';
+import { appendFeatureCodesFromColumn } from '../workers/pointsScan.js';
 
 interface ColumnarPointsChunk {
   shape: number[];
@@ -287,20 +291,6 @@ const FEATURE_STREAM_BATCH_ROWS = 16_384;
 const PRELOAD_STREAM_BATCH_ROWS = 65_536;
 
 /**
- * Assign a code to each row of one feature-column batch, appending into `codeBuffer`
- * at `offset` and tallying into `codeCounts`.
- *
- * Codes are allocated on first sight via the shared `nameToCode`, so they stay
- * stable for the whole stream — a gene coloured in batch 1 keeps its code in batch
- * 62, and `codeToName` always describes the codes actually written. For a
- * dictionary chunk that means dictionary order, not row order; the caller documents
- * why that is fine.
- *
- * A DICTIONARY column resolves its values once per chunk and maps raw indices;
- * asking the vector per row would materialise a JS string per point (~59s for 4M
- * rows) instead of once per distinct feature. See `resolveRowFeatureCodesFromTable`.
- */
-/**
  * Add this batch's per-feature row counts into `counts`, resolving names through
  * the already-populated `nameToCode`.
  *
@@ -359,58 +349,6 @@ export function tallyFeatureCodesFromColumn(
       }
     }
     seen += take;
-    chunkStart += chunk.length;
-  }
-}
-
-function appendFeatureCodesFromColumn(
-  column: Vector,
-  rows: number,
-  codeToName: Map<number, string>,
-  nameToCode: Map<string, number>,
-  codeBuffer: Int32Array,
-  codeCounts: Map<number, number>,
-  offset: number
-): void {
-  const codeFor = (name: string): number => {
-    let code = nameToCode.get(name);
-    if (code === undefined) {
-      code = nameToCode.size;
-      nameToCode.set(name, code);
-      codeToName.set(code, name);
-    }
-    return code;
-  };
-  let written = 0;
-  let chunkStart = 0;
-  for (const chunk of column.data) {
-    if (written >= rows) {
-      break;
-    }
-    const take = Math.min(chunk.length, rows - written);
-    const dictionary = chunk.dictionary;
-    if (dictionary && chunk.nullCount === 0) {
-      const codeByIndex = new Int32Array(dictionary.length);
-      for (let index = 0; index < dictionary.length; index += 1) {
-        const name = dictionary.get(index);
-        codeByIndex[index] = name == null ? -1 : codeFor(String(name));
-      }
-      const indices = chunk.values as ArrayLike<number>;
-      for (let row = 0; row < take; row += 1) {
-        const index = indices[row];
-        const code = index >= 0 && index < codeByIndex.length ? codeByIndex[index] : -1;
-        codeBuffer[offset + written + row] = code;
-        codeCounts.set(code, (codeCounts.get(code) ?? 0) + 1);
-      }
-    } else {
-      for (let row = 0; row < take; row += 1) {
-        const value = column.get(chunkStart + row);
-        const code = value == null ? -1 : codeFor(String(value));
-        codeBuffer[offset + written + row] = code;
-        codeCounts.set(code, (codeCounts.get(code) ?? 0) + 1);
-      }
-    }
-    written += take;
     chunkStart += chunk.length;
   }
 }
@@ -609,6 +547,41 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
    * reads, worker disabled, nothing decoded) so the caller falls back to one-shot.
    */
   /**
+   * Range-readable URLs for every part of this element's parquet, or null if any
+   * link in the chain will not serve a stream.
+   *
+   * All four bails matter and none of them is a failure: no `ParquetFile` in this
+   * runtime (Node, and any build without it), no dataset metadata, a part whose
+   * store path is not an http(s) URL (a file:/blob:/custom-scheme store), or an
+   * origin that refuses the suffix and bounded ranges the reader needs. Callers
+   * fall through to a byte-oriented path in every case.
+   *
+   * Shared by the main-thread stream and the worker one so the two agree on
+   * exactly when streaming is possible — the worker cannot make this judgement
+   * itself (the per-origin range probe is cached here, and a refused range makes
+   * the reader panic rather than throw).
+   */
+  private async resolveStreamablePartUrls(parquetPath: string): Promise<string[] | null> {
+    if (!(await this.canStreamParquetByUrl())) {
+      return null;
+    }
+    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
+    const partPaths = dataset?.parts.map((part) => part.path);
+    if (!partPaths || partPaths.length === 0) {
+      return null;
+    }
+    const partUrls: string[] = [];
+    for (const partPath of partPaths) {
+      const url = this.resolveStoreUrl(partPath);
+      if (!url || !(await this.serverSupportsStreamingRanges(url))) {
+        return null;
+      }
+      partUrls.push(url);
+    }
+    return partUrls;
+  }
+
+  /**
    * Progressive preload that streams geometry AND colour together.
    *
    * The row-group preload below cannot read a DICTIONARY-typed `feature_name`, so
@@ -653,21 +626,9 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       signal?: AbortSignal;
     }
   ): Promise<PointsLoadResult | null> {
-    if (!(await this.canStreamParquetByUrl())) {
+    const partUrls = await this.resolveStreamablePartUrls(parquetPath);
+    if (!partUrls) {
       return null;
-    }
-    const dataset = await this.loadParquetDatasetMetadata(parquetPath);
-    const partPaths = dataset?.parts.map((part) => part.path);
-    if (!partPaths || partPaths.length === 0) {
-      return null;
-    }
-    const partUrls: string[] = [];
-    for (const partPath of partPaths) {
-      const url = this.resolveStoreUrl(partPath);
-      if (!url || !(await this.serverSupportsStreamingRanges(url))) {
-        return null;
-      }
-      partUrls.push(url);
     }
     const { ParquetFile } = await SpatialDataTableSource.parquetModulePromise;
     if (!ParquetFile) {
@@ -677,7 +638,6 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
     const { axisNames, featureKey, maxRows } = options;
     const axisCount = axisNames.length;
     const { tableFromIPC } = await import('apache-arrow');
-    const { featureCatalogFromCodeMap } = await import('../pointsFeatures.js');
 
     // Preallocate once and append at a cursor; partials expose the filled prefix as
     // subarray VIEWS so emitting progress stays O(1).
@@ -764,6 +724,88 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       }
     }
     return filled > 0 ? snapshot() : null;
+  }
+
+  /**
+   * The same progressive geometry+colour preload as
+   * {@link streamPointsWithFeaturesByUrl}, with the range-fetching AND the parquet
+   * decode moved into the worker.
+   *
+   * The main thread keeps only what it must own: the capability decision (see
+   * {@link resolveStreamablePartUrls}), the accumulator the renderer reads from, and
+   * the progress callback. Per batch it copies the batch's rows into that
+   * accumulator and merges two small deltas — no parquet decode, no dictionary walk,
+   * no string materialisation.
+   *
+   * Preserving the progressive paint is the whole reason this is a stream rather
+   * than one `decodeGeometryWithFeatures` request. A single whole-payload decode in
+   * the worker would keep the tab responsive but leave the canvas empty until the
+   * entire 23MB / 4M-row payload finished — trading a frozen tab for a blank one.
+   *
+   * Returns null when the worker is off or the store cannot stream, so the caller
+   * falls through to the main-thread stream. A failure PART WAY THROUGH rejects
+   * instead: see the contract note on `streamGeometryWithFeaturesInWorker` for why
+   * a partial is not reported as success.
+   */
+  private async streamPointsWithFeaturesInWorker(
+    parquetPath: string,
+    options: {
+      axisNames: string[];
+      featureKey: string;
+      maxRows: number;
+      totalRowCount: number;
+      preloadTruncated: boolean;
+      hasFeatureCodeColumn: boolean;
+      onProgress?: (progress: PointsLoadProgress) => void;
+      signal?: AbortSignal;
+    }
+  ): Promise<PointsLoadResult | null> {
+    ensureParquetWorker();
+    if (!isParquetWorkerEnabled()) {
+      return null;
+    }
+    const partUrls = await this.resolveStreamablePartUrls(parquetPath);
+    if (!partUrls) {
+      return null;
+    }
+
+    const { axisNames, featureKey, maxRows } = options;
+    const accumulator = new PointsStreamAccumulator({
+      axisCount: axisNames.length,
+      maxRows,
+      featureKey,
+      totalRowCount: options.totalRowCount,
+      preloadTruncated: options.preloadTruncated,
+      hasFeatureCodeColumn: options.hasFeatureCodeColumn,
+    });
+
+    const end = await streamGeometryWithFeaturesInWorker(
+      {
+        partUrls,
+        axisNames,
+        featureKey,
+        maxRows,
+        batchSize: PRELOAD_STREAM_BATCH_ROWS,
+        ...(options.signal ? { signal: options.signal } : {}),
+      },
+      (chunk) => {
+        if (accumulator.append(chunk) === 0) {
+          return;
+        }
+        options.onProgress?.({
+          // Unfiltered preload: every decoded row is kept, so scanned === matched.
+          scannedRows: accumulator.filled,
+          matchedRows: accumulator.filled,
+          partIndex: chunk.partIndex,
+          partCount: chunk.partCount,
+          partialResult: accumulator.snapshot(),
+        });
+      }
+    );
+    if (!end) {
+      return null;
+    }
+    return accumulator.filled > 0 ? accumulator.snapshot() : null;
   }
 
   private async streamPointsGeometryByRowGroup(
@@ -940,46 +982,70 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       }
     }
 
-    // Progressive preload: stream geometry AND the feature column in the same
-    // batches, so points paint already coloured. Tried before the row-group path
-    // because that one cannot read a dictionary feature column at all — the case
-    // where colour otherwise waits for a whole separate decode.
+    // Preferred progressive preload: stream geometry AND the feature column in the
+    // same batches, so points paint already coloured. Tried before the row-group
+    // path below because that one cannot read a dictionary feature column at all —
+    // the case where colour otherwise waits for a whole separate decode.
     //
-    // WARNING: when this path is TAKEN it runs BEFORE the worker gate below and
-    // decodes ON THE MAIN THREAD. `streamPointsWithFeaturesByUrl` drives
-    // parquet-wasm's `ParquetFile` and `tableFromIPC` itself; only the per-batch
-    // *bookkeeping* after that is the dictionary lookup and typed-array copy this
-    // comment used to claim was all of it.
+    // Two implementations of the same stream, worker first. They produce the same
+    // result; the difference is only WHERE the parquet decode runs, and that
+    // difference is the point. The main-thread one drives `ParquetFile.stream()` and
+    // `tableFromIPC` on the UI thread. The worker one range-fetches and decodes
+    // off-thread and posts batches back, so the main thread only copies each batch
+    // into its accumulator.
     //
-    // It is taken only where the store can serve streaming range reads — see the
-    // four `return null` bails at the top of that method (no url-streaming support,
-    // no parts, a part whose URL will not range-read, no `ParquetFile`). Anywhere it
-    // bails, control falls through and the worker path below runs normally. So this
-    // is not "the worker is never used for points"; it is "on a store that supports
-    // streaming, an element with a feature key and a progress callback — the normal
-    // case for a coloured points layer — decodes its whole preload on the main
-    // thread, whether or not the worker is enabled".
+    // Measured on a 4-part Xenium transcripts element (12.2M rows, capped at 4M,
+    // 541-gene panel) in the docs demo: the main-thread stream reaches 4M rows at
+    // ~3.6s having spent ~2.8s of that window in long tasks — a thread ~78% busy —
+    // while the worker one delivers 62 batches and all 4M rows by ~1.6s for ~0.8s of
+    // long tasks. The load-phase blocking is the part this moves; total per-session
+    // blocking barely shifts, because what is left is downstream of the preload
+    // (feature-code settling, rendering 4M points, and the unvirtualized feature
+    // list of #172). On the wide panels where the reported freezes come from — 12k+
+    // features — the gap should be far larger, since the per-batch catalog rebuild
+    // this path used to do scales with the panel and is now memoised; that regime is
+    // NOT reproduced by any store to hand, so treat it as reasoning, not a reading.
     //
-    // Measured on such a store, a 4M-row capped preload of a 5-part Xenium
-    // transcripts element: five ~700ms decodes, ~4.4s of long tasks, zero
-    // `decodeParquetGeometryCapped` requests posted. Not a regression — this has
-    // been the shape since #89 — but it is why enabling the worker does not make
-    // that points layer stop blocking. Fixing it means decoding these batches in
-    // the worker; gating this path on the worker instead only trades a frozen tab
-    // for a blank one, since the progressive paint is what it buys. Neither is a
-    // drive-by. See the investigation in this branch before changing the order.
+    // The main-thread version stays as the fallback rather than being deleted,
+    // because it covers every host that has not wired a worker bundle — and because
+    // a stream that fails part way through restarts here from row 0 (see the
+    // contract note on `streamGeometryWithFeaturesInWorker`: a partial is never
+    // reported as success, since nothing downstream can tell a truncated preload
+    // from a complete one).
+    //
+    // What is NOT an option is gating this whole block on the worker and letting
+    // worker hosts take the one-shot `decodeGeometryWithFeatures` below instead.
+    // That keeps the tab responsive but shows nothing until the entire payload
+    // decodes — a frozen tab traded for a blank one, on the path whose entire value
+    // is that colour appears after the first batch.
     if (options.onProgress && featureKey) {
+      const streamOptions = {
+        axisNames,
+        featureKey,
+        maxRows,
+        totalRowCount: rowCount,
+        preloadTruncated: truncatePreload,
+        hasFeatureCodeColumn: featureCodeColumnName !== undefined,
+        onProgress: options.onProgress,
+        ...(options.signal ? { signal: options.signal } : {}),
+      };
       try {
-        const streamed = await this.streamPointsWithFeaturesByUrl(parquetPath, {
-          axisNames,
-          featureKey,
-          maxRows,
-          totalRowCount: rowCount,
-          preloadTruncated: truncatePreload,
-          hasFeatureCodeColumn: featureCodeColumnName !== undefined,
-          onProgress: options.onProgress,
-          ...(options.signal ? { signal: options.signal } : {}),
-        });
+        const streamed = await this.streamPointsWithFeaturesInWorker(parquetPath, streamOptions);
+        if (streamed?.featureCodes !== undefined) {
+          return streamed;
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          throw error;
+        }
+        console.warn(
+          `Worker streaming points preload failed for ${elementPath}; ` +
+            'retrying on the main thread.',
+          error
+        );
+      }
+      try {
+        const streamed = await this.streamPointsWithFeaturesByUrl(parquetPath, streamOptions);
         if (streamed?.featureCodes !== undefined) {
           return streamed;
         }

--- a/packages/core/src/pointsStreamAccumulator.ts
+++ b/packages/core/src/pointsStreamAccumulator.ts
@@ -1,0 +1,130 @@
+import { featureCatalogFromCodeMap } from './pointsFeatures.js';
+import type { PointsLoadResult } from './pointsLoadOptions.js';
+import type { ParquetWorkerStreamChunk } from './workers/parquetWorkerProtocol.js';
+
+export type PointsStreamAccumulatorOptions = {
+  axisCount: number;
+  /** Hard row cap; the buffers are allocated at this size up front. */
+  maxRows: number;
+  featureKey: string;
+  totalRowCount: number;
+  preloadTruncated: boolean;
+  hasFeatureCodeColumn: boolean;
+};
+
+/**
+ * The main-thread half of the worker's streaming points preload: it owns the
+ * buffers, the worker owns the decode.
+ *
+ * The split is what keeps the UI thread free. Each batch arrives as a DELTA — its
+ * own rows, plus only the catalog entries and per-feature tallies that batch was
+ * the first to contribute — so appending is two typed-array copies and a walk over
+ * however few distinct features the batch touched. No parquet decode, no dictionary
+ * walk, no per-row string.
+ *
+ * Buffers are preallocated at the cap and appended at a cursor, so {@link snapshot}
+ * hands out subarray VIEWS and emitting a progress tick stays O(1) — the same
+ * arrangement the main-thread stream uses, and the reason a 60-batch preload does
+ * not re-concatenate 4M rows sixty times.
+ */
+export class PointsStreamAccumulator {
+  private readonly axisBuffers: Float32Array[];
+  private readonly codeBuffer: Int32Array;
+  private readonly codeToName = new Map<number, string>();
+  private readonly codeCounts = new Map<number, number>();
+  private filledRows = 0;
+  /**
+   * Memoised, and rebuilt only when a batch actually brought new features.
+   *
+   * A dictionary feature column names every feature within the first batch or two,
+   * so the remaining ~60 ticks of a 4M-row element reuse this object. Rebuilding per
+   * tick instead would re-materialise a 12k-entry catalog sixty times over — putting
+   * a slice of the very cost this path exists to remove back on the main thread.
+   */
+  private catalog: PointsLoadResult['featureCatalog'];
+
+  constructor(private readonly options: PointsStreamAccumulatorOptions) {
+    this.axisBuffers = Array.from(
+      { length: options.axisCount },
+      () => new Float32Array(options.maxRows)
+    );
+    this.codeBuffer = new Int32Array(options.maxRows);
+    this.catalog = featureCatalogFromCodeMap(options.featureKey, this.codeToName);
+  }
+
+  /** Rows appended so far. */
+  get filled(): number {
+    return this.filledRows;
+  }
+
+  /**
+   * Append one streamed batch, clamped to the remaining cap.
+   *
+   * Returns the rows actually taken — 0 once full, which is the caller's cue that
+   * a progress tick would report nothing new.
+   */
+  append(chunk: ParquetWorkerStreamChunk): number {
+    const rows = Math.min(chunk.rows, this.options.maxRows - this.filledRows);
+    if (rows <= 0) {
+      return 0;
+    }
+    for (let axis = 0; axis < this.options.axisCount; axis += 1) {
+      const values = chunk.axes[axis];
+      if (!values) {
+        // A part missing one of the element's axes. The main-thread stream leaves
+        // the gap zeroed rather than failing the load; match it.
+        continue;
+      }
+      this.axisBuffers[axis].set(
+        values.length === rows ? values : values.subarray(0, rows),
+        this.filledRows
+      );
+    }
+    const codes = chunk.featureCodes;
+    this.codeBuffer.set(codes.length === rows ? codes : codes.subarray(0, rows), this.filledRows);
+    if (chunk.newFeatures.length > 0) {
+      for (const entry of chunk.newFeatures) {
+        this.codeToName.set(entry.code, entry.name);
+      }
+      this.catalog = featureCatalogFromCodeMap(this.options.featureKey, this.codeToName);
+    }
+    if (rows === chunk.rows) {
+      for (let index = 0; index < chunk.tallyCodes.length; index += 1) {
+        const code = chunk.tallyCodes[index];
+        this.codeCounts.set(code, (this.codeCounts.get(code) ?? 0) + chunk.tallyCounts[index]);
+      }
+    } else {
+      // The cap landed inside this batch, so its own tallies count rows being
+      // dropped. Re-tally just the prefix that is kept — otherwise the per-feature
+      // counts describe more points than the buffers hold.
+      for (let row = 0; row < rows; row += 1) {
+        const code = codes[row];
+        this.codeCounts.set(code, (this.codeCounts.get(code) ?? 0) + 1);
+      }
+    }
+    this.filledRows += rows;
+    return rows;
+  }
+
+  /**
+   * The preload as it stands: views over the filled prefix, plus the catalog that
+   * describes the codes actually written.
+   *
+   * The codes and the catalog are consistent WITH EACH OTHER but are in this
+   * stream's own code space, not the full-dataset scan's — the same contract the
+   * main-thread stream publishes, which `remapRowFeatureCodes` reconciles once the
+   * authoritative catalog settles.
+   */
+  snapshot(): PointsLoadResult {
+    return {
+      shape: [this.options.axisCount, this.filledRows] as [number, number],
+      data: this.axisBuffers.map((buffer) => buffer.subarray(0, this.filledRows)),
+      totalRowCount: this.options.totalRowCount,
+      preloadTruncated: this.options.preloadTruncated,
+      hasFeatureCodeColumn: this.options.hasFeatureCodeColumn,
+      featureCodes: this.codeBuffer.subarray(0, this.filledRows),
+      featureCatalog: this.catalog,
+      featureCodeCounts: new Map(this.codeCounts),
+    };
+  }
+}

--- a/packages/core/src/workers/parquet-worker.ts
+++ b/packages/core/src/workers/parquet-worker.ts
@@ -12,8 +12,11 @@ import type {
   ParquetWorkerMessage,
   ParquetWorkerRequest,
   ParquetWorkerResponse,
+  ParquetWorkerStreamChunk,
 } from './parquetWorkerProtocol.js';
+import { transferablesForStreamChunk } from './parquetWorkerProtocol.js';
 import {
+  appendFeatureCodesFromColumn,
   countFeatureCodesFromArray,
   decodeGeometryWithFeaturesFromPayload,
   decodeParquetPartsToTable,
@@ -602,7 +605,189 @@ async function handleDecodeShapesGeometry(
   };
 }
 
-async function handleRequest(request: ParquetWorkerRequest): Promise<ParquetWorkerResponse> {
+/**
+ * Cancellation flags for in-flight `streamGeometryWithFeatures` requests, keyed by
+ * the request id the stream is running under. A `cancelParquetStream` sets the flag
+ * and the stream loop stops before its next batch; without it a superseded preload
+ * keeps range-fetching a whole element nobody will read.
+ */
+const activeStreams = new Map<number, { cancelled: boolean }>();
+
+type StreamEmitter = (chunk: ParquetWorkerStreamChunk) => void;
+
+/** Copy one axis column's first `rows` values into a fresh transferable buffer. */
+function axisBatchValues(values: ArrayLike<number>, rows: number): Float32Array {
+  const out = new Float32Array(rows);
+  if (ArrayBuffer.isView(values)) {
+    // Typed source: one `set` (with the f64 -> f32 narrowing when needed) rather
+    // than a per-row JS loop.
+    out.set((values as unknown as Float32Array).subarray(0, rows));
+    return out;
+  }
+  for (let row = 0; row < rows; row += 1) {
+    out[row] = values[row];
+  }
+  return out;
+}
+
+/**
+ * The progressive geometry+colour preload, run end to end in the worker: range-fetch
+ * each part, decode batch by batch, and post every batch back as it lands.
+ *
+ * This is the same decode `VPointsSource.streamPointsWithFeaturesByUrl` performs on
+ * the main thread, moved here. It has to stay a decode-and-emit loop rather than a
+ * decode-then-return one, because the progressive paint is the reason that path is
+ * taken at all — a single whole-payload response would swap a blocked tab for a
+ * blank one.
+ *
+ * The accumulator stays on the MAIN thread (it owns the buffers the renderer reads),
+ * so each batch carries only its own rows plus deltas: the catalog entries first seen
+ * in this batch, and this batch's per-feature tallies. `codeToName` / `nameToCode`
+ * persist across batches and across parts, so a gene coloured in batch 1 keeps its
+ * code in batch 62 and the catalog always describes the codes actually written.
+ */
+async function handleStreamGeometryWithFeatures(
+  request: Extract<ParquetWorkerRequest, { type: 'streamGeometryWithFeatures' }>,
+  emit: StreamEmitter,
+  isCancelled: () => boolean
+): Promise<ParquetWorkerResponse> {
+  const { ParquetFile } = await getParquetModule();
+  if (!ParquetFile) {
+    return { ok: false, error: 'parquet-wasm ParquetFile is unavailable in this worker' };
+  }
+  const { partUrls, axisNames, featureKey, maxRows, batchSize } = request;
+  const axisCount = axisNames.length;
+  const codeToName = new Map<number, string>();
+  const nameToCode = new Map<string, number>();
+  let emitted = 0;
+  let sawFeatureColumn = true;
+
+  for (const [partIndex, url] of partUrls.entries()) {
+    if (emitted >= maxRows || isCancelled()) {
+      break;
+    }
+    const file = await ParquetFile.fromUrl(url);
+    const stream = await file.stream({
+      columns: [...axisNames, featureKey],
+      batchSize,
+    });
+    const reader = stream.getReader();
+    try {
+      for (;;) {
+        if (emitted >= maxRows || isCancelled()) {
+          break;
+        }
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        const table = tableFromIPC(value.intoIPCStream());
+        const rows = Math.min(table.numRows, maxRows - emitted);
+        if (rows <= 0) {
+          continue;
+        }
+        const featureColumn = table.getChild(featureKey);
+        if (!featureColumn) {
+          // The projection came back without the feature column, so nothing after
+          // this point can be coloured. End the stream rather than emit flat rows
+          // the caller would take for coloured ones.
+          sawFeatureColumn = false;
+          break;
+        }
+        const axes: Float32Array[] = [];
+        for (let axis = 0; axis < axisCount; axis += 1) {
+          const column = table.getChild(axisNames[axis]);
+          axes.push(
+            column
+              ? axisBatchValues(column.toArray() as ArrayLike<number>, rows)
+              : new Float32Array(rows)
+          );
+        }
+        const knownBefore = nameToCode.size;
+        const featureCodes = new Int32Array(rows);
+        const batchCounts = new Map<number, number>();
+        appendFeatureCodesFromColumn(
+          featureColumn,
+          rows,
+          codeToName,
+          nameToCode,
+          featureCodes,
+          batchCounts,
+          0
+        );
+        // Codes are handed out as `nameToCode.size`, so everything at or above the
+        // pre-batch size is new — no diffing of the whole catalog per batch.
+        const newFeatures: Array<{ code: number; name: string }> = [];
+        for (let code = knownBefore; code < nameToCode.size; code += 1) {
+          const name = codeToName.get(code);
+          if (name !== undefined) {
+            newFeatures.push({ code, name });
+          }
+        }
+        const tallyCodes = new Int32Array(batchCounts.size);
+        const tallyCounts = new Uint32Array(batchCounts.size);
+        let tallyIndex = 0;
+        for (const [code, count] of batchCounts) {
+          tallyCodes[tallyIndex] = code;
+          tallyCounts[tallyIndex] = count;
+          tallyIndex += 1;
+        }
+        emitted += rows;
+        if (isCancelled()) {
+          // Cancelled while this batch decoded: the caller has already settled and
+          // stopped listening, so posting would only be dropped on arrival.
+          break;
+        }
+        emit({
+          kind: 'geometryWithFeaturesBatch',
+          partIndex,
+          partCount: partUrls.length,
+          rows,
+          axes,
+          featureCodes,
+          newFeatures,
+          tallyCodes,
+          tallyCounts,
+        });
+      }
+    } finally {
+      // Covers both endings: on a stream that ran to completion this resolves and
+      // releases the lock, and on an early break it also stops the reader's
+      // outstanding range requests.
+      try {
+        await reader.cancel();
+      } catch {
+        /* the stream is already gone */
+      }
+    }
+    if (!sawFeatureColumn) {
+      break;
+    }
+  }
+
+  if (isCancelled()) {
+    return { ok: true, result: { kind: 'streamCancelled' } };
+  }
+  return {
+    ok: true,
+    result: { kind: 'geometryWithFeaturesStreamEnd', rows: emitted, sawFeatureColumn },
+  };
+}
+
+function handleCancelParquetStream(
+  request: Extract<ParquetWorkerRequest, { type: 'cancelParquetStream' }>
+): ParquetWorkerResponse {
+  const target = activeStreams.get(request.streamRequestId);
+  if (target) {
+    target.cancelled = true;
+  }
+  return { ok: true, result: { kind: 'streamCancelled' } };
+}
+
+async function handleRequest(
+  request: ParquetWorkerRequest,
+  context: { emit: StreamEmitter; isCancelled: () => boolean }
+): Promise<ParquetWorkerResponse> {
   switch (request.type) {
     case 'filterColumnarByFeatureCodes':
       return handleFilterColumnar(request);
@@ -628,6 +813,10 @@ async function handleRequest(request: ParquetWorkerRequest): Promise<ParquetWork
       return handleScanMortonRowGroupsInBounds(request);
     case 'decodeShapesGeometry':
       return handleDecodeShapesGeometry(request);
+    case 'streamGeometryWithFeatures':
+      return handleStreamGeometryWithFeatures(request, context.emit, context.isCancelled);
+    case 'cancelParquetStream':
+      return handleCancelParquetStream(request);
     default: {
       const _exhaustive: never = request;
       return { ok: false, error: `Unknown request type: ${String(_exhaustive)}` };
@@ -640,7 +829,19 @@ self.onmessage = (event: MessageEvent<ParquetWorkerMessage>) => {
   if (message.direction !== 'request') {
     return;
   }
-  void handleRequest(message.request)
+  // Only streaming requests can be cancelled, so only they get a registry entry —
+  // an entry per request would be a leak on the ~thousands of ordinary decodes a
+  // session runs.
+  const isStreaming = message.request.type === 'streamGeometryWithFeatures';
+  const state = { cancelled: false };
+  if (isStreaming) {
+    activeStreams.set(message.id, state);
+  }
+  const emit: StreamEmitter = (chunk) => {
+    const interim: ParquetWorkerMessage = { id: message.id, direction: 'stream', chunk };
+    self.postMessage(interim, transferablesForStreamChunk(chunk));
+  };
+  void handleRequest(message.request, { emit, isCancelled: () => state.cancelled })
     .then((response) => {
       const reply: ParquetWorkerMessage = { id: message.id, direction: 'response', response };
       const transferables: Transferable[] = [];
@@ -693,5 +894,10 @@ self.onmessage = (event: MessageEvent<ParquetWorkerMessage>) => {
         },
       };
       self.postMessage(reply);
+    })
+    .finally(() => {
+      if (isStreaming) {
+        activeStreams.delete(message.id);
+      }
     });
 };

--- a/packages/core/src/workers/parquetWorkerClient.ts
+++ b/packages/core/src/workers/parquetWorkerClient.ts
@@ -9,19 +9,35 @@ import {
   type ParquetWorkerPayload,
   type ParquetWorkerRequest,
   type ParquetWorkerResponse,
+  type ParquetWorkerStreamChunk,
   type PointsBounds,
 } from './parquetWorkerProtocol.js';
 
 let worker: Worker | undefined;
 let nextRequestId = 0;
-const pending = new Map<
-  number,
-  {
-    resolve: (value: unknown) => void;
-    reject: (error: Error) => void;
-    timeout?: ReturnType<typeof setTimeout>;
-  }
->();
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timeout?: ReturnType<typeof setTimeout>;
+  /**
+   * Set only for a STREAMING request. Its presence is what makes an interim
+   * message legal for this id — and what tells the timeout and the abort path to
+   * send the worker a cancel, since a stream it is not told about keeps fetching.
+   */
+  onChunk?: (chunk: ParquetWorkerStreamChunk) => void;
+  /**
+   * Whether any interim chunk has been delivered. A stream that fails after this
+   * has already handed the caller usable rows, so the failure is not equivalent
+   * to one that failed before producing anything — see the note on
+   * {@link streamGeometryWithFeaturesInWorker}.
+   */
+  deliveredChunk: boolean;
+  /** Detach the abort listener when the request settles, however it settles. */
+  removeAbortListener?: () => void;
+};
+
+const pending = new Map<number, PendingRequest>();
 
 // Safety net: if the worker was enabled but is not functionally wired (e.g. a
 // host points enableParquetWorker() at a URL that loads but whose module never
@@ -30,6 +46,14 @@ const pending = new Map<
 // thread (every *InWorker helper is wrapped in a try/catch fallback). Generous
 // by default because a working worker legitimately spends many seconds decoding
 // large parquet; the timeout is meant to catch a *silent* worker, not a slow one.
+//
+// It measures time SINCE THE LAST MESSAGE for this request, not time since the
+// request was posted. For the request/response types those are the same thing —
+// exactly one message ever arrives. For a stream they are not: a 4M-row preload
+// runs for minutes while posting a batch every few hundred ms, and a
+// time-since-posted budget would abandon a perfectly healthy stream mid-flight.
+// Re-arming per message keeps the meaning the comment above claims: catch a
+// worker that has gone silent, not one that is taking a while.
 let requestTimeoutMs = 30_000;
 
 /** Override the per-request worker timeout (ms). Set to 0/Infinity to disable. */
@@ -46,8 +70,67 @@ function settlePending(id: number) {
   if (entry.timeout !== undefined) {
     clearTimeout(entry.timeout);
   }
+  entry.removeAbortListener?.();
   pending.delete(id);
   return entry;
+}
+
+/**
+ * (Re)start the silence watchdog for a still-pending request. Called when the
+ * request is posted and again after every message it receives, so the budget is
+ * time-since-last-message; see {@link requestTimeoutMs}.
+ */
+function armTimeout(id: number) {
+  const entry = pending.get(id);
+  if (!entry) {
+    return;
+  }
+  if (entry.timeout !== undefined) {
+    clearTimeout(entry.timeout);
+    entry.timeout = undefined;
+  }
+  if (!(requestTimeoutMs > 0 && Number.isFinite(requestTimeoutMs))) {
+    return;
+  }
+  const budget = requestTimeoutMs;
+  entry.timeout = setTimeout(() => {
+    const stalled = settlePending(id);
+    if (!stalled) {
+      return;
+    }
+    if (stalled.onChunk) {
+      // Stop the worker fetching a payload nobody is left to receive.
+      cancelWorkerStream(id);
+    }
+    stalled.reject(
+      new Error(
+        stalled.deliveredChunk
+          ? `Parquet worker stream went quiet for ${budget}ms; falling back to the main thread`
+          : `Parquet worker did not respond within ${budget}ms; falling back to the main thread`
+      )
+    );
+  }, budget);
+}
+
+/**
+ * Ask the worker to abandon a stream, fire and forget.
+ *
+ * The cancel travels with a fresh id and registers no pending entry, so the
+ * worker's acknowledgement lands on an unknown id and is ignored. Awaiting it
+ * would only add a second request that can itself time out, on a path that is
+ * already giving up.
+ */
+function cancelWorkerStream(streamRequestId: number) {
+  const activeWorker = worker;
+  if (!activeWorker) {
+    return;
+  }
+  const message: ParquetWorkerMessage = {
+    id: ++nextRequestId,
+    direction: 'request',
+    request: { type: 'cancelParquetStream', streamRequestId },
+  };
+  activeWorker.postMessage(message);
 }
 
 /**
@@ -80,6 +163,32 @@ function ensureWorkerListener() {
   }
   worker.onmessage = (event: MessageEvent<ParquetWorkerMessage>) => {
     const message = event.data;
+    if (message.direction === 'stream') {
+      workerHasAnswered = true;
+      // Deliberately `pending.get`, not `settlePending`: an interim message must
+      // leave the entry in place, because the terminal response is still to come.
+      // This is the whole difference between this protocol and the strict
+      // request/response one it grew out of.
+      const streaming = pending.get(message.id);
+      if (!streaming?.onChunk) {
+        // Either the request already settled (timed out, aborted, or the worker
+        // died) and a batch was in flight behind the cancel, or a non-streaming
+        // request somehow got one. Dropping it is right in both cases.
+        return;
+      }
+      streaming.deliveredChunk = true;
+      armTimeout(message.id);
+      try {
+        streaming.onChunk(message.chunk);
+      } catch (error) {
+        // The consumer threw on a batch, so it cannot use the rest of the stream.
+        settlePending(message.id)?.reject(
+          error instanceof Error ? error : new Error(String(error))
+        );
+        cancelWorkerStream(message.id);
+      }
+      return;
+    }
     if (message.direction !== 'response') {
       return;
     }
@@ -122,31 +231,56 @@ function ensureWorkerListener() {
   };
 }
 
+type PostRequestOptions = {
+  /** Provide to receive interim batches; see {@link PendingRequest.onChunk}. */
+  onChunk?: (chunk: ParquetWorkerStreamChunk) => void;
+  /**
+   * Abandon the request when this fires. For a stream that also posts a cancel,
+   * so a superseded load stops costing bandwidth in the worker rather than
+   * merely stopping being listened to.
+   */
+  signal?: AbortSignal;
+};
+
 function postRequest<T>(
   request: ParquetWorkerRequest,
-  transferables: Transferable[] = []
+  transferables: Transferable[] = [],
+  options: PostRequestOptions = {}
 ): Promise<T> {
   const activeWorker = worker;
   if (!activeWorker) {
     return Promise.reject(new Error('Parquet worker is not enabled'));
   }
+  const { signal } = options;
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException('Aborted', 'AbortError'));
+  }
   const id = ++nextRequestId;
   return new Promise<T>((resolve, reject) => {
-    const entry: {
-      resolve: (value: unknown) => void;
-      reject: (error: Error) => void;
-      timeout?: ReturnType<typeof setTimeout>;
-    } = { resolve: resolve as (value: unknown) => void, reject };
-    if (requestTimeoutMs > 0 && Number.isFinite(requestTimeoutMs)) {
-      entry.timeout = setTimeout(() => {
-        settlePending(id)?.reject(
-          new Error(
-            `Parquet worker did not respond within ${requestTimeoutMs}ms; falling back to the main thread`
-          )
-        );
-      }, requestTimeoutMs);
-    }
+    const entry: PendingRequest = {
+      resolve: resolve as (value: unknown) => void,
+      reject,
+      deliveredChunk: false,
+      ...(options.onChunk ? { onChunk: options.onChunk } : {}),
+    };
     pending.set(id, entry);
+    if (signal) {
+      const onAbort = () => {
+        const aborted = settlePending(id);
+        if (!aborted) {
+          return;
+        }
+        if (aborted.onChunk) {
+          cancelWorkerStream(id);
+        }
+        aborted.reject(new DOMException('Aborted', 'AbortError'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      entry.removeAbortListener = () => {
+        signal.removeEventListener('abort', onAbort);
+      };
+    }
+    armTimeout(id);
     const message: ParquetWorkerMessage = { id, direction: 'request', request };
     if (transferables.length > 0) {
       activeWorker.postMessage(message, transferables);
@@ -563,6 +697,83 @@ export async function decodeGeometryWithFeaturesInWorker(
     ...(result.featureCodes ? { featureCodes: result.featureCodes } : {}),
     ...(result.featureCatalog ? { featureCatalog: result.featureCatalog } : {}),
   };
+}
+
+export type StreamGeometryWithFeaturesInput = {
+  /**
+   * Range-readable absolute URLs for the dataset's parts, in order. The CALLER
+   * establishes that they are servable (`canStreamParquetByUrl` plus a
+   * `serverSupportsStreamingRanges` probe per origin) — the worker cannot probe
+   * cheaply, and the reader panics rather than erroring on a refused range.
+   */
+  partUrls: string[];
+  axisNames: string[];
+  featureKey: string;
+  maxRows: number;
+  batchSize: number;
+  /** Superseded load: cancels the worker's fetching, not just our listening. */
+  signal?: AbortSignal;
+};
+
+export type StreamGeometryWithFeaturesEnd = {
+  /** Rows emitted across every batch — what the caller should have accumulated. */
+  rows: number;
+  /** False when a part's projection lacked the feature column; rows are uncoloured. */
+  sawFeatureColumn: boolean;
+};
+
+/**
+ * Progressive geometry+colour preload, decoded ENTIRELY in the worker.
+ *
+ * The worker range-fetches each part itself and posts batches back as it decodes
+ * them, so the main thread's only per-batch work is copying the batch into its
+ * accumulator. That is the point: the equivalent main-thread stream
+ * (`VPointsSource.streamPointsWithFeaturesByUrl`) keeps the progressive paint but
+ * does the parquet decode on the UI thread, which is where a 4M-row Xenium
+ * element's tens of seconds of long tasks come from.
+ *
+ * Returns null when the worker is off or there is nothing to read, matching the
+ * other `*InWorker` helpers — the caller falls through to the main-thread stream.
+ *
+ * ON FAILURE it REJECTS, even when batches were already delivered and painted.
+ * There is no partial-success return, deliberately: a truncated preload is
+ * indistinguishable to every downstream consumer from a complete one (they read
+ * `preloadTruncated` and the row cap, not "how far did the stream get"), so
+ * reporting one as success would silently drop points and skew the per-feature
+ * tallies. Rejecting sends the caller to the main-thread stream, which restarts
+ * from row 0 and re-paints over the partial — the worst case is the cost this
+ * whole path exists to avoid, which is exactly the status quo it replaced.
+ *
+ * Batches already handed to `onBatch` are therefore not a commitment. They are
+ * safe to have painted: each progress tick carries the catalog matching its own
+ * codes, so a later tick from a different code space is reconciled by the same
+ * `remapRowFeatureCodes` handoff that already spans preload and full scan.
+ */
+export async function streamGeometryWithFeaturesInWorker(
+  input: StreamGeometryWithFeaturesInput,
+  onBatch: (chunk: ParquetWorkerStreamChunk) => void
+): Promise<StreamGeometryWithFeaturesEnd | null> {
+  ensureParquetWorker();
+  if (!isParquetWorkerEnabled()) {
+    return null;
+  }
+  if (input.partUrls.length === 0 || input.maxRows <= 0) {
+    return null;
+  }
+  const { signal, ...rest } = input;
+  const request: Extract<ParquetWorkerRequest, { type: 'streamGeometryWithFeatures' }> = {
+    type: 'streamGeometryWithFeatures',
+    ...rest,
+  };
+  const result = await postRequest<Extract<ParquetWorkerResponse, { ok: true }>['result']>(
+    request,
+    [],
+    { onChunk: onBatch, ...(signal ? { signal } : {}) }
+  );
+  if (result.kind !== 'geometryWithFeaturesStreamEnd') {
+    throw new Error('Unexpected parquet worker response for streamGeometryWithFeatures');
+  }
+  return { rows: result.rows, sawFeatureColumn: result.sawFeatureColumn };
 }
 
 export type DecodeShapesGeometryInput = {

--- a/packages/core/src/workers/parquetWorkerProtocol.ts
+++ b/packages/core/src/workers/parquetWorkerProtocol.ts
@@ -136,6 +136,42 @@ export type ParquetWorkerRequest =
       featureCodes?: readonly number[];
     }
   | {
+      /**
+       * Progressive geometry+colour preload, streamed END TO END in the worker.
+       *
+       * The worker opens each part with `ParquetFile.fromUrl` and issues its own
+       * ranged fetches, so the caller ships URLs rather than bytes and never
+       * decodes. Batches come back as {@link ParquetWorkerStreamChunk} messages
+       * under this request's id, followed by one terminal response — the only
+       * request type in this protocol with more than one message per id.
+       *
+       * The caller resolves the URLs and vouches for the server (see
+       * `canStreamParquetByUrl` / `serverSupportsStreamingRanges`); the worker
+       * assumes both and fails the request if a URL will not open.
+       */
+      type: 'streamGeometryWithFeatures';
+      /** Absolute, range-readable URLs, in dataset part order. */
+      partUrls: string[];
+      axisNames: string[];
+      featureKey: string;
+      /** Stop once this many rows have been emitted, across all parts. */
+      maxRows: number;
+      /** Rows per emitted batch; the caller's `PRELOAD_STREAM_BATCH_ROWS`. */
+      batchSize: number;
+    }
+  | {
+      /**
+       * Stop a `streamGeometryWithFeatures` early — a superseded load, or a
+       * client-side timeout. Without it the worker keeps fetching a payload
+       * nobody will read.
+       *
+       * Carries the id of the stream to cancel, not its own: cancel travels as an
+       * ordinary request with a fresh id so it settles through the same path.
+       */
+      type: 'cancelParquetStream';
+      streamRequestId: number;
+    }
+  | {
       // Shapes geometry decode. The parquet worker is host to this too — see
       // `shapesGeometryDecode.ts`. If this generality holds the worker should be
       // renamed to a `parquet-worker`; deferred to avoid churning the points
@@ -145,6 +181,52 @@ export type ParquetWorkerRequest =
       geometryColumnName: string;
       geometryKind: 'polygon' | 'circle' | 'point';
     };
+
+/**
+ * One decoded batch of a {@link ParquetWorkerRequest} of type
+ * `streamGeometryWithFeatures`, posted while the request is still running.
+ *
+ * Deliberately a DELTA, not a snapshot: the accumulator lives on the main thread
+ * (it owns the buffers the renderer reads), so each batch carries only its own
+ * rows and only the catalog entries this batch was the first to see. Posting a
+ * growing snapshot instead would re-copy the whole preload once per batch —
+ * O(rows x batches) transfer for a 4M-row element.
+ *
+ * `axes` is one array per axis, in `axisNames` order, each of length `rows`; the
+ * buffers are transferred, so the worker must not retain them.
+ */
+export type ParquetWorkerStreamChunk = {
+  kind: 'geometryWithFeaturesBatch';
+  /** Index of the part this batch came from, and how many parts there are. */
+  partIndex: number;
+  partCount: number;
+  /** Rows in this batch — the length of every array below except the tallies. */
+  rows: number;
+  axes: Float32Array[];
+  featureCodes: Int32Array;
+  /**
+   * Catalog entries first assigned in this batch. Empty once the stream has seen
+   * every feature, which for a dictionary column is usually after batch one.
+   */
+  newFeatures: ReadonlyArray<{ code: number; name: string }>;
+  /**
+   * Per-feature row tallies FOR THIS BATCH, as parallel arrays over the codes the
+   * batch actually used. The main thread adds them into its running totals; a
+   * whole-tally snapshot per batch would be O(features x batches).
+   */
+  tallyCodes: Int32Array;
+  tallyCounts: Uint32Array;
+};
+
+/** Buffers to transfer with a stream chunk. */
+export function transferablesForStreamChunk(chunk: ParquetWorkerStreamChunk): Transferable[] {
+  return [
+    ...chunk.axes.map((axis) => axis.buffer),
+    chunk.featureCodes.buffer,
+    chunk.tallyCodes.buffer,
+    chunk.tallyCounts.buffer,
+  ];
+}
 
 export type ParquetWorkerColumnarResult = {
   kind: 'columnar';
@@ -176,6 +258,23 @@ export type ParquetWorkerResponse =
             featureCodes?: Int32Array;
             featureCatalog?: PointsFeatureCatalog;
           }
+        | {
+            /**
+             * Terminal message of a `streamGeometryWithFeatures` request: the
+             * rows are already on the main thread, so this only reports how the
+             * stream ended.
+             */
+            kind: 'geometryWithFeaturesStreamEnd';
+            /** Total rows emitted across every batch of this stream. */
+            rows: number;
+            /**
+             * False when a part's projection came back without the feature
+             * column, which is the one case where the emitted rows are NOT
+             * coloured and the caller has to settle codes separately.
+             */
+            sawFeatureColumn: boolean;
+          }
+        | { kind: 'streamCancelled' }
         | { kind: 'parquetTable'; tableIpc: Uint8Array }
         | { kind: 'catalog'; catalog: PointsFeatureCatalog }
         | { kind: 'rowFeatureCodes'; codes: Int32Array; numRows: number }
@@ -197,6 +296,13 @@ export type ParquetWorkerMessage = {
 } & (
   | { direction: 'request'; request: ParquetWorkerRequest }
   | { direction: 'response'; response: ParquetWorkerResponse }
+  /**
+   * An INTERIM message: more may follow under this id, and a `response` is still
+   * to come. Only `streamGeometryWithFeatures` produces these — every other
+   * request type posts exactly one `response` and nothing else, which is why a
+   * reader that ignores this direction still behaves correctly for them.
+   */
+  | { direction: 'stream'; chunk: ParquetWorkerStreamChunk }
 );
 
 export function columnarDataFromWorkerResult(

--- a/packages/core/src/workers/pointsScan.ts
+++ b/packages/core/src/workers/pointsScan.ts
@@ -526,6 +526,77 @@ export function scanMortonTableInBounds(input: {
   }
 }
 
+/**
+ * Assign a code to each row of one feature-column batch, appending into `codeBuffer`
+ * at `offset` and tallying into `codeCounts`.
+ *
+ * Codes are allocated on first sight via the shared `nameToCode`, so they stay
+ * stable for the whole stream — a gene coloured in batch 1 keeps its code in batch
+ * 62, and `codeToName` always describes the codes actually written. For a
+ * dictionary chunk that means dictionary order, not row order; the caller documents
+ * why that is fine.
+ *
+ * Lives here rather than beside its main-thread caller because the worker's
+ * `streamGeometryWithFeatures` handler needs the identical accumulation — the two
+ * paths must assign the same codes for the same stream or the catalog they publish
+ * would not describe the codes they wrote.
+ *
+ * A DICTIONARY column resolves its values once per chunk and maps raw indices;
+ * asking the vector per row would materialise a JS string per point (~59s for 4M
+ * rows) instead of once per distinct feature. See `resolveRowFeatureCodesFromTable`.
+ */
+export function appendFeatureCodesFromColumn(
+  column: Vector,
+  rows: number,
+  codeToName: Map<number, string>,
+  nameToCode: Map<string, number>,
+  codeBuffer: Int32Array,
+  codeCounts: Map<number, number>,
+  offset: number
+): void {
+  const codeFor = (name: string): number => {
+    let code = nameToCode.get(name);
+    if (code === undefined) {
+      code = nameToCode.size;
+      nameToCode.set(name, code);
+      codeToName.set(code, name);
+    }
+    return code;
+  };
+  let written = 0;
+  let chunkStart = 0;
+  for (const chunk of column.data) {
+    if (written >= rows) {
+      break;
+    }
+    const take = Math.min(chunk.length, rows - written);
+    const dictionary = chunk.dictionary;
+    if (dictionary && chunk.nullCount === 0) {
+      const codeByIndex = new Int32Array(dictionary.length);
+      for (let index = 0; index < dictionary.length; index += 1) {
+        const name = dictionary.get(index);
+        codeByIndex[index] = name == null ? -1 : codeFor(String(name));
+      }
+      const indices = chunk.values as ArrayLike<number>;
+      for (let row = 0; row < take; row += 1) {
+        const index = indices[row];
+        const code = index >= 0 && index < codeByIndex.length ? codeByIndex[index] : -1;
+        codeBuffer[offset + written + row] = code;
+        codeCounts.set(code, (codeCounts.get(code) ?? 0) + 1);
+      }
+    } else {
+      for (let row = 0; row < take; row += 1) {
+        const value = column.get(chunkStart + row);
+        const code = value == null ? -1 : codeFor(String(value));
+        codeBuffer[offset + written + row] = code;
+        codeCounts.set(code, (codeCounts.get(code) ?? 0) + 1);
+      }
+    }
+    written += take;
+    chunkStart += chunk.length;
+  }
+}
+
 export function extractRowFeatureCodesFromTable(
   table: Table,
   featureKey: string,

--- a/packages/core/tests/parquetWorkerStreaming.spec.ts
+++ b/packages/core/tests/parquetWorkerStreaming.spec.ts
@@ -1,0 +1,351 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  disableParquetWorker,
+  enableParquetWorker,
+  setParquetWorkerDefaultEnabled,
+  setParquetWorkerRequestTimeout,
+  streamGeometryWithFeaturesInWorker,
+} from '../src/workers/parquetWorkerClient.js';
+import type {
+  ParquetWorkerMessage,
+  ParquetWorkerRequest,
+  ParquetWorkerResponse,
+  ParquetWorkerStreamChunk,
+} from '../src/workers/parquetWorkerProtocol.js';
+
+/**
+ * The streaming protocol, exercised against a scripted worker.
+ *
+ * `streamGeometryWithFeatures` is the only request type that posts more than one
+ * message per id, and the client's request/response machinery had to grow to fit
+ * it: an interim message must NOT settle the pending entry, and the silence
+ * watchdog has to measure time since the last message rather than time since the
+ * request went out. Both are easy to regress into a stream that either resolves on
+ * its first batch or times out mid-flight, and neither shows up in a type check —
+ * hence these.
+ */
+
+const STREAM_INPUT = {
+  partUrls: ['https://example.test/points/part-0.parquet'],
+  axisNames: ['x', 'y'],
+  featureKey: 'feature_name',
+  maxRows: 1_000,
+  batchSize: 100,
+};
+
+/** A batch of `rows` rows, all of one feature, with x = y = the row's index. */
+function batch(partIndex: number, rows: number, feature: { code: number; name: string } | null) {
+  const xs = Float32Array.from({ length: rows }, (_, index) => index);
+  const chunk: ParquetWorkerStreamChunk = {
+    kind: 'geometryWithFeaturesBatch',
+    partIndex,
+    partCount: 1,
+    rows,
+    axes: [xs, xs.slice()],
+    featureCodes: new Int32Array(rows).fill(feature ? feature.code : 0),
+    newFeatures: feature ? [feature] : [],
+    tallyCodes: Int32Array.from([feature ? feature.code : 0]),
+    tallyCounts: Uint32Array.from([rows]),
+  };
+  return chunk;
+}
+
+type Scripted = {
+  /** Every request the client posted, in order. */
+  posted: ParquetWorkerRequest[];
+  /** Ids the client posted, parallel to {@link posted}. */
+  postedIds: number[];
+  /** Push an interim chunk under the first stream request's id. */
+  emit(chunk: ParquetWorkerStreamChunk): void;
+  /** Post the terminal response under the first stream request's id. */
+  finish(response: ParquetWorkerResponse): void;
+  /** Fire an `error` event, as a live worker that threw would. */
+  fail(detail: string): void;
+};
+
+/**
+ * Install a Worker that records requests and replies only when told to, so each
+ * test drives the message sequence itself.
+ */
+function installScriptedWorker(): Scripted {
+  const state: Partial<Scripted> & { instance?: FakeWorker } = { posted: [], postedIds: [] };
+  let streamId: number | undefined;
+
+  class FakeWorker {
+    onmessage: ((event: MessageEvent<ParquetWorkerMessage>) => void) | null = null;
+    onerror: ((event: unknown) => void) | null = null;
+    constructor() {
+      state.instance = this;
+    }
+    postMessage(message: ParquetWorkerMessage) {
+      if (message.direction !== 'request') {
+        return;
+      }
+      state.posted?.push(message.request);
+      state.postedIds?.push(message.id);
+      if (message.request.type === 'streamGeometryWithFeatures' && streamId === undefined) {
+        streamId = message.id;
+      }
+    }
+    terminate() {
+      /* no-op */
+    }
+  }
+  (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+
+  const deliver = (message: ParquetWorkerMessage) => {
+    state.instance?.onmessage?.({ data: message } as MessageEvent<ParquetWorkerMessage>);
+  };
+  const scripted: Scripted = {
+    posted: state.posted as ParquetWorkerRequest[],
+    postedIds: state.postedIds as number[],
+    emit(chunk) {
+      if (streamId === undefined) {
+        throw new Error('no stream request has been posted yet');
+      }
+      deliver({ id: streamId, direction: 'stream', chunk });
+    },
+    finish(response) {
+      if (streamId === undefined) {
+        throw new Error('no stream request has been posted yet');
+      }
+      deliver({ id: streamId, direction: 'response', response });
+    },
+    fail(detail) {
+      state.instance?.onerror?.({ message: detail });
+    },
+  };
+  return scripted;
+}
+
+describe('parquet worker streaming protocol', () => {
+  const originalWorker = (globalThis as { Worker?: unknown }).Worker;
+
+  afterEach(() => {
+    disableParquetWorker();
+    setParquetWorkerRequestTimeout(30_000);
+    setParquetWorkerDefaultEnabled(false);
+    (globalThis as { Worker?: unknown }).Worker = originalWorker;
+  });
+
+  it('returns null without a worker, so the caller streams on the main thread', async () => {
+    disableParquetWorker();
+    setParquetWorkerDefaultEnabled(false);
+    await expect(streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {})).resolves.toBeNull();
+  });
+
+  it('delivers every interim batch and resolves on the terminal response', async () => {
+    const scripted = installScriptedWorker();
+    enableParquetWorker({ workerUrl: 'about:blank' });
+
+    const seen: ParquetWorkerStreamChunk[] = [];
+    const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
+    await Promise.resolve();
+
+    scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+    scripted.emit(batch(0, 10, { code: 1, name: 'ACE2' }));
+    // Three interim messages under one id: the pending entry must survive all of
+    // them. A settle-on-first-response client resolves here with the wrong value.
+    scripted.emit(batch(0, 5, null));
+    expect(seen).toHaveLength(3);
+
+    scripted.finish({
+      ok: true,
+      result: { kind: 'geometryWithFeaturesStreamEnd', rows: 25, sawFeatureColumn: true },
+    });
+    await expect(pending).resolves.toEqual({ rows: 25, sawFeatureColumn: true });
+  });
+
+  it('reports a stream that ended without its feature column', async () => {
+    const scripted = installScriptedWorker();
+    enableParquetWorker({ workerUrl: 'about:blank' });
+    const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
+    await Promise.resolve();
+    scripted.finish({
+      ok: true,
+      result: { kind: 'geometryWithFeaturesStreamEnd', rows: 40, sawFeatureColumn: false },
+    });
+    await expect(pending).resolves.toEqual({ rows: 40, sawFeatureColumn: false });
+  });
+
+  describe('the silence watchdog', () => {
+    it('does not fire while batches keep arriving, however long the stream runs', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+      setParquetWorkerRequestTimeout(60);
+
+      const seen: ParquetWorkerStreamChunk[] = [];
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
+      await Promise.resolve();
+
+      // Six batches at 20ms apart is 120ms of streaming under a 60ms budget: a
+      // time-since-POSTED timeout abandons this healthy stream half way through.
+      for (let index = 0; index < 6; index += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        scripted.emit(batch(0, 10, index === 0 ? { code: 0, name: 'ABCC11' } : null));
+      }
+      scripted.finish({
+        ok: true,
+        result: { kind: 'geometryWithFeaturesStreamEnd', rows: 60, sawFeatureColumn: true },
+      });
+
+      await expect(pending).resolves.toEqual({ rows: 60, sawFeatureColumn: true });
+      expect(seen).toHaveLength(6);
+    });
+
+    it('fires when a started stream goes quiet, and tells the worker to stop', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+      setParquetWorkerRequestTimeout(40);
+
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
+      await Promise.resolve();
+      const streamId = scripted.postedIds[0];
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+
+      await expect(pending).rejects.toThrow(/stream went quiet for 40ms/);
+      // Otherwise the worker keeps range-fetching a payload nobody will read.
+      expect(scripted.posted).toContainEqual({
+        type: 'cancelParquetStream',
+        streamRequestId: streamId,
+      });
+    });
+
+    it('keeps the original wording for a request that never answered at all', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+      setParquetWorkerRequestTimeout(30);
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
+      await expect(pending).rejects.toThrow(/did not respond within 30ms/);
+      expect(scripted.posted[0]?.type).toBe('streamGeometryWithFeatures');
+    });
+  });
+
+  describe('a stream that fails part way through', () => {
+    it('rejects even though batches were already delivered', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+
+      const seen: ParquetWorkerStreamChunk[] = [];
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
+      await Promise.resolve();
+
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+      scripted.emit(batch(0, 10, null));
+      scripted.finish({ ok: false, error: 'range read failed on part 1' });
+
+      // Partial success is NOT reported as success: downstream cannot tell a
+      // truncated preload from a complete one, so the caller must restart.
+      await expect(pending).rejects.toThrow(/range read failed on part 1/);
+      expect(seen).toHaveLength(2);
+    });
+
+    it('rejects when a live worker throws mid-stream, and stays enabled', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+
+      const seen: ParquetWorkerStreamChunk[] = [];
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
+      await Promise.resolve();
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+
+      // A worker that has posted chunks has demonstrably loaded, so an error event
+      // is "this request died", not "the bundle is missing" — the stream rejects
+      // but the worker must survive for the next request.
+      scripted.fail('decode panicked');
+      await expect(pending).rejects.toThrow(/decode panicked/);
+      expect(seen).toHaveLength(1);
+
+      const next = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
+      await Promise.resolve();
+      expect(scripted.posted.filter((r) => r.type === 'streamGeometryWithFeatures')).toHaveLength(
+        2
+      );
+      disableParquetWorker();
+      await expect(next).rejects.toThrow();
+    });
+
+    it('rejects and cancels when the consumer throws on a batch', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {
+        throw new Error('accumulator overflowed');
+      });
+      await Promise.resolve();
+      const streamId = scripted.postedIds[0];
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+
+      await expect(pending).rejects.toThrow(/accumulator overflowed/);
+      expect(scripted.posted).toContainEqual({
+        type: 'cancelParquetStream',
+        streamRequestId: streamId,
+      });
+    });
+
+    it('ignores a batch that arrives after the request settled', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+
+      const seen: ParquetWorkerStreamChunk[] = [];
+      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
+      await Promise.resolve();
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+      scripted.finish({ ok: false, error: 'gave up' });
+      await expect(pending).rejects.toThrow(/gave up/);
+
+      // A batch already in flight behind the cancel. Dropping it must not throw.
+      expect(() => scripted.emit(batch(0, 10, null))).not.toThrow();
+      expect(seen).toHaveLength(1);
+    });
+  });
+
+  describe('abort', () => {
+    it('rejects and cancels the worker-side stream when the load is superseded', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+
+      const controller = new AbortController();
+      const seen: ParquetWorkerStreamChunk[] = [];
+      const pending = streamGeometryWithFeaturesInWorker(
+        { ...STREAM_INPUT, signal: controller.signal },
+        (chunk) => seen.push(chunk)
+      );
+      await Promise.resolve();
+      const streamId = scripted.postedIds[0];
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+
+      controller.abort();
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+      expect(seen).toHaveLength(1);
+      // Superseding a load has to stop the worker FETCHING, not just stop us
+      // listening — otherwise a few pans queue several whole-element downloads.
+      expect(scripted.posted).toContainEqual({
+        type: 'cancelParquetStream',
+        streamRequestId: streamId,
+      });
+    });
+
+    it('never posts a request for an already-aborted signal', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+      const controller = new AbortController();
+      controller.abort();
+      await expect(
+        streamGeometryWithFeaturesInWorker({ ...STREAM_INPUT, signal: controller.signal }, () => {})
+      ).rejects.toMatchObject({ name: 'AbortError' });
+      expect(scripted.posted).toHaveLength(0);
+    });
+  });
+
+  it('fails every in-flight stream when the worker is torn down', async () => {
+    installScriptedWorker();
+    enableParquetWorker({ workerUrl: 'about:blank' });
+    const first = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
+    const second = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
+    await Promise.resolve();
+    disableParquetWorker();
+    await expect(first).rejects.toThrow(/disabled/);
+    await expect(second).rejects.toThrow(/disabled/);
+  });
+});

--- a/packages/core/tests/parquetWorkerStreaming.spec.ts
+++ b/packages/core/tests/parquetWorkerStreaming.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   disableParquetWorker,
   enableParquetWorker,
@@ -169,6 +169,17 @@ describe('parquet worker streaming protocol', () => {
   });
 
   describe('the silence watchdog', () => {
+    // Fake timers, deliberately. These assert a RELATIONSHIP between the budget and
+    // the gaps between messages, and a real-timer version of the first one — six
+    // 20ms sleeps under a 60ms budget — fails whenever the machine is busy enough
+    // for one sleep to overrun. That is a flake, not a finding.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('does not fire while batches keep arriving, however long the stream runs', async () => {
       const scripted = installScriptedWorker();
       enableParquetWorker({ workerUrl: 'about:blank' });
@@ -178,10 +189,10 @@ describe('parquet worker streaming protocol', () => {
       const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
       await Promise.resolve();
 
-      // Six batches at 20ms apart is 120ms of streaming under a 60ms budget: a
+      // Six batches 20ms apart is 120ms of streaming under a 60ms budget: a
       // time-since-POSTED timeout abandons this healthy stream half way through.
       for (let index = 0; index < 6; index += 1) {
-        await new Promise((resolve) => setTimeout(resolve, 20));
+        await vi.advanceTimersByTimeAsync(20);
         scripted.emit(batch(0, 10, index === 0 ? { code: 0, name: 'ABCC11' } : null));
       }
       scripted.finish({
@@ -203,7 +214,9 @@ describe('parquet worker streaming protocol', () => {
       const streamId = scripted.postedIds[0];
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
 
-      await expect(pending).rejects.toThrow(/stream went quiet for 40ms/);
+      const settled = expect(pending).rejects.toThrow(/stream went quiet for 40ms/);
+      await vi.advanceTimersByTimeAsync(41);
+      await settled;
       // Otherwise the worker keeps range-fetching a payload nobody will read.
       expect(scripted.posted).toContainEqual({
         type: 'cancelParquetStream',
@@ -216,7 +229,9 @@ describe('parquet worker streaming protocol', () => {
       enableParquetWorker({ workerUrl: 'about:blank' });
       setParquetWorkerRequestTimeout(30);
       const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-      await expect(pending).rejects.toThrow(/did not respond within 30ms/);
+      const settled = expect(pending).rejects.toThrow(/did not respond within 30ms/);
+      await vi.advanceTimersByTimeAsync(31);
+      await settled;
       expect(scripted.posted[0]?.type).toBe('streamGeometryWithFeatures');
     });
   });

--- a/packages/core/tests/pointsStreamAccumulator.spec.ts
+++ b/packages/core/tests/pointsStreamAccumulator.spec.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import { PointsStreamAccumulator } from '../src/pointsStreamAccumulator.js';
+import type { ParquetWorkerStreamChunk } from '../src/workers/parquetWorkerProtocol.js';
+
+/**
+ * The main-thread half of the worker's streaming preload.
+ *
+ * The worker sends DELTAS — a batch's own rows, the features it was first to see,
+ * its own tallies — so everything the caller finally hands the renderer is built
+ * here. These pin the three things that silently corrupt a preload if they drift:
+ * the append offset, the running catalog, and the per-feature counts.
+ */
+
+const BASE = {
+  axisCount: 2,
+  featureKey: 'feature_name',
+  totalRowCount: 500,
+  preloadTruncated: false,
+  hasFeatureCodeColumn: false,
+};
+
+/** One batch: explicit xs/ys and codes, plus whatever catalog entries are new. */
+function chunk(options: {
+  partIndex?: number;
+  partCount?: number;
+  xs: number[];
+  ys: number[];
+  codes: number[];
+  newFeatures?: Array<{ code: number; name: string }>;
+}): ParquetWorkerStreamChunk {
+  const tally = new Map<number, number>();
+  for (const code of options.codes) {
+    tally.set(code, (tally.get(code) ?? 0) + 1);
+  }
+  return {
+    kind: 'geometryWithFeaturesBatch',
+    partIndex: options.partIndex ?? 0,
+    partCount: options.partCount ?? 1,
+    rows: options.codes.length,
+    axes: [Float32Array.from(options.xs), Float32Array.from(options.ys)],
+    featureCodes: Int32Array.from(options.codes),
+    newFeatures: options.newFeatures ?? [],
+    tallyCodes: Int32Array.from([...tally.keys()]),
+    tallyCounts: Uint32Array.from([...tally.values()]),
+  };
+}
+
+describe('PointsStreamAccumulator', () => {
+  it('appends consecutive batches at the cursor, not over each other', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 10 });
+    accumulator.append(
+      chunk({
+        xs: [1, 2, 3],
+        ys: [10, 20, 30],
+        codes: [0, 0, 1],
+        newFeatures: [
+          { code: 0, name: 'ABCC11' },
+          { code: 1, name: 'ACE2' },
+        ],
+      })
+    );
+    accumulator.append(chunk({ xs: [4, 5], ys: [40, 50], codes: [1, 0] }));
+
+    expect(accumulator.filled).toBe(5);
+    const snapshot = accumulator.snapshot();
+    expect(snapshot.shape).toEqual([2, 5]);
+    expect(Array.from(snapshot.data[0])).toEqual([1, 2, 3, 4, 5]);
+    expect(Array.from(snapshot.data[1])).toEqual([10, 20, 30, 40, 50]);
+    expect(Array.from(snapshot.featureCodes ?? [])).toEqual([0, 0, 1, 1, 0]);
+  });
+
+  it('exposes each partial as views over the filled prefix, never the whole buffer', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 1_000 });
+    accumulator.append(chunk({ xs: [1, 2], ys: [3, 4], codes: [0, 0] }));
+    const snapshot = accumulator.snapshot();
+    // Preallocated at 1000 but only 2 rows in: a partial that reported the whole
+    // buffer would paint 998 points at the origin.
+    expect(snapshot.data[0].length).toBe(2);
+    expect(snapshot.featureCodes?.length).toBe(2);
+  });
+
+  it('grows the catalog across batches and keeps it describing the codes written', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 10 });
+    accumulator.append(
+      chunk({ xs: [1], ys: [1], codes: [0], newFeatures: [{ code: 0, name: 'ABCC11' }] })
+    );
+    expect(accumulator.snapshot().featureCatalog?.entries).toEqual([
+      { code: 0, name: 'ABCC11' },
+    ]);
+
+    accumulator.append(
+      chunk({ xs: [2], ys: [2], codes: [1], newFeatures: [{ code: 1, name: 'ACE2' }] })
+    );
+    const catalog = accumulator.snapshot().featureCatalog;
+    expect(catalog?.featureKey).toBe('feature_name');
+    expect(catalog?.entries).toEqual([
+      { code: 0, name: 'ABCC11' },
+      { code: 1, name: 'ACE2' },
+    ]);
+  });
+
+  it('reuses the catalog object across batches that brought no new features', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 10 });
+    accumulator.append(
+      chunk({ xs: [1], ys: [1], codes: [0], newFeatures: [{ code: 0, name: 'ABCC11' }] })
+    );
+    const first = accumulator.snapshot().featureCatalog;
+    accumulator.append(chunk({ xs: [2], ys: [2], codes: [0] }));
+    // Identity, not equality: rebuilding a 12k-entry catalog on each of ~60 ticks
+    // is exactly the main-thread cost this path exists to remove.
+    expect(accumulator.snapshot().featureCatalog).toBe(first);
+  });
+
+  it('accumulates per-feature tallies across batches', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 10 });
+    accumulator.append(
+      chunk({
+        xs: [1, 2, 3],
+        ys: [1, 2, 3],
+        codes: [0, 1, 0],
+        newFeatures: [
+          { code: 0, name: 'ABCC11' },
+          { code: 1, name: 'ACE2' },
+        ],
+      })
+    );
+    accumulator.append(chunk({ xs: [4, 5], ys: [4, 5], codes: [1, 1] }));
+    expect(accumulator.snapshot().featureCodeCounts).toEqual(
+      new Map([
+        [0, 2],
+        [1, 3],
+      ])
+    );
+  });
+
+  it('hands out an independent tally per snapshot', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 10 });
+    accumulator.append(chunk({ xs: [1], ys: [1], codes: [0] }));
+    const early = accumulator.snapshot().featureCodeCounts;
+    accumulator.append(chunk({ xs: [2], ys: [2], codes: [0] }));
+    // A consumer holding an earlier tick must not see it mutate underneath.
+    expect(early?.get(0)).toBe(1);
+    expect(accumulator.snapshot().featureCodeCounts?.get(0)).toBe(2);
+  });
+
+  describe('the row cap', () => {
+    it('takes only the prefix of a batch that straddles it', () => {
+      const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 4 });
+      accumulator.append(chunk({ xs: [1, 2], ys: [1, 2], codes: [0, 0] }));
+      const taken = accumulator.append(
+        chunk({ xs: [3, 4, 5, 6], ys: [3, 4, 5, 6], codes: [0, 0, 1, 1] })
+      );
+      expect(taken).toBe(2);
+      expect(accumulator.filled).toBe(4);
+      expect(Array.from(accumulator.snapshot().data[0])).toEqual([1, 2, 3, 4]);
+    });
+
+    it('re-tallies a straddling batch so the counts match the rows kept', () => {
+      const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 3 });
+      accumulator.append(
+        chunk({
+          xs: [1, 2, 3, 4],
+          ys: [1, 2, 3, 4],
+          codes: [0, 0, 1, 1],
+          newFeatures: [
+            { code: 0, name: 'ABCC11' },
+            { code: 1, name: 'ACE2' },
+          ],
+        })
+      );
+      // The batch's own tally says ACE2 has 2 rows; only one of them fits.
+      expect(accumulator.snapshot().featureCodeCounts).toEqual(
+        new Map([
+          [0, 2],
+          [1, 1],
+        ])
+      );
+    });
+
+    it('takes nothing once full, so the caller can skip a pointless tick', () => {
+      const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 2 });
+      accumulator.append(chunk({ xs: [1, 2], ys: [1, 2], codes: [0, 0] }));
+      expect(accumulator.append(chunk({ xs: [3], ys: [3], codes: [0] }))).toBe(0);
+      expect(accumulator.filled).toBe(2);
+    });
+  });
+
+  it('leaves an axis missing from a batch zeroed rather than failing the load', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, axisCount: 3, maxRows: 4 });
+    const batch = chunk({ xs: [1, 2], ys: [3, 4], codes: [0, 0] });
+    accumulator.append(batch); // two axes supplied, the element declares three
+    expect(Array.from(accumulator.snapshot().data[2])).toEqual([0, 0]);
+  });
+
+  it('carries the preload framing through to every snapshot', () => {
+    const accumulator = new PointsStreamAccumulator({
+      ...BASE,
+      maxRows: 4,
+      totalRowCount: 4_831_895,
+      preloadTruncated: true,
+      hasFeatureCodeColumn: true,
+    });
+    accumulator.append(chunk({ xs: [1], ys: [1], codes: [0] }));
+    const snapshot = accumulator.snapshot();
+    // These describe the DATASET, not how far the stream got — a consumer reads
+    // them to know the preload is a capped sample of a much larger element.
+    expect(snapshot.totalRowCount).toBe(4_831_895);
+    expect(snapshot.preloadTruncated).toBe(true);
+    expect(snapshot.hasFeatureCodeColumn).toBe(true);
+  });
+
+  it('reports an empty preload before any batch lands', () => {
+    const accumulator = new PointsStreamAccumulator({ ...BASE, maxRows: 4 });
+    expect(accumulator.filled).toBe(0);
+    const snapshot = accumulator.snapshot();
+    expect(snapshot.shape).toEqual([2, 0]);
+    expect(snapshot.featureCatalog?.entries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The problem

`VPointsSource.loadPoints` reached `streamPointsWithFeaturesByUrl` **before** the
`ensureParquetWorker()` / `isParquetWorkerEnabled()` gate below it. That method drives
parquet-wasm's `ParquetFile.stream()` and `tableFromIPC` itself, on the main thread, and it
is taken whenever `options.onProgress && featureKey` — the normal case for a points layer
coloured by feature. So the preload never reached the parquet worker even on hosts where
the worker was wired and demonstrably working for other request types.

The comment landed in #171 describes this accurately; this PR is the fix it points at.

## Measurements

Docs demo (`pnpm --filter docs build` + `docusaurus serve`), pointed at a 4.83M-row Xenium
transcripts element with a **12,448-feature** panel, capped at 4M rows. Instrumented with a
`PerformanceObserver` on `longtask` plus a patch over `Worker.prototype.postMessage`
counting `m.request.type`, and over the inbound `onmessage` to count interim messages.

| | before (`main`) | after |
| --- | --- | --- |
| worker requests posted | **zero** | `streamGeometryWithFeatures` ×1 → 62 batches, 4,000,000 rows |
| preload completes | **never** — still going at 9.4 min | **75 s** |
| worst single task | **113,256 / 92,942 / 90,514 ms** | ~4,200 ms |
| long tasks to that point | 543,101 ms and climbing | ~63,000 ms |

The before case freezes the tab hard enough that a `setInterval` sampler starves after
6.8 s and devtools evaluation times out for minutes — readings had to be persisted from
inside the `longtask` observer callback, which fires between the giant tasks.

## The fix

The same stream now runs end to end in the worker: it range-fetches each part itself and
posts batches back as it decodes them, so the progressive coloured paint is preserved while
the main thread only copies each batch into its accumulator.

Gating the existing block on the worker instead — letting worker hosts take the one-shot
`decodeGeometryWithFeatures` — was considered and rejected: it trades a frozen tab for a
blank one, on the path whose entire value is that colour appears after the first batch. The
main-thread stream therefore stays, as the fallback for hosts without a worker bundle and
for a stream that fails part way through.

### Protocol

This is the first request type that posts more than one message per id.

- `ParquetWorkerMessage` gains a `direction: 'stream'` interim variant alongside the
  terminal `response`. Interim messages use `pending.get`, not `settlePending`, so the
  entry survives until the terminal response.
- The per-request timeout (`setParquetWorkerRequestTimeout`) now measures **time since the
  last message** rather than time to the only response. Identical for request/response
  types, where exactly one message ever arrives; without it a minutes-long stream looks
  stuck. The existing "did not respond within Nms" wording is preserved for a request that
  never answered at all.
- A new `cancelParquetStream` request stops the worker **fetching** when a load is
  superseded or the client gives up, not just the client listening.
- `rejectAllPending` and the `onerror` dead-worker detection are unchanged in behaviour: a
  worker that has posted chunks counts as having answered, so a mid-stream throw fails that
  request without disabling the worker.

### Partial failure

A stream that fails after delivering batches **rejects**; there is no partial-success
return. Nothing downstream can distinguish a truncated preload from a complete one — 
consumers read `preloadTruncated` and the row cap, not "how far did it get" — so reporting
one as success would silently drop points and skew the per-feature tallies. The caller
restarts on the main-thread stream from row 0 and re-paints over the partial. Batches
already painted are safe: each progress tick carries the catalog matching its own codes,
which is the existing `remapRowFeatureCodes` handoff.

## What this does *not* fix

Necessary but not sufficient for that dataset. The feature column is a dictionary, so batch
**one** already names all 12,448 features — every one of the 62 progress ticks then
re-renders the unvirtualized feature list of #172 (12,453 checkboxes in the DOM, confirmed
directly), which dominates what remains. Note this also means there is no "before the
catalog fills in" window on this path, so #172's cost is paid on every tick rather than
only at the end; coalescing progress ticks would cut it proportionally, but that changes
paint behaviour and is left out of this PR.

## Testing

1050 unit tests pass; build and `lint:biome` clean. 25 new:

- `parquetWorkerStreaming.spec.ts` — interim messages don't settle the request; the
  watchdog does not fire while batches keep arriving but does when a started stream goes
  quiet (and cancels); failure after delivered batches rejects; a live worker throwing
  mid-stream rejects but stays enabled; abort cancels worker-side; late chunk after settle
  is ignored; consumer throwing on a batch rejects and cancels. Driven with fake timers, so
  they can't flake under CPU contention.
- `pointsStreamAccumulator.spec.ts` — append offsets, prefix views, catalog growth and
  object reuse, tally accumulation, cap straddling and re-tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
