### PR TITLE
Virtualize the points feature list, and add streamPoints() (#172, #175)

### DIFF
--- a/.changeset/points-stream-async-iterable.md
+++ b/.changeset/points-stream-async-iterable.md
@@ -1,0 +1,38 @@
+---
+'@spatialdata/core': minor
+---
+
+Add `streamPoints()`, the async-iterable form of the incremental points load
+
+`onProgress(partialResult)` left three properties implicit that an iterable states
+outright (#175): partial failure is *consumed n items, then it threw*, cancellation is
+`break`, and read-ahead depth is visible rather than unexpressed.
+
+```ts
+for await (const progress of element.streamPoints({ includeFeatureCodes: true })) {
+  draw(progress.partialResult);
+}
+```
+
+Additive:
+
+- `SpatialDataPointsSource.streamPoints` / `PointsElement.streamPoints` — an
+  `AsyncGenerator<PointsLoadProgress, PointsLoadResult>`. It yields the growing result
+  and *returns* the settled one, which `for await` discards.
+- `streamPointsMatchingFeatureCodes` beside `loadPointsMatchingFeatureCodes`.
+- `coalesceLatest`, `sampleByStep` and `drainStream` — generic combinators over async
+  iterables. `coalesceLatest` is the rate lever: it drops superseded items when the
+  consumer falls behind, sound here only because every points tick is cumulative.
+
+`PointsLoadOptions.onProgress` is deprecated but fully supported and implemented by
+draining the same generator, so the two cannot drift. It still selects the progressive
+read path, so a caller passing no callback takes the one-shot decode exactly as before.
+Nothing is scheduled for removal.
+
+Internally `streamGeometryWithFeaturesInWorker` is a generator and `postRequest`'s
+`onChunk` option is gone; streaming requests go through `postStreamingRequest`, which
+owns the queue. Neither is published, so no consumer sees the change.
+
+Not done here: `PointsResolver` keeps its `silent`-emit throttle. It has to keep the
+partial fresh on every tick while notifying rarely, which is neither combinator's
+policy, so replacing it deserves its own evidence.

--- a/.changeset/virtualize-points-feature-list.md
+++ b/.changeset/virtualize-points-feature-list.md
@@ -1,0 +1,23 @@
+---
+'@spatialdata/vis': minor
+'@spatialdata/core': patch
+---
+
+Virtualize the points feature list
+
+The list rendered a row per catalog entry. On a 12,448-feature Xenium element that is
+91,107 DOM nodes and 12,453 checkboxes for a list showing eight rows at a time (#172);
+measured after, 745 nodes and 17 rows.
+
+Windowed with `@tanstack/react-virtual` (a new `@spatialdata/vis` dependency) at a fixed
+22px row height — the rows are single lines, so nothing needs measuring. Scroll extent,
+search, sorting, colour overrides and hover highlighting are unchanged.
+
+That promoted the classification pass to the floor, so it goes too: the summary lines
+count greyed and partly-loaded rows across the whole catalog however few rows render,
+and they ran on every engine notify. They are now memoised, and only mounted rows are
+classified per render.
+
+One supporting change in `@spatialdata/core`: `PointsResolver`'s covered-codes set is
+memoised on the scan signature. It was re-parsing a 12k-entry string and returning a
+fresh `Set` per call, which defeated any memoisation downstream of it.

--- a/.changeset/virtualize-points-feature-list.md
+++ b/.changeset/virtualize-points-feature-list.md
@@ -18,6 +18,11 @@ count greyed and partly-loaded rows across the whole catalog however few rows re
 and they ran on every engine notify. They are now memoised, and only mounted rows are
 classified per render.
 
+Two things virtualization would otherwise have cost, fixed with it: the scroll
+container is focusable, so a keyboard user can still reach features outside the
+mounted window; and a hovered row that the virtualizer unmounts no longer leaves a
+stale highlight on the canvas, since removing a node fires no `mouseleave`.
+
 One supporting change in `@spatialdata/core`: `PointsResolver`'s covered-codes set is
 memoised on the scan signature. It was re-parsing a 12k-entry string and returning a
 fresh `Set` per call, which defeated any memoisation downstream of it.

--- a/packages/core/src/asyncStream.ts
+++ b/packages/core/src/asyncStream.ts
@@ -1,0 +1,128 @@
+/**
+ * Combinators for the async-iterable load APIs (#175) — rate control as a function
+ * over the stream, rather than a flag threaded through every producer.
+ *
+ * Nothing here is points-specific.
+ */
+
+/**
+ * Yield only the newest item whenever the consumer falls behind the producer, so a
+ * repaint costs what the consumer can afford rather than what the producer emits.
+ *
+ * ONLY for CUMULATIVE streams — each item a snapshot subsuming its predecessors, as
+ * a progressive load's growing buffer is. On a stream of deltas, dropping one loses
+ * data.
+ *
+ * The source is pumped independently of the consumer, so a slow consumer never
+ * throttles the decode. A source failure is raised after any item already in hand.
+ */
+export async function* coalesceLatest<T>(source: AsyncIterable<T>): AsyncGenerator<T, void> {
+  const iterator = source[Symbol.asyncIterator]();
+  /** Newest undelivered item, boxed so `undefined` stays a legal item value. */
+  let latest: { item: T } | undefined;
+  let finished = false;
+  let failure: { error: unknown } | undefined;
+  /** Resolves the consumer's wait when the pump has news. */
+  let wake: (() => void) | undefined;
+
+  const notify = () => {
+    const resume = wake;
+    wake = undefined;
+    resume?.();
+  };
+
+  const pump = (async () => {
+    try {
+      for (;;) {
+        const result = await iterator.next();
+        if (result.done) {
+          break;
+        }
+        // The overwrite IS the coalescing: whatever was waiting is superseded.
+        latest = { item: result.value };
+        notify();
+      }
+    } catch (error) {
+      failure = { error };
+    } finally {
+      finished = true;
+      notify();
+    }
+  })();
+  // The pump owns its errors (re-raised below, in consumer order), so this never
+  // rejects; referenced only so it does not look unhandled.
+  void pump;
+
+  try {
+    for (;;) {
+      if (latest) {
+        const { item } = latest;
+        latest = undefined;
+        yield item;
+        continue;
+      }
+      if (finished) {
+        if (failure) {
+          throw failure.error;
+        }
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  } finally {
+    // Cancellation, however the loop ended. Not awaited: an async generator queues
+    // `return()` behind the pump's outstanding `next()`, so awaiting would block on
+    // the very read we are abandoning. Posting it is what matters.
+    void Promise.resolve(iterator.return?.()).catch(() => {});
+  }
+}
+
+/**
+ * Yield an item only once `metric` has advanced by `step` since the last — plus the
+ * final item, always, so the consumer never ends on a stale view.
+ *
+ * "Repaint every 250k rows", not "every batch". {@link coalesceLatest} adapts to how
+ * fast the consumer is; this one to how much has changed. They compose.
+ */
+export async function* sampleByStep<T>(
+  source: AsyncIterable<T>,
+  step: number,
+  metric: (item: T) => number
+): AsyncGenerator<T, void> {
+  let lastEmitted: number | undefined;
+  /** Held back, not dropped: if the stream ends here it is the consumer's only view
+   * of the last few items. */
+  let heldBack: { item: T } | undefined;
+  for await (const item of source) {
+    const value = metric(item);
+    if (lastEmitted === undefined || value - lastEmitted >= step) {
+      lastEmitted = value;
+      heldBack = undefined;
+      yield item;
+    } else {
+      heldBack = { item };
+    }
+  }
+  if (heldBack) {
+    yield heldBack.item;
+  }
+}
+
+/**
+ * Drain an async generator into `onItem` and return its return value — the bridge
+ * that lets a deprecated `onProgress` be the same code path as the stream.
+ */
+export async function drainStream<T, TReturn>(
+  stream: AsyncGenerator<T, TReturn>,
+  onItem?: (item: T) => void
+): Promise<TReturn> {
+  for (;;) {
+    const next = await stream.next();
+    if (next.done) {
+      return next.value;
+    }
+    onItem?.(next.value);
+  }
+}

--- a/packages/core/src/engine/PointsResolver.ts
+++ b/packages/core/src/engine/PointsResolver.ts
@@ -796,12 +796,38 @@ export class PointsResolver implements ResourceResolver<PointsResolveConfig, Poi
     return { signature: key.slice(0, hash), memoryCap: Number(key.slice(hash + 1)) };
   }
 
-  /** Feature codes a matched batch/scan covers, parsed from its signature. */
-  private static coveredCodes(signature: string): Set<number> {
-    if (signature === '') {
-      return new Set();
+  /**
+   * Feature codes a matched batch/scan covers, parsed from its signature.
+   *
+   * Memoised for two reasons: the parse is O(codes) over a string 12k entries long
+   * on a wide Xenium panel, run on every coverage check; and, more importantly, a
+   * fresh `Set` per call has a fresh identity per call, so every `useMemo` keyed on
+   * it downstream would miss and the panel's whole-catalog pass would run per render
+   * regardless.
+   *
+   * Keyed by signature, a pure function of the code list, so a hit is always right.
+   * A small map rather than one slot because several signatures are live at once — a
+   * settled batch's and an in-flight scan's. Read-only; every use is `has` / `size`.
+   */
+  private static readonly coveredCodesCache = new Map<string, ReadonlySet<number>>();
+  private static readonly COVERED_CODES_CACHE_MAX = 8;
+
+  private static coveredCodes(signature: string): ReadonlySet<number> {
+    const cached = PointsResolver.coveredCodesCache.get(signature);
+    if (cached) {
+      return cached;
     }
-    return new Set(signature.split(',').map(Number));
+    const codes: ReadonlySet<number> =
+      signature === '' ? new Set<number>() : new Set(signature.split(',').map(Number));
+    if (PointsResolver.coveredCodesCache.size >= PointsResolver.COVERED_CODES_CACHE_MAX) {
+      // Map iterates in insertion order, so the first key is the oldest.
+      const oldest = PointsResolver.coveredCodesCache.keys().next();
+      if (!oldest.done) {
+        PointsResolver.coveredCodesCache.delete(oldest.value);
+      }
+    }
+    PointsResolver.coveredCodesCache.set(signature, codes);
+    return codes;
   }
 
   /**

--- a/packages/core/src/engine/PointsResolver.ts
+++ b/packages/core/src/engine/PointsResolver.ts
@@ -806,8 +806,10 @@ export class PointsResolver implements ResourceResolver<PointsResolveConfig, Poi
    * regardless.
    *
    * Keyed by signature, a pure function of the code list, so a hit is always right.
-   * A small map rather than one slot because several signatures are live at once — a
-   * settled batch's and an in-flight scan's. Read-only; every use is `has` / `size`.
+   * A small LRU rather than one slot because several signatures are live at once — a
+   * settled batch's and an in-flight scan's — and the settled one is read on every
+   * coverage check while each selection change inserts a new one. Read-only; every
+   * use is `has` / `size`.
    */
   private static readonly coveredCodesCache = new Map<string, ReadonlySet<number>>();
   private static readonly COVERED_CODES_CACHE_MAX = 8;
@@ -815,12 +817,17 @@ export class PointsResolver implements ResourceResolver<PointsResolveConfig, Poi
   private static coveredCodes(signature: string): ReadonlySet<number> {
     const cached = PointsResolver.coveredCodesCache.get(signature);
     if (cached) {
+      // Re-insert to move this key to the end. Without it the map is FIFO, and the
+      // signature read most often — a settled batch's — is the one inserted
+      // earliest, so eight selection changes evict exactly the entry that matters.
+      PointsResolver.coveredCodesCache.delete(signature);
+      PointsResolver.coveredCodesCache.set(signature, cached);
       return cached;
     }
     const codes: ReadonlySet<number> =
       signature === '' ? new Set<number>() : new Set(signature.split(',').map(Number));
     if (PointsResolver.coveredCodesCache.size >= PointsResolver.COVERED_CODES_CACHE_MAX) {
-      // Map iterates in insertion order, so the first key is the oldest.
+      // Map iterates in insertion order, so the first key is the least recently used.
       const oldest = PointsResolver.coveredCodesCache.keys().next();
       if (!oldest.done) {
         PointsResolver.coveredCodesCache.delete(oldest.value);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,9 @@
  * Core library for interfacing with SpatialData stores in TypeScript/JavaScript
  */
 
+// Combinators for the async-iterable streaming APIs (#175) — `streamPoints` and
+// friends. Generic; nothing points-specific.
+export { coalesceLatest, drainStream, sampleByStep } from './asyncStream.js';
 // Resource Resolver contracts (ADR 0004).
 export * from './engine/index.js';
 // Memory accounting (ADR 0005).

--- a/packages/core/src/models/VPointsSource.ts
+++ b/packages/core/src/models/VPointsSource.ts
@@ -1,4 +1,5 @@
 import type { Vector } from 'apache-arrow';
+import { drainStream } from '../asyncStream.js';
 import {
   decodeIntStat,
   decodeUnsignedIntStat,
@@ -94,6 +95,45 @@ function extentMayContainSelectedCodes(
     return true;
   }
   return extent.max >= selectedMin && extent.min <= selectedMax;
+}
+
+/** What the feature-index scan generators yield and return. */
+type MatchingFeatureScanChunks = AsyncGenerator<
+  { progress: PointsLoadProgress },
+  { totalRowCount: number; axisNames: string[]; scannedRows: number; matchedRows: number }
+>;
+
+/**
+ * Re-express the feature-index scan's chunks as a progress stream that RETURNS the
+ * settled result. Each `partialResult` is already the full accumulated buffer, so no
+ * re-accumulation here; the totals come from the generator's return value, which
+ * also counts rows scanned after the last match.
+ */
+async function* collectMatchingFeatureScan(
+  chunks: MatchingFeatureScanChunks,
+  memoryCap: number,
+  signal?: AbortSignal
+): AsyncGenerator<PointsLoadProgress, PointsLoadResult> {
+  let latest: PointsLoadResult | undefined;
+  for (;;) {
+    checkAbort(signal);
+    const next = await chunks.next();
+    if (next.done) {
+      const { totalRowCount, scannedRows, matchedRows, axisNames } = next.value;
+      if (!latest) {
+        // No chunks matched at all.
+        return emptyFilteredPointsResult(axisNames, totalRowCount);
+      }
+      return {
+        ...latest,
+        totalRowCount,
+        scannedRowCount: scannedRows,
+        preloadTruncated: matchedRows >= memoryCap,
+      };
+    }
+    latest = next.value.progress.partialResult;
+    yield next.value.progress;
+  }
 }
 
 function emptyFilteredPointsResult(axisNames: string[], totalRowCount: number): PointsLoadResult {
@@ -613,7 +653,7 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
    * Returns null when the fast path does not apply (non-URL store, no suffix-range
    * support, no streaming reader, nothing decoded) so the caller falls through.
    */
-  private async streamPointsWithFeaturesByUrl(
+  private async *streamPointsWithFeaturesByUrl(
     parquetPath: string,
     options: {
       axisNames: string[];
@@ -622,10 +662,9 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       totalRowCount: number;
       preloadTruncated: boolean;
       hasFeatureCodeColumn: boolean;
-      onProgress?: (progress: PointsLoadProgress) => void;
       signal?: AbortSignal;
     }
-  ): Promise<PointsLoadResult | null> {
+  ): AsyncGenerator<PointsLoadProgress, PointsLoadResult | null> {
     const partUrls = await this.resolveStreamablePartUrls(parquetPath);
     if (!partUrls) {
       return null;
@@ -710,14 +749,14 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
             filled
           );
           filled += rows;
-          options.onProgress?.({
+          yield {
             // Unfiltered preload: every decoded row is kept, so scanned === matched.
             scannedRows: filled,
             matchedRows: filled,
             partIndex,
             partCount: partUrls.length,
             partialResult: snapshot(),
-          });
+          };
         }
       } finally {
         reader.releaseLock();
@@ -747,7 +786,7 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
    * instead: see the contract note on `streamGeometryWithFeaturesInWorker` for why
    * a partial is not reported as success.
    */
-  private async streamPointsWithFeaturesInWorker(
+  private async *streamPointsWithFeaturesInWorker(
     parquetPath: string,
     options: {
       axisNames: string[];
@@ -756,10 +795,9 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       totalRowCount: number;
       preloadTruncated: boolean;
       hasFeatureCodeColumn: boolean;
-      onProgress?: (progress: PointsLoadProgress) => void;
       signal?: AbortSignal;
     }
-  ): Promise<PointsLoadResult | null> {
+  ): AsyncGenerator<PointsLoadProgress, PointsLoadResult | null> {
     ensureParquetWorker();
     if (!isParquetWorkerEnabled()) {
       return null;
@@ -779,36 +817,49 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       hasFeatureCodeColumn: options.hasFeatureCodeColumn,
     });
 
-    const end = await streamGeometryWithFeaturesInWorker(
-      {
-        partUrls,
-        axisNames,
-        featureKey,
-        maxRows,
-        batchSize: PRELOAD_STREAM_BATCH_ROWS,
-        ...(options.signal ? { signal: options.signal } : {}),
-      },
-      (chunk) => {
-        if (accumulator.append(chunk) === 0) {
-          return;
+    const chunks = streamGeometryWithFeaturesInWorker({
+      partUrls,
+      axisNames,
+      featureKey,
+      maxRows,
+      batchSize: PRELOAD_STREAM_BATCH_ROWS,
+      ...(options.signal ? { signal: options.signal } : {}),
+    });
+    // Hand-driven rather than `for await`, because this stream's END is its return
+    // value, which `for await` discards. That costs the automatic close, hence the
+    // `finally`: without it a consumer breaking out of OUR stream leaves the worker
+    // fetching a payload nobody will read. `chunks` is always suspended at a yield by
+    // then — a return arriving mid-`next()` queues until our own yield — so awaiting
+    // cannot deadlock.
+    try {
+      for (;;) {
+        const next = await chunks.next();
+        if (next.done) {
+          if (!next.value) {
+            return null;
+          }
+          break;
         }
-        options.onProgress?.({
+        const chunk = next.value;
+        if (accumulator.append(chunk) === 0) {
+          continue;
+        }
+        yield {
           // Unfiltered preload: every decoded row is kept, so scanned === matched.
           scannedRows: accumulator.filled,
           matchedRows: accumulator.filled,
           partIndex: chunk.partIndex,
           partCount: chunk.partCount,
           partialResult: accumulator.snapshot(),
-        });
+        };
       }
-    );
-    if (!end) {
-      return null;
+    } finally {
+      await chunks.return(null);
     }
     return accumulator.filled > 0 ? accumulator.snapshot() : null;
   }
 
-  private async streamPointsGeometryByRowGroup(
+  private async *streamPointsGeometryByRowGroup(
     parquetPath: string,
     options: {
       axisNames: string[];
@@ -820,10 +871,9 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
        * per-row codes at all — the worker gates code extraction on `featureKey`. */
       featureKey?: string;
       featureCodeColumnName?: string;
-      onProgress?: (progress: PointsLoadProgress) => void;
       signal?: AbortSignal;
     }
-  ): Promise<PointsLoadResult | null> {
+  ): AsyncGenerator<PointsLoadProgress, PointsLoadResult | null> {
     const dataset = await this.loadParquetDatasetMetadata(parquetPath);
     if (!dataset || dataset.totalNumRowGroups <= 0) {
       return null;
@@ -921,30 +971,80 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
         }
       }
       filled += rows;
-      options.onProgress?.({
+      yield {
         // Unfiltered preload: every decoded row is kept, so scanned === matched.
         scannedRows: filled,
         matchedRows: filled,
         partIndex: rowGroupIndex,
         partCount: dataset.totalNumRowGroups,
         partialResult: snapshot(),
-      });
+      };
     }
     return filled > 0 ? snapshot() : null;
   }
 
+  /**
+   * Load a points element, yielding the growing result as it decodes — the
+   * pull-style form of {@link loadPoints}, and the one to prefer (#175).
+   *
+   * ```ts
+   * for await (const progress of source.streamPoints(path, { includeFeatureCodes: true })) {
+   *   draw(progress.partialResult);
+   * }
+   * ```
+   *
+   * Partial failure is "consumed n items, then it threw" — what you already drew
+   * stays drawn. `break` cancels: it runs the `finally` chain where the worker-backed
+   * stream posts its cancel (`options.signal` still covers supersession decided
+   * elsewhere). Rate control is a combinator — `coalesceLatest` / `sampleByStep`.
+   *
+   * RETURNS the final {@link PointsLoadResult}, which `for await` discards; drive
+   * `next()` for both, or use {@link loadPoints}. Unlike `loadPoints` this always
+   * takes a progressive path where one is available.
+   */
+  streamPoints(
+    elementPath: string,
+    options: PointsLoadOptions = {}
+  ): AsyncGenerator<PointsLoadProgress, PointsLoadResult> {
+    return this.pointsStream(elementPath, options, true);
+  }
+
+  /**
+   * Load a points element in one call. Implemented by draining {@link streamPoints},
+   * so the deprecated `onProgress` callback cannot drift from the stream.
+   */
   async loadPoints(
     elementPath: string,
     options: PointsLoadOptions = {}
   ): Promise<PointsLoadResult> {
+    return drainStream(
+      // No `onProgress` means the caller never wanted the progressive decode —
+      // the path selection `loadPoints` has always made.
+      this.pointsStream(elementPath, options, options.onProgress !== undefined),
+      options.onProgress
+    );
+  }
+
+  /**
+   * The body shared by {@link streamPoints} and {@link loadPoints}. `progressive`
+   * picks between the streaming readers and the one-shot decodes — not simply
+   * `true`, because a stream nobody is watching would be a different, slower load
+   * for every caller that never asked for ticks.
+   */
+  private async *pointsStream(
+    elementPath: string,
+    options: PointsLoadOptions,
+    progressive: boolean
+  ): AsyncGenerator<PointsLoadProgress, PointsLoadResult> {
     checkAbort(options.signal);
     const memoryCap = resolvePointsMemoryCap(options.memoryCap);
     if (options.featureCodes !== undefined && options.fullDatasetFeatureScan === true) {
-      return this.loadPointsMatchingFeatureCodes(elementPath, {
+      const scan = this.loadPointsMatchingFeatureCodesByChunk(elementPath, {
         memoryCap,
         featureCodes: options.featureCodes,
-        onProgress: options.onProgress,
+        ...(options.signal ? { abort: options.signal } : {}),
       });
+      return yield* collectMatchingFeatureScan(scan, memoryCap, options.signal);
     }
 
     const parquetPath = getParquetPath(elementPath);
@@ -1017,7 +1117,7 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
     // That keeps the tab responsive but shows nothing until the entire payload
     // decodes — a frozen tab traded for a blank one, on the path whose entire value
     // is that colour appears after the first batch.
-    if (options.onProgress && featureKey) {
+    if (progressive && featureKey) {
       const streamOptions = {
         axisNames,
         featureKey,
@@ -1025,11 +1125,14 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
         totalRowCount: rowCount,
         preloadTruncated: truncatePreload,
         hasFeatureCodeColumn: featureCodeColumnName !== undefined,
-        onProgress: options.onProgress,
         ...(options.signal ? { signal: options.signal } : {}),
       };
+      // `yield*` delegates: each reader's ticks reach our consumer unchanged and its
+      // return value is what we test. A reader that throws after yielding has already
+      // handed rows over — deliberate; the next reader restarts from row 0 and paints
+      // over the partial.
       try {
-        const streamed = await this.streamPointsWithFeaturesInWorker(parquetPath, streamOptions);
+        const streamed = yield* this.streamPointsWithFeaturesInWorker(parquetPath, streamOptions);
         if (streamed?.featureCodes !== undefined) {
           return streamed;
         }
@@ -1044,7 +1147,7 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
         );
       }
       try {
-        const streamed = await this.streamPointsWithFeaturesByUrl(parquetPath, streamOptions);
+        const streamed = yield* this.streamPointsWithFeaturesByUrl(parquetPath, streamOptions);
         if (streamed?.featureCodes !== undefined) {
           return streamed;
         }
@@ -1062,9 +1165,9 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       // supports row-group range reads. Streams the axes — plus an authoritative
       // integer code column when the dataset has one, so those datasets stream
       // COLOURED rather than colour-later.
-      if (options.onProgress && (await this.canLoadParquetRowGroups())) {
+      if (progressive && (await this.canLoadParquetRowGroups())) {
         try {
-          const streamed = await this.streamPointsGeometryByRowGroup(parquetPath, {
+          const streamed = yield* this.streamPointsGeometryByRowGroup(parquetPath, {
             axisNames,
             columns: [...axisNames, ...(featureCodeColumnName ? [featureCodeColumnName] : [])],
             maxRows,
@@ -1072,7 +1175,6 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
             preloadTruncated: truncatePreload,
             ...(featureKey ? { featureKey } : {}),
             ...(featureCodeColumnName ? { featureCodeColumnName } : {}),
-            onProgress: options.onProgress,
             ...(options.signal ? { signal: options.signal } : {}),
           });
           // The streamed batch is the FINAL result only when nothing more is needed
@@ -1694,12 +1796,15 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
     }
     return { totalRowCount, axisNames, scannedRows, matchedRows };
   }
-  async loadPointsMatchingFeatureCodes(
+  /**
+   * Whole-dataset scan for a feature selection, yielding the growing matched batch —
+   * the pull-style form of {@link loadPointsMatchingFeatureCodes}.
+   */
+  streamPointsMatchingFeatureCodes(
     elementPath: string,
     options: {
       memoryCap: number;
       featureCodes: readonly number[];
-      onProgress?: (progress: PointsLoadProgress) => void;
       /** Authoritative name→code map for dict-only elements (no `*_codes`
        * column), letting the scan resolve each row's `feature_name` to the same
        * code space the selection was made in. When absent for a dict-only
@@ -1708,34 +1813,36 @@ export default class SpatialDataPointsSource extends SpatialDataTableSource {
       /** Aborts the scan between row-group chunks when it is superseded. */
       signal?: AbortSignal;
     }
-  ): Promise<PointsLoadResult> {
-    const chunkGenerator = this.loadPointsMatchingFeatureCodesByChunk(elementPath, {
-      ...options,
-      abort: options.signal,
-    });
-    // Each `progress.partialResult` is already the full accumulated buffer, so the
-    // last one IS the whole matched batch — no need to re-accumulate/concat here.
-    // Final totals come from the generator's return value (authoritative: it also
-    // counts rows scanned after the last match, which the last partial can't see).
-    let latest: PointsLoadResult | undefined;
-    while (true) {
-      checkAbort(options.signal);
-      const next = await chunkGenerator.next();
-      if (next.done) {
-        const { totalRowCount, scannedRows, matchedRows, axisNames } = next.value;
-        if (!latest) {
-          return emptyFilteredPointsResult(axisNames, totalRowCount);
-        }
-        return {
-          ...latest,
-          totalRowCount,
-          scannedRowCount: scannedRows,
-          preloadTruncated: matchedRows >= options.memoryCap,
-        };
-      }
-      options.onProgress?.(next.value.progress);
-      latest = next.value.progress.partialResult;
+  ): AsyncGenerator<PointsLoadProgress, PointsLoadResult> {
+    return collectMatchingFeatureScan(
+      this.loadPointsMatchingFeatureCodesByChunk(elementPath, {
+        ...options,
+        ...(options.signal ? { abort: options.signal } : {}),
+      }),
+      options.memoryCap,
+      options.signal
+    );
+  }
+
+  async loadPointsMatchingFeatureCodes(
+    elementPath: string,
+    options: {
+      memoryCap: number;
+      featureCodes: readonly number[];
+      /**
+       * @deprecated Prefer {@link streamPointsMatchingFeatureCodes}; this is
+       * implemented by draining it.
+       */
+      onProgress?: (progress: PointsLoadProgress) => void;
+      featureCodeByName?: ReadonlyMap<string, number>;
+      /** Aborts the scan between row-group chunks when it is superseded. */
+      signal?: AbortSignal;
     }
+  ): Promise<PointsLoadResult> {
+    return drainStream(
+      this.streamPointsMatchingFeatureCodes(elementPath, options),
+      options.onProgress
+    );
   }
 
   private async resolveExplicitFeatureCodeColumn(elementPath: string): Promise<{

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -663,6 +663,20 @@ export class PointsElement extends AbstractSpatialElement<'points', PointsAttrs>
     return this.vPoints.loadPoints(`points/${this.key}`, options);
   }
 
+  /**
+   * This element's points as an async iterable, yielding the growing result — the
+   * pull-style form of {@link loadPoints}. See `SpatialDataPointsSource.streamPoints`.
+   *
+   * ```ts
+   * for await (const progress of element.streamPoints({ includeFeatureCodes: true })) {
+   *   draw(progress.partialResult);
+   * }
+   * ```
+   */
+  streamPoints(options?: PointsLoadOptions) {
+    return this.vPoints.streamPoints(`points/${this.key}`, options);
+  }
+
   async loadRowFeatureCodes(options?: {
     memoryCap?: number;
     featureCatalog?: PointsFeatureCatalog | null;
@@ -680,12 +694,23 @@ export class PointsElement extends AbstractSpatialElement<'points', PointsAttrs>
   async loadPointsMatchingFeatureCodes(options: {
     memoryCap: number;
     featureCodes: readonly number[];
+    /** @deprecated Prefer {@link streamPointsMatchingFeatureCodes}. */
     onProgress?: (progress: PointsLoadProgress) => void;
     featureCodeByName?: ReadonlyMap<string, number>;
     /** Aborts the scan between row-group chunks when it is superseded. */
     signal?: AbortSignal;
   }) {
     return this.vPoints.loadPointsMatchingFeatureCodes(`points/${this.key}`, options);
+  }
+
+  /** The async-iterable form of {@link loadPointsMatchingFeatureCodes}. */
+  streamPointsMatchingFeatureCodes(options: {
+    memoryCap: number;
+    featureCodes: readonly number[];
+    featureCodeByName?: ReadonlyMap<string, number>;
+    signal?: AbortSignal;
+  }) {
+    return this.vPoints.streamPointsMatchingFeatureCodes(`points/${this.key}`, options);
   }
 
   async loadFeatureCounts() {

--- a/packages/core/src/pointsLoadOptions.ts
+++ b/packages/core/src/pointsLoadOptions.ts
@@ -13,7 +13,14 @@ export interface PointsLoadOptions {
   memoryCap?: number;
   /** When set, scan the dataset for matching features instead of capping raw rows first. */
   featureCodes?: readonly number[];
-  /** Progress callback for filtered scans (main thread). */
+  /**
+   * Progress callback for progressive/filtered loads.
+   *
+   * @deprecated Prefer `streamPoints`, which `loadPoints` now drains (#175): partial
+   * failure is "consumed n items, then it threw", cancellation is `break`, and rate
+   * control is a combinator rather than a producer flag. Still fully supported, and
+   * still what selects the progressive read path; nothing scheduled for removal.
+   */
   onProgress?: (progress: PointsLoadProgress) => void;
   /**
    * When true with {@link featureCodes}, scan the full dataset for matches (slow).

--- a/packages/core/src/workers/parquetWorkerClient.ts
+++ b/packages/core/src/workers/parquetWorkerClient.ts
@@ -21,11 +21,12 @@ type PendingRequest = {
   reject: (error: Error) => void;
   timeout?: ReturnType<typeof setTimeout>;
   /**
-   * Set only for a STREAMING request. Its presence is what makes an interim
-   * message legal for this id — and what tells the timeout and the abort path to
-   * send the worker a cancel, since a stream it is not told about keeps fetching.
+   * Set only for a STREAMING request, and only by {@link postStreamingRequest} — its
+   * generator's sink, not a caller-supplied callback. Its presence makes an interim
+   * message legal for this id, and tells the timeout and abort paths to cancel: a
+   * stream the worker is not told about keeps fetching.
    */
-  onChunk?: (chunk: ParquetWorkerStreamChunk) => void;
+  deliverChunk?: (chunk: ParquetWorkerStreamChunk) => void;
   /**
    * Whether any interim chunk has been delivered. A stream that fails after this
    * has already handed the caller usable rows, so the failure is not equivalent
@@ -98,7 +99,7 @@ function armTimeout(id: number) {
     if (!stalled) {
       return;
     }
-    if (stalled.onChunk) {
+    if (stalled.deliverChunk) {
       // Stop the worker fetching a payload nobody is left to receive.
       cancelWorkerStream(id);
     }
@@ -170,7 +171,7 @@ function ensureWorkerListener() {
       // This is the whole difference between this protocol and the strict
       // request/response one it grew out of.
       const streaming = pending.get(message.id);
-      if (!streaming?.onChunk) {
+      if (!streaming?.deliverChunk) {
         // Either the request already settled (timed out, aborted, or the worker
         // died) and a batch was in flight behind the cancel, or a non-streaming
         // request somehow got one. Dropping it is right in both cases.
@@ -179,7 +180,7 @@ function ensureWorkerListener() {
       streaming.deliveredChunk = true;
       armTimeout(message.id);
       try {
-        streaming.onChunk(message.chunk);
+        streaming.deliverChunk(message.chunk);
       } catch (error) {
         // The consumer threw on a batch, so it cannot use the rest of the stream.
         settlePending(message.id)?.reject(
@@ -232,8 +233,6 @@ function ensureWorkerListener() {
 }
 
 type PostRequestOptions = {
-  /** Provide to receive interim batches; see {@link PendingRequest.onChunk}. */
-  onChunk?: (chunk: ParquetWorkerStreamChunk) => void;
   /**
    * Abandon the request when this fires. For a stream that also posts a cancel,
    * so a superseded load stops costing bandwidth in the worker rather than
@@ -241,6 +240,30 @@ type PostRequestOptions = {
    */
   signal?: AbortSignal;
 };
+
+/**
+ * Abandoning `signal` settles the pending entry and, for a stream, tells the worker
+ * to stop fetching. Shared by the request/response and streaming posts.
+ */
+function attachAbort(id: number, entry: PendingRequest, signal: AbortSignal | undefined) {
+  if (!signal) {
+    return;
+  }
+  const onAbort = () => {
+    const aborted = settlePending(id);
+    if (!aborted) {
+      return;
+    }
+    if (aborted.deliverChunk) {
+      cancelWorkerStream(id);
+    }
+    aborted.reject(new DOMException('Aborted', 'AbortError'));
+  };
+  signal.addEventListener('abort', onAbort, { once: true });
+  entry.removeAbortListener = () => {
+    signal.removeEventListener('abort', onAbort);
+  };
+}
 
 function postRequest<T>(
   request: ParquetWorkerRequest,
@@ -261,25 +284,9 @@ function postRequest<T>(
       resolve: resolve as (value: unknown) => void,
       reject,
       deliveredChunk: false,
-      ...(options.onChunk ? { onChunk: options.onChunk } : {}),
     };
     pending.set(id, entry);
-    if (signal) {
-      const onAbort = () => {
-        const aborted = settlePending(id);
-        if (!aborted) {
-          return;
-        }
-        if (aborted.onChunk) {
-          cancelWorkerStream(id);
-        }
-        aborted.reject(new DOMException('Aborted', 'AbortError'));
-      };
-      signal.addEventListener('abort', onAbort, { once: true });
-      entry.removeAbortListener = () => {
-        signal.removeEventListener('abort', onAbort);
-      };
-    }
+    attachAbort(id, entry, signal);
     armTimeout(id);
     const message: ParquetWorkerMessage = { id, direction: 'request', request };
     if (transferables.length > 0) {
@@ -288,6 +295,91 @@ function postRequest<T>(
       activeWorker.postMessage(message);
     }
   });
+}
+
+/**
+ * Post a STREAMING request, yielding its interim chunks and returning the terminal
+ * response's result.
+ *
+ * The worker boundary stays push (`postMessage` is push), so this sits on top of the
+ * message plumbing: chunks land in a queue and the generator drains it. What it buys
+ * is semantics the callback shape could only state in prose — partial failure is
+ * `try`/`catch` around the loop, `break` runs the `finally` below and cancels, and
+ * the queue makes read-ahead depth visible. Credit-based backpressure (the worker
+ * waiting before decoding on) is a further step, worth taking only if depth hurts.
+ *
+ * No transferables: streaming requests carry plain descriptors and the worker
+ * range-fetches the bytes itself.
+ */
+async function* postStreamingRequest<T>(
+  request: ParquetWorkerRequest,
+  options: PostRequestOptions = {}
+): AsyncGenerator<ParquetWorkerStreamChunk, T> {
+  const activeWorker = worker;
+  if (!activeWorker) {
+    throw new Error('Parquet worker is not enabled');
+  }
+  if (options.signal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
+  const id = ++nextRequestId;
+  const queue: ParquetWorkerStreamChunk[] = [];
+  let settled: { ok: true; value: T } | { ok: false; error: Error } | undefined;
+  let wake: (() => void) | undefined;
+  const notify = () => {
+    const resume = wake;
+    wake = undefined;
+    resume?.();
+  };
+
+  const entry: PendingRequest = {
+    resolve: (value) => {
+      settled = { ok: true, value: value as T };
+      notify();
+    },
+    reject: (error) => {
+      settled = { ok: false, error };
+      notify();
+    },
+    deliveredChunk: false,
+    deliverChunk: (chunk) => {
+      queue.push(chunk);
+      notify();
+    },
+  };
+  pending.set(id, entry);
+  attachAbort(id, entry, options.signal);
+  armTimeout(id);
+  activeWorker.postMessage({ id, direction: 'request', request } satisfies ParquetWorkerMessage);
+
+  try {
+    for (;;) {
+      // Queue before terminal state, always: chunks that arrived alongside the end
+      // (or a rejection) are still the caller's — dropping them would discard rows
+      // the worker already decoded and sent.
+      const chunk = queue.shift();
+      if (chunk !== undefined) {
+        yield chunk;
+        continue;
+      }
+      if (settled) {
+        if (settled.ok) {
+          return settled.value;
+        }
+        throw settled.error;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  } finally {
+    // The consumer left early — `break`, an exception, or collection. On a normal
+    // end the message handler has already settled this id, so this is a no-op.
+    if (pending.has(id)) {
+      settlePending(id);
+      cancelWorkerStream(id);
+    }
+  }
 }
 
 export function transferablesForParquetPayload(
@@ -732,27 +824,25 @@ export type StreamGeometryWithFeaturesEnd = {
  * does the parquet decode on the UI thread, which is where a 4M-row Xenium
  * element's tens of seconds of long tasks come from.
  *
- * Returns null when the worker is off or there is nothing to read, matching the
- * other `*InWorker` helpers — the caller falls through to the main-thread stream.
+ * Yields each decoded batch and RETURNS the stream's end summary — or `null` when
+ * the worker is off or there is nothing to read, matching the other `*InWorker`
+ * helpers, so the caller falls through to the main-thread stream.
  *
- * ON FAILURE it REJECTS, even when batches were already delivered and painted.
- * There is no partial-success return, deliberately: a truncated preload is
- * indistinguishable to every downstream consumer from a complete one (they read
- * `preloadTruncated` and the row cap, not "how far did the stream get"), so
- * reporting one as success would silently drop points and skew the per-feature
- * tallies. Rejecting sends the caller to the main-thread stream, which restarts
- * from row 0 and re-paints over the partial — the worst case is the cost this
- * whole path exists to avoid, which is exactly the status quo it replaced.
+ * ON FAILURE it THROWS, even when batches were already yielded. There is no
+ * partial-success return, deliberately: downstream reads `preloadTruncated` and the
+ * row cap, not "how far did the stream get", so reporting a truncated preload as
+ * success would silently drop points and skew the per-feature tallies. Throwing
+ * sends the caller to the main-thread stream, which restarts from row 0.
  *
- * Batches already handed to `onBatch` are therefore not a commitment. They are
- * safe to have painted: each progress tick carries the catalog matching its own
- * codes, so a later tick from a different code space is reconciled by the same
- * `remapRowFeatureCodes` handoff that already spans preload and full scan.
+ * Batches already yielded are therefore not a commitment — the consumer took n
+ * items, then it threw. They are safe to have painted: each carries the catalog
+ * matching its own codes, reconciled by the same `remapRowFeatureCodes` handoff that
+ * already spans preload and full scan. `break` tells the worker to stop fetching;
+ * see {@link postStreamingRequest}.
  */
-export async function streamGeometryWithFeaturesInWorker(
-  input: StreamGeometryWithFeaturesInput,
-  onBatch: (chunk: ParquetWorkerStreamChunk) => void
-): Promise<StreamGeometryWithFeaturesEnd | null> {
+export async function* streamGeometryWithFeaturesInWorker(
+  input: StreamGeometryWithFeaturesInput
+): AsyncGenerator<ParquetWorkerStreamChunk, StreamGeometryWithFeaturesEnd | null> {
   ensureParquetWorker();
   if (!isParquetWorkerEnabled()) {
     return null;
@@ -765,11 +855,9 @@ export async function streamGeometryWithFeaturesInWorker(
     type: 'streamGeometryWithFeatures',
     ...rest,
   };
-  const result = await postRequest<Extract<ParquetWorkerResponse, { ok: true }>['result']>(
-    request,
-    [],
-    { onChunk: onBatch, ...(signal ? { signal } : {}) }
-  );
+  const result = yield* postStreamingRequest<
+    Extract<ParquetWorkerResponse, { ok: true }>['result']
+  >(request, signal ? { signal } : {});
   if (result.kind !== 'geometryWithFeaturesStreamEnd') {
     throw new Error('Unexpected parquet worker response for streamGeometryWithFeatures');
   }

--- a/packages/core/tests/asyncStream.spec.ts
+++ b/packages/core/tests/asyncStream.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import { coalesceLatest, drainStream, sampleByStep } from '../src/asyncStream.js';
+
+/**
+ * The combinators behind the async-iterable streaming APIs (#175).
+ *
+ * `coalesceLatest` is the one with teeth: it deliberately DROPS items, sound only
+ * because every points tick is a cumulative snapshot. These pin both halves — the
+ * newest item always survives, and nothing is dropped when the consumer keeps up.
+ */
+
+/** A generator over `items`, optionally ending by throwing. */
+async function* from<T>(items: T[], failWith?: Error): AsyncGenerator<T, void> {
+  for (const item of items) {
+    yield item;
+  }
+  if (failWith) {
+    throw failWith;
+  }
+}
+
+/** Yield to the microtask queue enough times for a pump to run ahead. */
+async function settle() {
+  for (let index = 0; index < 16; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('coalesceLatest', () => {
+  it('passes everything through when the consumer keeps up', async () => {
+    const seen: number[] = [];
+    for await (const item of coalesceLatest(from([1, 2, 3]))) {
+      seen.push(item);
+    }
+    // The producer here is synchronous-ish, so this is not a guarantee about
+    // dropping; it is the floor — nothing is invented or reordered.
+    expect(seen[seen.length - 1]).toBe(3);
+    expect(seen).toEqual([...seen].sort((a, b) => a - b));
+  });
+
+  it('drops superseded items while the consumer is busy, and never the newest', async () => {
+    // A producer that runs to completion while the consumer is asleep on its
+    // first item — the shape of a worker decoding faster than a panel repaints.
+    async function* fast() {
+      for (let index = 1; index <= 50; index += 1) {
+        yield index;
+        await Promise.resolve();
+      }
+    }
+    const seen: number[] = [];
+    for await (const item of coalesceLatest(fast())) {
+      seen.push(item);
+      await settle();
+    }
+    expect(seen.length).toBeLessThan(50);
+    // The last value is the one that matters: for a cumulative stream it is the
+    // whole answer, and dropping it would lose data rather than save work.
+    expect(seen[seen.length - 1]).toBe(50);
+  });
+
+  it('delivers what it already has before raising the source failure', async () => {
+    const seen: number[] = [];
+    const boom = new Error('range read failed');
+    await expect(
+      (async () => {
+        for await (const item of coalesceLatest(from([1, 2, 3], boom))) {
+          seen.push(item);
+        }
+      })()
+    ).rejects.toThrow(/range read failed/);
+    // "Consumed n items, then it threw" — the partial-failure contract, as
+    // ordinary control flow.
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[seen.length - 1]).toBe(3);
+  });
+
+  it('closes the source when the consumer breaks out', async () => {
+    const closed = vi.fn();
+    async function* cancellable() {
+      try {
+        for (let index = 0; ; index += 1) {
+          yield index;
+        }
+      } finally {
+        closed();
+      }
+    }
+    for await (const _item of coalesceLatest(cancellable())) {
+      break;
+    }
+    await settle();
+    // `break` is cancellation: the source's `finally` is where a worker-backed
+    // stream posts its cancel.
+    expect(closed).toHaveBeenCalled();
+  });
+});
+
+describe('sampleByStep', () => {
+  it('emits only once the metric has advanced by the step', async () => {
+    const rows = [10, 20, 120, 130, 240];
+    const seen: number[] = [];
+    for await (const item of sampleByStep(from(rows), 100, (value) => value)) {
+      seen.push(item);
+    }
+    // 10 is the first (nothing to compare against), 120 clears 10+100, 240 clears
+    // 120+100. 20 and 130 are inside the step.
+    expect(seen).toEqual([10, 120, 240]);
+  });
+
+  it('always emits the final item, even when it is inside the step', async () => {
+    const seen: number[] = [];
+    for await (const item of sampleByStep(from([0, 5, 9]), 100, (value) => value)) {
+      seen.push(item);
+    }
+    // Otherwise the consumer's last view is 0 while the load actually reached 9 —
+    // a stale final state, which is worse than an extra tick.
+    expect(seen).toEqual([0, 9]);
+  });
+
+  it('holds nothing back when every item clears the step', async () => {
+    const seen: number[] = [];
+    for await (const item of sampleByStep(from([0, 100, 200]), 100, (value) => value)) {
+      seen.push(item);
+    }
+    expect(seen).toEqual([0, 100, 200]);
+  });
+});
+
+describe('drainStream', () => {
+  it('returns the generator return value and pushes every item to the callback', async () => {
+    async function* stream(): AsyncGenerator<number, string> {
+      yield 1;
+      yield 2;
+      return 'settled';
+    }
+    const seen: number[] = [];
+    await expect(drainStream(stream(), (item) => seen.push(item))).resolves.toBe('settled');
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it('works with no callback at all', async () => {
+    async function* stream(): AsyncGenerator<number, string> {
+      yield 1;
+      return 'settled';
+    }
+    await expect(drainStream(stream())).resolves.toBe('settled');
+  });
+
+  it('propagates a failure after the items it already delivered', async () => {
+    async function* stream(): AsyncGenerator<number, string> {
+      yield 1;
+      throw new Error('decode panicked');
+    }
+    const seen: number[] = [];
+    await expect(drainStream(stream(), (item) => seen.push(item))).rejects.toThrow(
+      /decode panicked/
+    );
+    expect(seen).toEqual([1]);
+  });
+});

--- a/packages/core/tests/parquetWorkerStreaming.spec.ts
+++ b/packages/core/tests/parquetWorkerStreaming.spec.ts
@@ -23,7 +23,42 @@ import type {
  * request went out. Both are easy to regress into a stream that either resolves on
  * its first batch or times out mid-flight, and neither shows up in a type check —
  * hence these.
+ *
+ * The helper is an async generator now (#175), not a promise plus an `onBatch`
+ * callback. The behaviours below are deliberately unchanged — the same protocol read
+ * through `for await` — plus two the callback shape could not express: leaving the
+ * loop early cancels, and a partial failure is "consumed n items, then it threw".
  */
+
+/**
+ * Let a generator's queued body run. Async generator bodies are scheduled rather
+ * than run synchronously on `next()`, and each queued chunk costs a few microtasks
+ * to travel worker → queue → generator → consumer. The count bounds a wait rather
+ * than asserting one. Microtasks, not timers: two suites here use fake timers.
+ */
+async function flush() {
+  for (let index = 0; index < 32; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+/** Consume a stream in the background, exposing its chunks and its end (or failure)
+ * — the pull-side equivalent of the `onBatch` callback these tests used to pass. */
+function drive(stream: AsyncGenerator<ParquetWorkerStreamChunk, unknown>) {
+  const seen: ParquetWorkerStreamChunk[] = [];
+  const done = (async () => {
+    for (;;) {
+      const next = await stream.next();
+      if (next.done) {
+        return next.value;
+      }
+      seen.push(next.value);
+    }
+  })();
+  // Asserted on later; keep an early rejection from being reported as unhandled.
+  done.catch(() => {});
+  return { seen, done };
+}
 
 const STREAM_INPUT = {
   partUrls: ['https://example.test/points/part-0.parquet'],
@@ -131,41 +166,46 @@ describe('parquet worker streaming protocol', () => {
   it('returns null without a worker, so the caller streams on the main thread', async () => {
     disableParquetWorker();
     setParquetWorkerDefaultEnabled(false);
-    await expect(streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {})).resolves.toBeNull();
+    // The RETURN value, not a yield: the generator ends immediately, which is the
+    // caller's cue to fall through to the main-thread stream.
+    await expect(streamGeometryWithFeaturesInWorker(STREAM_INPUT).next()).resolves.toEqual({
+      done: true,
+      value: null,
+    });
   });
 
   it('delivers every interim batch and resolves on the terminal response', async () => {
     const scripted = installScriptedWorker();
     enableParquetWorker({ workerUrl: 'about:blank' });
 
-    const seen: ParquetWorkerStreamChunk[] = [];
-    const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
-    await Promise.resolve();
+    const { seen, done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+    await flush();
 
     scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
     scripted.emit(batch(0, 10, { code: 1, name: 'ACE2' }));
     // Three interim messages under one id: the pending entry must survive all of
     // them. A settle-on-first-response client resolves here with the wrong value.
     scripted.emit(batch(0, 5, null));
+    await flush();
     expect(seen).toHaveLength(3);
 
     scripted.finish({
       ok: true,
       result: { kind: 'geometryWithFeaturesStreamEnd', rows: 25, sawFeatureColumn: true },
     });
-    await expect(pending).resolves.toEqual({ rows: 25, sawFeatureColumn: true });
+    await expect(done).resolves.toEqual({ rows: 25, sawFeatureColumn: true });
   });
 
   it('reports a stream that ended without its feature column', async () => {
     const scripted = installScriptedWorker();
     enableParquetWorker({ workerUrl: 'about:blank' });
-    const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-    await Promise.resolve();
+    const { done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+    await flush();
     scripted.finish({
       ok: true,
       result: { kind: 'geometryWithFeaturesStreamEnd', rows: 40, sawFeatureColumn: false },
     });
-    await expect(pending).resolves.toEqual({ rows: 40, sawFeatureColumn: false });
+    await expect(done).resolves.toEqual({ rows: 40, sawFeatureColumn: false });
   });
 
   describe('the silence watchdog', () => {
@@ -185,9 +225,8 @@ describe('parquet worker streaming protocol', () => {
       enableParquetWorker({ workerUrl: 'about:blank' });
       setParquetWorkerRequestTimeout(60);
 
-      const seen: ParquetWorkerStreamChunk[] = [];
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
-      await Promise.resolve();
+      const { seen, done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
 
       // Six batches 20ms apart is 120ms of streaming under a 60ms budget: a
       // time-since-POSTED timeout abandons this healthy stream half way through.
@@ -200,7 +239,7 @@ describe('parquet worker streaming protocol', () => {
         result: { kind: 'geometryWithFeaturesStreamEnd', rows: 60, sawFeatureColumn: true },
       });
 
-      await expect(pending).resolves.toEqual({ rows: 60, sawFeatureColumn: true });
+      await expect(done).resolves.toEqual({ rows: 60, sawFeatureColumn: true });
       expect(seen).toHaveLength(6);
     });
 
@@ -209,12 +248,12 @@ describe('parquet worker streaming protocol', () => {
       enableParquetWorker({ workerUrl: 'about:blank' });
       setParquetWorkerRequestTimeout(40);
 
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-      await Promise.resolve();
+      const { done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
       const streamId = scripted.postedIds[0];
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
 
-      const settled = expect(pending).rejects.toThrow(/stream went quiet for 40ms/);
+      const settled = expect(done).rejects.toThrow(/stream went quiet for 40ms/);
       await vi.advanceTimersByTimeAsync(41);
       await settled;
       // Otherwise the worker keeps range-fetching a payload nobody will read.
@@ -228,8 +267,9 @@ describe('parquet worker streaming protocol', () => {
       const scripted = installScriptedWorker();
       enableParquetWorker({ workerUrl: 'about:blank' });
       setParquetWorkerRequestTimeout(30);
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-      const settled = expect(pending).rejects.toThrow(/did not respond within 30ms/);
+      const { done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
+      const settled = expect(done).rejects.toThrow(/did not respond within 30ms/);
       await vi.advanceTimersByTimeAsync(31);
       await settled;
       expect(scripted.posted[0]?.type).toBe('streamGeometryWithFeatures');
@@ -241,17 +281,18 @@ describe('parquet worker streaming protocol', () => {
       const scripted = installScriptedWorker();
       enableParquetWorker({ workerUrl: 'about:blank' });
 
-      const seen: ParquetWorkerStreamChunk[] = [];
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
-      await Promise.resolve();
+      const { seen, done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
 
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
       scripted.emit(batch(0, 10, null));
       scripted.finish({ ok: false, error: 'range read failed on part 1' });
 
       // Partial success is NOT reported as success: downstream cannot tell a
-      // truncated preload from a complete one, so the caller must restart.
-      await expect(pending).rejects.toThrow(/range read failed on part 1/);
+      // truncated preload from a complete one, so the caller must restart. As an
+      // iterable that is just the ordinary reading — two items consumed, then a
+      // throw — rather than a contract note.
+      await expect(done).rejects.toThrow(/range read failed on part 1/);
       expect(seen).toHaveLength(2);
     });
 
@@ -259,39 +300,71 @@ describe('parquet worker streaming protocol', () => {
       const scripted = installScriptedWorker();
       enableParquetWorker({ workerUrl: 'about:blank' });
 
-      const seen: ParquetWorkerStreamChunk[] = [];
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
-      await Promise.resolve();
+      const { seen, done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+      await flush();
 
       // A worker that has posted chunks has demonstrably loaded, so an error event
       // is "this request died", not "the bundle is missing" — the stream rejects
       // but the worker must survive for the next request.
       scripted.fail('decode panicked');
-      await expect(pending).rejects.toThrow(/decode panicked/);
+      await expect(done).rejects.toThrow(/decode panicked/);
       expect(seen).toHaveLength(1);
 
-      const next = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-      await Promise.resolve();
+      const next = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
       expect(scripted.posted.filter((r) => r.type === 'streamGeometryWithFeatures')).toHaveLength(
         2
       );
       disableParquetWorker();
-      await expect(next).rejects.toThrow();
+      await expect(next.done).rejects.toThrow();
     });
 
     it('rejects and cancels when the consumer throws on a batch', async () => {
       const scripted = installScriptedWorker();
       enableParquetWorker({ workerUrl: 'about:blank' });
 
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {
-        throw new Error('accumulator overflowed');
-      });
-      await Promise.resolve();
+      // A real `for await`: throwing from the body calls the generator's `return()`,
+      // which is where the cancel is posted. The callback version had to route the
+      // consumer's exception back through the message handler to get here.
+      const consumer = (async () => {
+        for await (const _chunk of streamGeometryWithFeaturesInWorker(STREAM_INPUT)) {
+          throw new Error('accumulator overflowed');
+        }
+      })();
+      consumer.catch(() => {});
+      await flush();
       const streamId = scripted.postedIds[0];
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
 
-      await expect(pending).rejects.toThrow(/accumulator overflowed/);
+      await expect(consumer).rejects.toThrow(/accumulator overflowed/);
+      expect(scripted.posted).toContainEqual({
+        type: 'cancelParquetStream',
+        streamRequestId: streamId,
+      });
+    });
+
+    it('cancels the worker-side stream when the consumer just stops reading', async () => {
+      const scripted = installScriptedWorker();
+      enableParquetWorker({ workerUrl: 'about:blank' });
+
+      // `break` IS cancellation — the property the callback shape had no way to
+      // express, and the reason `cancelParquetStream` needed an explicit API call
+      // before. Nothing here mentions cancelling.
+      const taken: ParquetWorkerStreamChunk[] = [];
+      const consumer = (async () => {
+        for await (const chunk of streamGeometryWithFeaturesInWorker(STREAM_INPUT)) {
+          taken.push(chunk);
+          break;
+        }
+      })();
+      await flush();
+      const streamId = scripted.postedIds[0];
+      scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+
+      await consumer;
+      expect(taken).toHaveLength(1);
       expect(scripted.posted).toContainEqual({
         type: 'cancelParquetStream',
         streamRequestId: streamId,
@@ -302,12 +375,11 @@ describe('parquet worker streaming protocol', () => {
       const scripted = installScriptedWorker();
       enableParquetWorker({ workerUrl: 'about:blank' });
 
-      const seen: ParquetWorkerStreamChunk[] = [];
-      const pending = streamGeometryWithFeaturesInWorker(STREAM_INPUT, (chunk) => seen.push(chunk));
-      await Promise.resolve();
+      const { seen, done } = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+      await flush();
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
       scripted.finish({ ok: false, error: 'gave up' });
-      await expect(pending).rejects.toThrow(/gave up/);
+      await expect(done).rejects.toThrow(/gave up/);
 
       // A batch already in flight behind the cancel. Dropping it must not throw.
       expect(() => scripted.emit(batch(0, 10, null))).not.toThrow();
@@ -321,17 +393,16 @@ describe('parquet worker streaming protocol', () => {
       enableParquetWorker({ workerUrl: 'about:blank' });
 
       const controller = new AbortController();
-      const seen: ParquetWorkerStreamChunk[] = [];
-      const pending = streamGeometryWithFeaturesInWorker(
-        { ...STREAM_INPUT, signal: controller.signal },
-        (chunk) => seen.push(chunk)
+      const { seen, done } = drive(
+        streamGeometryWithFeaturesInWorker({ ...STREAM_INPUT, signal: controller.signal })
       );
-      await Promise.resolve();
+      await flush();
       const streamId = scripted.postedIds[0];
       scripted.emit(batch(0, 10, { code: 0, name: 'ABCC11' }));
+      await flush();
 
       controller.abort();
-      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+      await expect(done).rejects.toMatchObject({ name: 'AbortError' });
       expect(seen).toHaveLength(1);
       // Superseding a load has to stop the worker FETCHING, not just stop us
       // listening — otherwise a few pans queue several whole-element downloads.
@@ -347,7 +418,10 @@ describe('parquet worker streaming protocol', () => {
       const controller = new AbortController();
       controller.abort();
       await expect(
-        streamGeometryWithFeaturesInWorker({ ...STREAM_INPUT, signal: controller.signal }, () => {})
+        streamGeometryWithFeaturesInWorker({
+          ...STREAM_INPUT,
+          signal: controller.signal,
+        }).next()
       ).rejects.toMatchObject({ name: 'AbortError' });
       expect(scripted.posted).toHaveLength(0);
     });
@@ -356,11 +430,11 @@ describe('parquet worker streaming protocol', () => {
   it('fails every in-flight stream when the worker is torn down', async () => {
     installScriptedWorker();
     enableParquetWorker({ workerUrl: 'about:blank' });
-    const first = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-    const second = streamGeometryWithFeaturesInWorker(STREAM_INPUT, () => {});
-    await Promise.resolve();
+    const first = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+    const second = drive(streamGeometryWithFeaturesInWorker(STREAM_INPUT));
+    await flush();
     disableParquetWorker();
-    await expect(first).rejects.toThrow(/disabled/);
-    await expect(second).rejects.toThrow(/disabled/);
+    await expect(first.done).rejects.toThrow(/disabled/);
+    await expect(second.done).rejects.toThrow(/disabled/);
   });
 });

--- a/packages/core/tests/pointsStreamAccumulator.spec.ts
+++ b/packages/core/tests/pointsStreamAccumulator.spec.ts
@@ -84,9 +84,7 @@ describe('PointsStreamAccumulator', () => {
     accumulator.append(
       chunk({ xs: [1], ys: [1], codes: [0], newFeatures: [{ code: 0, name: 'ABCC11' }] })
     );
-    expect(accumulator.snapshot().featureCatalog?.entries).toEqual([
-      { code: 0, name: 'ABCC11' },
-    ]);
+    expect(accumulator.snapshot().featureCatalog?.entries).toEqual([{ code: 0, name: 'ABCC11' }]);
 
     accumulator.append(
       chunk({ xs: [2], ys: [2], codes: [1], newFeatures: [{ code: 1, name: 'ACE2' }] })

--- a/packages/core/tests/pointsStreamApi.spec.ts
+++ b/packages/core/tests/pointsStreamApi.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import SpatialDataPointsSource from '../src/models/VPointsSource.js';
+import type { PointsLoadProgress } from '../src/pointsLoadOptions.js';
+import * as parquetWorkerClient from '../src/workers/parquetWorkerClient.js';
+import type { ParquetWorkerStreamChunk } from '../src/workers/parquetWorkerProtocol.js';
+
+/**
+ * `streamPoints` — the async-iterable form of `loadPoints` (#175).
+ *
+ * Two things to pin. That the iterable really is the producer: `loadPoints` drains
+ * it, so a tick the stream yields is a tick `onProgress` receives, and the two
+ * cannot drift. And that adding it changed nothing for existing callers —
+ * `loadPoints` without an `onProgress` must still take the one-shot decode.
+ */
+
+/** A worker stream batch of `rows` rows, all of one feature. */
+function chunk(rows: number, feature: { code: number; name: string }): ParquetWorkerStreamChunk {
+  const xs = Float32Array.from({ length: rows }, (_, index) => index);
+  return {
+    kind: 'geometryWithFeaturesBatch',
+    partIndex: 0,
+    partCount: 1,
+    rows,
+    axes: [xs, xs.slice()],
+    featureCodes: new Int32Array(rows).fill(feature.code),
+    newFeatures: [feature],
+    tallyCodes: Int32Array.from([feature.code]),
+    tallyCounts: Uint32Array.from([rows]),
+  };
+}
+
+/** A source whose element metadata and part URLs are stubbed, so only the read
+ * strategy under test is exercised. */
+function pointsSource() {
+  const source = new SpatialDataPointsSource({
+    store: { get: async () => null },
+    fileType: '.zarr',
+  });
+  vi.spyOn(source, 'loadSpatialDataElementAttrs').mockResolvedValue({
+    'encoding-type': 'ngff:points',
+    axes: ['x', 'y'],
+    spatialdata_attrs: { feature_key: 'feature_name', version: '0.2' },
+  });
+  vi.spyOn(source, 'resolveParquetRowCount').mockResolvedValue(30);
+  vi.spyOn(source, 'canLoadParquetRowGroups').mockResolvedValue(false);
+  vi.spyOn(source, 'loadParquetDatasetMetadata').mockResolvedValue(null);
+  vi.spyOn(source, 'loadParquetSchemaTable').mockResolvedValue(null);
+  // Private, but it is the capability gate the streaming readers consult and there
+  // is no public seam for it.
+  vi.spyOn(
+    source as unknown as { resolveStreamablePartUrls: () => Promise<string[]> },
+    'resolveStreamablePartUrls'
+  ).mockResolvedValue(['https://example.test/part-0.parquet']);
+  vi.spyOn(parquetWorkerClient, 'isParquetWorkerEnabled').mockReturnValue(true);
+  vi.spyOn(parquetWorkerClient, 'ensureParquetWorker').mockImplementation(() => {});
+  return source;
+}
+
+/** Stub the worker stream with a scripted generator, recording whether the
+ * consumer closed it early. */
+function scriptWorkerStream(chunks: ParquetWorkerStreamChunk[]) {
+  const state = { closed: false, delivered: 0 };
+  vi.spyOn(parquetWorkerClient, 'streamGeometryWithFeaturesInWorker').mockImplementation(
+    async function* () {
+      try {
+        for (const item of chunks) {
+          state.delivered += 1;
+          yield item;
+        }
+        return { rows: chunks.reduce((sum, c) => sum + c.rows, 0), sawFeatureColumn: true };
+      } finally {
+        state.closed = true;
+      }
+    }
+  );
+  return state;
+}
+
+describe('streamPoints', () => {
+  it('yields the growing result and returns the settled one', async () => {
+    const source = pointsSource();
+    scriptWorkerStream([
+      chunk(10, { code: 0, name: 'ABCC11' }),
+      chunk(10, { code: 1, name: 'ACE2' }),
+    ]);
+
+    const stream = source.streamPoints('points/transcripts', { includeFeatureCodes: true });
+    const ticks: PointsLoadProgress[] = [];
+    let settled: Awaited<ReturnType<typeof source.loadPoints>> | undefined;
+    for (;;) {
+      const next = await stream.next();
+      if (next.done) {
+        settled = next.value;
+        break;
+      }
+      ticks.push(next.value);
+    }
+
+    expect(ticks.map((tick) => tick.matchedRows)).toEqual([10, 20]);
+    // Cumulative, not deltas — which is what makes `coalesceLatest` safe over this
+    // stream, and why the last tick and the return value agree on row count.
+    expect(ticks[0].partialResult.shape[1]).toBe(10);
+    expect(settled?.shape[1]).toBe(20);
+    expect(settled?.featureCatalog?.entries.map((entry) => entry.name)).toEqual(['ABCC11', 'ACE2']);
+  });
+
+  it('gives loadPoints onProgress exactly the ticks the stream yields', async () => {
+    const source = pointsSource();
+    scriptWorkerStream([
+      chunk(10, { code: 0, name: 'ABCC11' }),
+      chunk(10, { code: 1, name: 'ACE2' }),
+      chunk(5, { code: 2, name: 'ACKR1' }),
+    ]);
+
+    const seen: number[] = [];
+    const result = await source.loadPoints('points/transcripts', {
+      includeFeatureCodes: true,
+      onProgress: (progress) => seen.push(progress.matchedRows),
+    });
+
+    // The deprecated callback is a drain of the same generator, so this IS the
+    // stream's tick sequence — not a parallel implementation of it.
+    expect(seen).toEqual([10, 20, 25]);
+    expect(result.shape[1]).toBe(25);
+  });
+
+  it('closes the underlying worker stream when the consumer stops early', async () => {
+    const source = pointsSource();
+    const state = scriptWorkerStream([
+      chunk(10, { code: 0, name: 'ABCC11' }),
+      chunk(10, { code: 1, name: 'ACE2' }),
+      chunk(10, { code: 2, name: 'ACKR1' }),
+    ]);
+
+    for await (const _tick of source.streamPoints('points/transcripts', {
+      includeFeatureCodes: true,
+    })) {
+      break;
+    }
+
+    // `break` propagates down the `yield*` chain to the worker stream's `finally`,
+    // which is where the cancel is posted. Nothing here asks for cancellation.
+    expect(state.closed).toBe(true);
+    expect(state.delivered).toBeLessThan(3);
+  });
+
+  it('leaves loadPoints without onProgress on its one-shot decode', async () => {
+    const source = pointsSource();
+    const streamed = scriptWorkerStream([chunk(10, { code: 0, name: 'ABCC11' })]);
+    const oneShot = vi
+      .spyOn(parquetWorkerClient, 'decodeGeometryWithFeaturesInWorker')
+      .mockResolvedValue({
+        shape: [2, 30],
+        data: [new Float32Array(30), new Float32Array(30)],
+      });
+    vi.spyOn(
+      source as unknown as { fetchParquetPayloadCapped: () => Promise<{ parts: Uint8Array[] }> },
+      'fetchParquetPayloadCapped'
+    ).mockResolvedValue({ parts: [new Uint8Array(1)] });
+
+    const result = await source.loadPoints('points/transcripts', { includeFeatureCodes: true });
+
+    // The path-selection gate is unchanged: no callback, no progressive read. A
+    // caller that never asked for ticks must not silently get a different, slower
+    // reader.
+    expect(streamed.delivered).toBe(0);
+    expect(oneShot).toHaveBeenCalled();
+    expect(result.shape[1]).toBe(30);
+  });
+});

--- a/packages/vis/package.json
+++ b/packages/vis/package.json
@@ -42,6 +42,7 @@
     "@spatialdata/core": "workspace:*",
     "@spatialdata/layers": "workspace:*",
     "@spatialdata/react": "workspace:*",
+    "@tanstack/react-virtual": "^3.14.10",
     "@uidotdev/usehooks": "^2.4.1",
     "@uiw/react-json-view": "2.0.0-alpha.43",
     "@vivjs/views": "catalog:",

--- a/packages/vis/src/SpatialCanvas/PointsFeatureFilterPanel.tsx
+++ b/packages/vis/src/SpatialCanvas/PointsFeatureFilterPanel.tsx
@@ -4,10 +4,16 @@ import {
   resolveFeatureSelectionCodes,
 } from '@spatialdata/core';
 import { featureCodeToRgb } from '@spatialdata/layers';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type { CSSProperties } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSpatialCanvasActions } from './context';
-import { describeFeatureRowState, featureRowOpacity } from './featureRowState';
+import {
+  classifyFeatureRow,
+  type FeatureRowsInput,
+  featureRowOpacity,
+  summariseFeatureRows,
+} from './featureRowState';
 import { usePointsFeatureState } from './PointsFeatureState';
 import type { PointsLayerConfig } from './types';
 
@@ -81,19 +87,38 @@ const panelStyle: CSSProperties = {
   fontSize: '12px',
 };
 
+/**
+ * Fixed row height (px) for the virtualized list. Fixed rather than measured: a row
+ * is one line of text beside a checkbox and a swatch, so there is nothing to
+ * measure and the virtualizer stays off `ResizeObserver`. {@link featureRowStyle}
+ * pins the same number on the row — rows are absolutely positioned, so one taller
+ * than its estimate would overlap its neighbour rather than push it down.
+ */
+const FEATURE_ROW_HEIGHT = 22;
+
+/** Scroll viewport height, also the virtualizer's `initialRect`, so the first
+ * render (before layout measures the container) windows to rows rather than none. */
+const FEATURE_LIST_HEIGHT = 180;
+
 const listStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-  maxHeight: 180,
+  maxHeight: FEATURE_LIST_HEIGHT,
   overflowY: 'auto',
-  padding: '4px 0',
 };
 
 const checkboxLabelStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: 6,
+};
+
+/** A virtualized row: absolutely positioned in the spacer, translated to its slot. */
+const featureRowStyle: CSSProperties = {
+  ...checkboxLabelStyle,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: FEATURE_ROW_HEIGHT,
 };
 
 const helperStyle: CSSProperties = {
@@ -214,10 +239,15 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
     entry.count ?? partialCounts?.get(entry.code);
   const countIsPartial = (entry: { code: number; count?: number }): boolean =>
     entry.count === undefined && partialCounts?.get(entry.code) !== undefined;
-  // Dataset totals by code, so a row can be compared against what is resident without
-  // rescanning `entries` per row.
-  const datasetCountByCode = new Map<number, number>(
-    entries.flatMap((entry) => (entry.count !== undefined ? [[entry.code, entry.count]] : []))
+  // Dataset totals by code, so a row need not rescan `entries` to find its own.
+  // Memoised: it is O(features) to build, and it feeds the whole-catalog pass below,
+  // which a fresh Map per render would defeat.
+  const datasetCountByCode = useMemo(
+    () =>
+      new Map<number, number>(
+        entries.flatMap((entry) => (entry.count !== undefined ? [[entry.code, entry.count]] : []))
+      ),
+    [entries]
   );
   /** Resident points for a feature, when that is meaningfully LESS than the dataset —
    * i.e. there is a shortfall worth showing. `undefined` otherwise. */
@@ -229,13 +259,26 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
   };
   // The selection persists as NAMES (see `PointsLayerConfig.featureNames`), but the
   // rest of this panel — checkboxes, greying, the engine reads — works in codes.
-  // Resolve once here against the catalog we are already rendering.
-  const selection = resolveFeatureSelectionCodes(config, catalog);
+  // Resolve once here against the catalog we are already rendering. Memoised on the
+  // two config fields rather than on `config`, which is a fresh object every render;
+  // its identity gates the whole-catalog pass below.
+  const configFeatureNames = config.featureNames;
+  const configFeatureCodes = config.featureCodes;
+  const selection = useMemo(
+    () =>
+      resolveFeatureSelectionCodes(
+        { featureNames: configFeatureNames, featureCodes: configFeatureCodes },
+        catalog
+      ),
+    [configFeatureNames, configFeatureCodes, catalog]
+  );
   const allSelected = selection === undefined;
   const noneSelected = selection !== undefined && selection.length === 0;
-  const selectedCodes = allSelected
-    ? new Set(entries.map((entry) => entry.code))
-    : new Set(selection ?? []);
+  const selectedCodes = useMemo(
+    () =>
+      allSelected ? new Set(entries.map((entry) => entry.code)) : new Set<number>(selection ?? []),
+    [allSelected, entries, selection]
+  );
 
   const sortedEntries = useMemo(() => {
     const list = [...entries];
@@ -262,6 +305,74 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
     }
     return sortedEntries.filter((entry) => entry.name.toLowerCase().includes(query));
   }, [sortedEntries, searchQuery]);
+
+  // A feature's points are "loaded" (renderable now, not greyed) if it is in the
+  // instant resident preview OR its points are currently on screen via the
+  // last-completed feature-index scan (`loadedMatchingCodes`). Keying off what's
+  // rendered — not the current scan's settled state — keeps already-loaded
+  // features un-greyed while a newly added feature's scan is still in flight.
+  const residentKnown = residentCodes !== undefined;
+  // Element fact AND this layer's config — the probe's answer is cached per element
+  // and outlives the config that asked for it.
+  const tiledLayer = tiled && pointsTilingEnabled(config.pointsTiling);
+  const scanning = matchingLoadState?.loading ?? false;
+  const rowsInput = useMemo<FeatureRowsInput>(
+    () => ({
+      entries,
+      residentCodes,
+      loadedMatchingCodes,
+      selectedCodes,
+      allSelected,
+      noneSelected,
+      scanning,
+      supportsOnDemandLoad,
+      residentKnown,
+      residentFeatureCounts,
+      datasetCountByCode,
+      tiled: tiledLayer,
+    }),
+    [
+      entries,
+      residentCodes,
+      loadedMatchingCodes,
+      selectedCodes,
+      allSelected,
+      noneSelected,
+      scanning,
+      supportsOnDemandLoad,
+      residentKnown,
+      residentFeatureCounts,
+      datasetCountByCode,
+      tiledLayer,
+    ]
+  );
+  // The one remaining whole-catalog pass: the summary lines below count rows across
+  // every feature, not the mounted window, so this is O(features) however few rows
+  // render. Memoised so it re-runs when an answer could have changed, rather than on
+  // every engine notify — dozens of times during a streaming preload.
+  const { notLoadedCount, partialCount } = useMemo(
+    () => summariseFeatureRows(rowsInput),
+    [rowsInput]
+  );
+  const rowInfo = (code: number) => classifyFeatureRow(code, rowsInput);
+
+  // Virtualized list. Without it a 12,448-feature Xenium panel mounts 12,453
+  // checkboxes and ~91k DOM nodes — most of a minute of long tasks on its own
+  // (#172). The React Compiler skips this component anyway ('use no memo' above),
+  // which is what its incompatible-library warning about this hook amounts to here.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: visibleEntries.length,
+    getScrollElement: () => listRef.current,
+    estimateSize: () => FEATURE_ROW_HEIGHT,
+    // Codes are unique and stable, so a row keeps its React identity — and its open
+    // colour picker — as the window scrolls past it.
+    getItemKey: (index) => visibleEntries[index]?.code ?? index,
+    overscan: 8,
+    // Before layout measures the scroll box, fall back to its known height rather
+    // than zero, or the first paint windows to no rows at all.
+    initialRect: { width: 0, height: FEATURE_LIST_HEIGHT },
+  });
 
   // Write NAMES, and clear any legacy `featureCodes` so the two cannot disagree —
   // `featureNames` wins when both are set, and a stale code list left behind in a
@@ -381,46 +492,6 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
 
   const selectedCount = noneSelected ? 0 : allSelected ? entries.length : selectedCodes.size;
   const showSearch = entries.length > FEATURE_LIST_SEARCH_THRESHOLD;
-  // A feature's points are "loaded" (renderable now, not greyed) if it is in the
-  // instant resident preview OR its points are currently on screen via the
-  // last-completed feature-index scan (`loadedMatchingCodes`). Keying off what's
-  // rendered — not the current scan's settled state — keeps already-loaded
-  // features un-greyed while a newly added feature's scan is still in flight.
-  const residentKnown = residentCodes !== undefined;
-  // Element fact AND this layer's config — the probe's answer is cached per element
-  // and outlives the config that asked for it.
-  const tiledLayer = tiled && pointsTilingEnabled(config.pointsTiling);
-  const scanning = matchingLoadState?.loading ?? false;
-  const rowInfo = (code: number) => {
-    const resident = residentKnown && (residentCodes?.has(code) ?? false);
-    const rendered = loadedMatchingCodes?.has(code) ?? false;
-    const selected = !noneSelected && (allSelected || selectedCodes.has(code));
-    const state = describeFeatureRowState({
-      resident,
-      rendered,
-      selected,
-      scanning,
-      supportsOnDemandLoad,
-      residentKnown,
-      residentPointCount: residentFeatureCounts?.get(code),
-      datasetPointCount: datasetCountByCode.get(code),
-      tiled: tiledLayer,
-    });
-    return { resident, rendered, selected, state };
-  };
-  const notLoadedCount = residentKnown
-    ? entries.reduce((total, entry) => total + (rowInfo(entry.code).state.greyed ? 1 : 0), 0)
-    : 0;
-  // Features that ARE drawn but only in part. Counted separately from `notLoadedCount`
-  // because they are the opposite failure of understanding: those rows look completely
-  // healthy — un-greyed, with a full dataset count beside them — while most of their
-  // points are outside the cap.
-  const partialCount = residentKnown
-    ? entries.reduce(
-        (total, entry) => total + (rowInfo(entry.code).state.tone === 'partial' ? 1 : 0),
-        0
-      )
-    : 0;
 
   return (
     <div style={panelStyle}>
@@ -512,111 +583,124 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
           style={searchStyle}
         />
       ) : null}
-      <div style={listStyle}>
-        {visibleEntries.map((entry) => {
-          const { resident, rendered, selected, state } = rowInfo(entry.code);
-          const countStr =
-            entry.count !== undefined ? ` · ${entry.count.toLocaleString()} pts` : '';
-          // Multi-line diagnostic: the human state + reason, then the raw signals
-          // that drove the decision (what made this row grey / not grey).
-          const overridden = colorOverrides?.[entry.name] !== undefined;
-          const rgb = effectiveRgb(entry.name, entry.code);
-          const title =
-            `${entry.name} · code ${entry.code}${countStr}\n` +
-            `${state.label}: ${state.reason}\n` +
-            `[resident=${resident ? 'y' : 'n'} rendered=${rendered ? 'y' : 'n'} ` +
-            `selected=${selected ? 'y' : 'n'} scan=${scanning ? 'running' : 'idle'}]`;
-          return (
-            <label
-              key={entry.code}
-              style={{ ...checkboxLabelStyle, opacity: featureRowOpacity(state) }}
-              title={title}
-              onMouseEnter={() => setHighlightedFeature(entry.code)}
-              onMouseLeave={() => setHighlightedFeature(null)}
-            >
-              <input
-                type="checkbox"
-                checked={selected}
-                onChange={(event) => toggleFeature(entry.code, event.target.checked)}
-              />
-              {/* Swatch = colour picker: this span's background is the effective
-                  colour and a transparent colour input overlays it. Interactive content
-                  inside the label, so operating it does not toggle the checkbox. */}
-              <span
+      <div ref={listRef} style={listStyle}>
+        {/* Spacer sized to the whole list, windowed rows inside it: the scrollbar
+            tracks all 12k features while the DOM holds ~20. */}
+        <div style={{ position: 'relative', width: '100%', height: rowVirtualizer.getTotalSize() }}>
+          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+            const entry = visibleEntries[virtualRow.index];
+            if (!entry) {
+              return null;
+            }
+            const { resident, rendered, selected, state } = rowInfo(entry.code);
+            const countStr =
+              entry.count !== undefined ? ` · ${entry.count.toLocaleString()} pts` : '';
+            // Multi-line diagnostic: the human state + reason, then the raw signals
+            // that drove the decision (what made this row grey / not grey).
+            const overridden = colorOverrides?.[entry.name] !== undefined;
+            const rgb = effectiveRgb(entry.name, entry.code);
+            const title =
+              `${entry.name} · code ${entry.code}${countStr}\n` +
+              `${state.label}: ${state.reason}\n` +
+              `[resident=${resident ? 'y' : 'n'} rendered=${rendered ? 'y' : 'n'} ` +
+              `selected=${selected ? 'y' : 'n'} scan=${scanning ? 'running' : 'idle'}]`;
+            return (
+              <label
+                key={virtualRow.key}
+                data-index={virtualRow.index}
                 style={{
-                  ...colorSwatchStyle,
-                  background: `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`,
-                  ...(overridden ? colorSwatchOverriddenStyle : {}),
+                  ...featureRowStyle,
+                  transform: `translateY(${virtualRow.start}px)`,
+                  opacity: featureRowOpacity(state),
                 }}
-                title={`${entry.name} colour${overridden ? ' (overridden)' : ''}`}
+                title={title}
+                onMouseEnter={() => setHighlightedFeature(entry.code)}
+                onMouseLeave={() => setHighlightedFeature(null)}
               >
                 <input
-                  type="color"
-                  aria-label={`${entry.name} colour`}
-                  value={rgbToHex(rgb)}
-                  style={colorInputStyle}
-                  onClick={(event) => event.stopPropagation()}
-                  onChange={(event) => setColorOverride(entry.name, hexToRgb(event.target.value))}
+                  type="checkbox"
+                  checked={selected}
+                  onChange={(event) => toggleFeature(entry.code, event.target.checked)}
                 />
-              </span>
-              <span>
-                {entry.name}
-                {state.greyed ? ' ·' : ''}
-              </span>
-              {overridden ? (
-                <button
-                  type="button"
-                  style={resetOverrideStyle}
-                  title="Reset to default colour"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    clearColorOverride(entry.name);
+                {/* Swatch = colour picker: this span's background is the effective
+                    colour and a transparent colour input overlays it. Interactive content
+                    inside the label, so operating it does not toggle the checkbox. */}
+                <span
+                  style={{
+                    ...colorSwatchStyle,
+                    background: `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`,
+                    ...(overridden ? colorSwatchOverriddenStyle : {}),
                   }}
+                  title={`${entry.name} colour${overridden ? ' (overridden)' : ''}`}
                 >
-                  ⟲
-                </button>
-              ) : null}
-              {hasAnyCounts
-                ? (() => {
-                    // Once dataset totals land, keep showing the resident tally too when
-                    // it falls short — the panel used to drop it, which is what let a
-                    // capped element present "1,182,402" for a feature it was drawing a
-                    // fraction of. `rendered` means a scan supplied it whole, so the
-                    // shortfall is no longer what's on screen.
-                    const shortfall =
-                      state.tone === 'partial' ? residentShortfall(entry) : undefined;
-                    return (
-                      <span
-                        style={countStyle}
-                        title={
-                          shortfall !== undefined
-                            ? `${shortfall.toLocaleString()} of ${formatFeatureCount(
-                                entry.count
-                              )} points are inside the memory cap`
-                            : countIsPartial(entry)
-                              ? 'Points loaded so far (resident window) — dataset total still counting'
-                              : 'Points in the dataset'
-                        }
-                      >
-                        {shortfall !== undefined ? (
-                          <>
-                            <span style={shortfallStyle}>{shortfall.toLocaleString()}</span>
-                            <span style={ofTotalStyle}> / {formatFeatureCount(entry.count)}</span>
-                          </>
-                        ) : (
-                          <>
-                            {countIsPartial(entry) ? '≥' : ''}
-                            {formatFeatureCount(effectiveCount(entry))}
-                          </>
-                        )}
-                      </span>
-                    );
-                  })()
-                : null}
-            </label>
-          );
-        })}
+                  <input
+                    type="color"
+                    aria-label={`${entry.name} colour`}
+                    value={rgbToHex(rgb)}
+                    style={colorInputStyle}
+                    onClick={(event) => event.stopPropagation()}
+                    onChange={(event) => setColorOverride(entry.name, hexToRgb(event.target.value))}
+                  />
+                </span>
+                <span>
+                  {entry.name}
+                  {state.greyed ? ' ·' : ''}
+                </span>
+                {overridden ? (
+                  <button
+                    type="button"
+                    style={resetOverrideStyle}
+                    title="Reset to default colour"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      event.preventDefault();
+                      clearColorOverride(entry.name);
+                    }}
+                  >
+                    ⟲
+                  </button>
+                ) : null}
+                {hasAnyCounts
+                  ? (() => {
+                      // Once dataset totals land, keep showing the resident tally too when
+                      // it falls short — the panel used to drop it, which is what let a
+                      // capped element present "1,182,402" for a feature it was drawing a
+                      // fraction of. `rendered` means a scan supplied it whole, so the
+                      // shortfall is no longer what's on screen.
+                      const shortfall =
+                        state.tone === 'partial' ? residentShortfall(entry) : undefined;
+                      return (
+                        <span
+                          style={countStyle}
+                          title={
+                            shortfall !== undefined
+                              ? `${shortfall.toLocaleString()} of ${formatFeatureCount(
+                                  entry.count
+                                )} points are inside the memory cap`
+                              : countIsPartial(entry)
+                                ? 'Points loaded so far (resident window) — dataset total still counting'
+                                : 'Points in the dataset'
+                          }
+                        >
+                          {shortfall !== undefined ? (
+                            <>
+                              <span style={shortfallStyle}>{shortfall.toLocaleString()}</span>
+                              <span style={ofTotalStyle}> / {formatFeatureCount(entry.count)}</span>
+                            </>
+                          ) : (
+                            <>
+                              {countIsPartial(entry) ? '≥' : ''}
+                              {formatFeatureCount(effectiveCount(entry))}
+                            </>
+                          )}
+                        </span>
+                      );
+                    })()
+                  : null}
+              </label>
+            );
+          })}
+        </div>
         {showSearch && visibleEntries.length === 0 ? (
           <div style={helperStyle}>No features match your search.</div>
         ) : null}

--- a/packages/vis/src/SpatialCanvas/PointsFeatureFilterPanel.tsx
+++ b/packages/vis/src/SpatialCanvas/PointsFeatureFilterPanel.tsx
@@ -212,6 +212,7 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
     supportsOnDemandLoad,
     matchingLoadState,
     residentFeatureCounts,
+    highlightedFeature,
     requestCatalog,
     setHighlightedFeature,
     retryFailedLoads,
@@ -373,6 +374,21 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
     // than zero, or the first paint windows to no rows at all.
     initialRect: { width: 0, height: FEATURE_LIST_HEIGHT },
   });
+
+  // A hovered row can be unmounted by a scroll while the pointer is still over it,
+  // and removing a node fires no `mouseleave` — so the row's own handler never runs
+  // and the canvas keeps emphasising a feature that is no longer under the pointer.
+  // Watch for the highlighted row leaving the window instead. A boolean dep, so this
+  // fires once on that transition rather than per render or per scroll event.
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const highlightMounted =
+    highlightedFeature === null ||
+    virtualRows.some((row) => visibleEntries[row.index]?.code === highlightedFeature);
+  useEffect(() => {
+    if (!highlightMounted) {
+      setHighlightedFeature(null);
+    }
+  }, [highlightMounted, setHighlightedFeature]);
 
   // Write NAMES, and clear any legacy `featureCodes` so the two cannot disagree —
   // `featureNames` wins when both are set, and a stale code list left behind in a
@@ -583,11 +599,18 @@ export function PointsFeatureFilterPanel({ config }: PointsFeatureFilterPanelPro
           style={searchStyle}
         />
       ) : null}
-      <div ref={listRef} style={listStyle}>
+      {/* Focusable: only the MOUNTED rows hold checkboxes, so without a tab stop on
+          the scroller a keyboard user reaches ~17 of 12,448 features and the list
+          never scrolls. Arrow/PageDown on the focused container scrolls it. It carries
+          no `aria-label` because biome will not accept a name on a generic role
+          without a `<fieldset>`; the "Features (…)" heading right above names it.
+          biome-ignore lint/a11y/noNoninteractiveTabindex: a scrollable region must be
+          keyboard reachable (WCAG 2.1.1); virtualization is what made it load-bearing. */}
+      <div ref={listRef} style={listStyle} tabIndex={0}>
         {/* Spacer sized to the whole list, windowed rows inside it: the scrollbar
             tracks all 12k features while the DOM holds ~20. */}
         <div style={{ position: 'relative', width: '100%', height: rowVirtualizer.getTotalSize() }}>
-          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          {virtualRows.map((virtualRow) => {
             const entry = visibleEntries[virtualRow.index];
             if (!entry) {
               return null;

--- a/packages/vis/src/SpatialCanvas/PointsFeatureState.tsx
+++ b/packages/vis/src/SpatialCanvas/PointsFeatureState.tsx
@@ -136,6 +136,10 @@ export interface PointsFeatureState {
   /** Running per-feature counts over the resident window (`code → rows`), available
    * while the whole-dataset counts scan is still running. Partial by construction. */
   residentFeatureCounts: ReturnType<PointsDataEngine['getResidentFeatureCounts']>;
+  /** The hover-emphasised feature code, or `null` when nothing is highlighted. A
+   * panel needs to READ this, not just set it: a virtualized list can unmount the
+   * hovered row without a `mouseleave`, leaving an emphasis nothing will clear. */
+  highlightedFeature: number | null;
   /** Stable callback — trigger the full-dataset catalog build (idempotent). */
   requestCatalog: () => void;
   /** Stable callback — set (or clear, with null) the hover-highlighted feature code
@@ -160,6 +164,7 @@ const EMPTY_POINTS_FEATURE_STATE: Omit<
   truncation: undefined,
   tiled: false,
   residentFeatureCounts: undefined,
+  highlightedFeature: null,
 };
 
 /**
@@ -224,6 +229,9 @@ export function usePointsFeatureState(
     truncation: engine.getActiveTruncation(key, featureCodes),
     tiled: engine.isTiled(key),
     residentFeatureCounts: engine.getResidentFeatureCounts(key),
+    // The engine stores "none" as -1; null reads better and matches the setter.
+    highlightedFeature:
+      engine.getHighlightedFeature(key) < 0 ? null : engine.getHighlightedFeature(key),
     requestCatalog,
     setHighlightedFeature,
     retryFailedLoads,

--- a/packages/vis/src/SpatialCanvas/featureRowState.ts
+++ b/packages/vis/src/SpatialCanvas/featureRowState.ts
@@ -197,3 +197,101 @@ export function featureRowOpacity(state: FeatureRowState): number {
   }
   return state.tone === 'loading' ? 0.6 : 0.4;
 }
+
+/**
+ * Everything a feature list's rows are classified against, gathered so one object
+ * identity stands for "nothing that affects any row has changed".
+ *
+ * Virtualization is why. With only the visible window in the DOM, the remaining
+ * per-render cost is the summary: the "N of M not loaded" lines count rows across
+ * the entire catalog, so they stay O(features) however few rows are mounted.
+ * Bundling lets the panel memoise that pass on one dependency.
+ *
+ * Every field is a primitive or an object whose identity changes exactly when its
+ * contents do — the engine's resident-code/count reads rebuild only when the
+ * row-code buffer changes, and the matching codes are cached on the scan signature.
+ */
+export interface FeatureRowsInput {
+  entries: readonly { code: number; name: string; count?: number }[];
+  /** Feature codes present in the resident (preloaded) window. */
+  residentCodes: ReadonlySet<number> | undefined;
+  /** Feature codes on screen via the last-completed feature-index scan. */
+  loadedMatchingCodes: ReadonlySet<number> | undefined;
+  /** The current selection as codes. Ignored when `allSelected`/`noneSelected`. */
+  selectedCodes: ReadonlySet<number>;
+  allSelected: boolean;
+  noneSelected: boolean;
+  scanning: boolean;
+  supportsOnDemandLoad: boolean;
+  residentKnown: boolean;
+  residentFeatureCounts: ReadonlyMap<number, number> | undefined;
+  /** Dataset totals by code, so a row need not rescan `entries` to find its own. */
+  datasetCountByCode: ReadonlyMap<number, number>;
+  /** This LAYER draws tiles (the element's tiling probe AND its config say so). */
+  tiled: boolean;
+}
+
+/** A row's classification plus the signals that produced it — the panel shows both,
+ * so they cannot drift apart. */
+export interface FeatureRowInfo {
+  resident: boolean;
+  rendered: boolean;
+  selected: boolean;
+  state: FeatureRowState;
+}
+
+/** Classify one feature row against the whole list's inputs. */
+export function classifyFeatureRow(code: number, input: FeatureRowsInput): FeatureRowInfo {
+  const resident = input.residentKnown && (input.residentCodes?.has(code) ?? false);
+  const rendered = input.loadedMatchingCodes?.has(code) ?? false;
+  const selected = !input.noneSelected && (input.allSelected || input.selectedCodes.has(code));
+  const state = describeFeatureRowState({
+    resident,
+    rendered,
+    selected,
+    scanning: input.scanning,
+    supportsOnDemandLoad: input.supportsOnDemandLoad,
+    residentKnown: input.residentKnown,
+    residentPointCount: input.residentFeatureCounts?.get(code),
+    datasetPointCount: input.datasetCountByCode.get(code),
+    tiled: input.tiled,
+  });
+  return { resident, rendered, selected, state };
+}
+
+/** How many rows are greyed, and how many are drawn but only in part. */
+export interface FeatureRowsSummary {
+  /** Rows whose points are not on screen at all. */
+  notLoadedCount: number;
+  /** Rows that ARE drawn, but only the part inside the memory cap. Counted apart
+   * from `notLoadedCount` because they look healthy — un-greyed, full dataset count
+   * beside them — while most of their points are missing. */
+  partialCount: number;
+}
+
+/**
+ * The two whole-catalog tallies behind the panel's summary lines — the single
+ * O(features) pass left after virtualization, so memoise it on the
+ * {@link FeatureRowsInput} identity. Retains no per-row result; only mounted rows
+ * need one, from {@link classifyFeatureRow}.
+ *
+ * Both are 0 when the resident set is unknown, matching `describeFeatureRowState`'s
+ * "treat everything as shown" fallback — with nothing to compare against, a
+ * shortfall claim would be invented rather than measured.
+ */
+export function summariseFeatureRows(input: FeatureRowsInput): FeatureRowsSummary {
+  if (!input.residentKnown) {
+    return { notLoadedCount: 0, partialCount: 0 };
+  }
+  let notLoadedCount = 0;
+  let partialCount = 0;
+  for (const entry of input.entries) {
+    const { state } = classifyFeatureRow(entry.code, input);
+    if (state.greyed) {
+      notLoadedCount += 1;
+    } else if (state.tone === 'partial') {
+      partialCount += 1;
+    }
+  }
+  return { notLoadedCount, partialCount };
+}

--- a/packages/vis/tests/pointsFeatureListVirtualization.spec.tsx
+++ b/packages/vis/tests/pointsFeatureListVirtualization.spec.tsx
@@ -8,7 +8,7 @@
  * it is the floor the DOM cost was hiding.
  */
 import type { PointsDataEngine, PointsLoadTarget } from '@spatialdata/layers';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SpatialCanvasProvider } from '../src/SpatialCanvas/context';
 import { PointsFeatureFilterPanel } from '../src/SpatialCanvas/PointsFeatureFilterPanel';
@@ -33,11 +33,15 @@ function catalogOf(count: number) {
  * `usePointsFeatureState` calls. A real engine would drag in a store and a loader. */
 function stubEngine(overrides: Record<string, unknown> = {}) {
   const catalog = catalogOf(FEATURE_COUNT);
+  let highlighted = -1;
   const engine = {
     subscribe: () => () => {},
     getVersion: () => 1,
     ensureFeatureCatalog: vi.fn(async () => {}),
-    setHighlightedFeature: vi.fn(),
+    getHighlightedFeature: () => highlighted,
+    setHighlightedFeature: vi.fn((_key: string, code: number | null) => {
+      highlighted = code ?? -1;
+    }),
     retry: vi.fn(),
     supportsFeatureScan: () => true,
     getFeatureCatalog: () => catalog,
@@ -112,6 +116,32 @@ describe('points feature list virtualization', () => {
     // 12,448 features rendered a row each measured at 91,107 nodes. The windowed
     // panel is ~112. Any number in the low hundreds means the window is holding.
     expect(container.querySelectorAll('*').length).toBeLessThan(500);
+  });
+
+  it('makes the scroll container focusable, so rows outside the window stay reachable', () => {
+    const { container } = renderPanel(stubEngine());
+    const scroller = container.querySelector<HTMLElement>('div[style*="overflow-y: auto"]');
+    // Only mounted rows hold checkboxes. Without a tab stop on the scroller itself,
+    // Tab leaves the list after ~17 of 12,448 features and never scrolls it.
+    expect(scroller?.tabIndex).toBe(0);
+  });
+
+  it('clears a highlight whose row the virtualizer has unmounted', () => {
+    const engine = stubEngine();
+    const { container } = renderPanel(engine);
+    const scroller = container.querySelector<HTMLElement>('div[style*="overflow-y: auto"]');
+    // Hover the first row, then scroll far past it. Removing a node fires no
+    // `mouseleave`, so the row's own handler never runs — the panel has to notice
+    // the highlighted row leaving the window.
+    const firstRow = container.querySelectorAll('label')[2];
+    fireEvent.mouseEnter(firstRow);
+    expect(engine.getHighlightedFeature(LAYER_KEY)).toBeGreaterThanOrEqual(0);
+
+    if (scroller) {
+      scroller.scrollTop = 8_000;
+      fireEvent.scroll(scroller);
+    }
+    expect(engine.getHighlightedFeature(LAYER_KEY)).toBe(-1);
   });
 
   it('still reports the full catalog size in the header', () => {

--- a/packages/vis/tests/pointsFeatureListVirtualization.spec.tsx
+++ b/packages/vis/tests/pointsFeatureListVirtualization.spec.tsx
@@ -1,0 +1,157 @@
+/**
+ * The points feature list must stay windowed.
+ *
+ * A Xenium 5K-plus panel is ~12.4k features, and a row each put 91,107 nodes and
+ * 12,453 checkboxes in the DOM (#172). The net for both halves of the fix: the DOM
+ * stays a window, and the whole-catalog classification pass behind the summary lines
+ * runs per change of input rather than per render — it survives virtualization, so
+ * it is the floor the DOM cost was hiding.
+ */
+import type { PointsDataEngine, PointsLoadTarget } from '@spatialdata/layers';
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpatialCanvasProvider } from '../src/SpatialCanvas/context';
+import { PointsFeatureFilterPanel } from '../src/SpatialCanvas/PointsFeatureFilterPanel';
+import { PointsFeatureStateProvider } from '../src/SpatialCanvas/PointsFeatureState';
+import type { PointsLayerConfig } from '../src/SpatialCanvas/types';
+
+const FEATURE_COUNT = 12_448;
+const LAYER_KEY = 'points:transcripts';
+
+function catalogOf(count: number) {
+  return {
+    featureKey: 'feature_name',
+    entries: Array.from({ length: count }, (_, index) => ({
+      code: index,
+      name: `GENE_${String(index).padStart(5, '0')}`,
+      count: count - index,
+    })),
+  };
+}
+
+/** A duck-typed stand-in for the engine's read surface — only what
+ * `usePointsFeatureState` calls. A real engine would drag in a store and a loader. */
+function stubEngine(overrides: Record<string, unknown> = {}) {
+  const catalog = catalogOf(FEATURE_COUNT);
+  const engine = {
+    subscribe: () => () => {},
+    getVersion: () => 1,
+    ensureFeatureCatalog: vi.fn(async () => {}),
+    setHighlightedFeature: vi.fn(),
+    retry: vi.fn(),
+    supportsFeatureScan: () => true,
+    getFeatureCatalog: () => catalog,
+    isFeatureCatalogLoading: () => false,
+    isFeatureCatalogRefining: () => false,
+    // Every feature resident, so no row is greyed and the summary pass has real work.
+    getResidentFeatureCodes: () => new Set(catalog.entries.map((entry) => entry.code)),
+    getLoadedMatchingFeatureCodes: () => undefined,
+    getMatchingLoadState: () => undefined,
+    getActiveTruncation: () => undefined,
+    isTiled: () => false,
+    getResidentFeatureCounts: () => new Map(catalog.entries.map((e) => [e.code, e.count])),
+    ...overrides,
+  };
+  return engine as unknown as PointsDataEngine;
+}
+
+const CONFIG: PointsLayerConfig = {
+  id: 'layer-1',
+  type: 'points',
+  visible: true,
+  opacity: 1,
+  elementKey: 'transcripts',
+};
+
+function renderPanel(engine: PointsDataEngine) {
+  const target = {
+    key: LAYER_KEY,
+    layerId: CONFIG.id,
+    element: {} as PointsLoadTarget['element'],
+  };
+  return render(
+    <SpatialCanvasProvider>
+      <PointsFeatureStateProvider engine={engine} target={target}>
+        <PointsFeatureFilterPanel config={CONFIG} />
+      </PointsFeatureStateProvider>
+    </SpatialCanvasProvider>
+  );
+}
+
+/**
+ * jsdom lays nothing out, so `offsetHeight` — what the virtualizer measures its
+ * scroll box with — is 0, and a zero-height viewport windows to no rows. Stand in
+ * the height the panel gives the list; without it every assertion below would pass
+ * on an empty list, the one outcome that must not count as success.
+ */
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(180);
+  vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(240);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('points feature list virtualization', () => {
+  it('mounts a window of rows, not the whole catalog', () => {
+    const { container } = renderPanel(stubEngine());
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    // Two of these are the "All features" / "Deselect all" controls, which are not
+    // part of the virtualized list.
+    expect(checkboxes.length).toBeLessThan(60);
+    // The list is not simply empty — the whole point is that it still renders rows.
+    // A 180px viewport of 22px rows plus overscan — around 17 rows, and nowhere
+    // near 12,448. The lower bound matters as much as the upper: an empty list
+    // would satisfy the cap above while rendering nothing at all.
+    expect(checkboxes.length).toBeGreaterThan(10);
+  });
+
+  it('keeps the DOM far below the unvirtualized cost', () => {
+    const { container } = renderPanel(stubEngine());
+    // 12,448 features rendered a row each measured at 91,107 nodes. The windowed
+    // panel is ~112. Any number in the low hundreds means the window is holding.
+    expect(container.querySelectorAll('*').length).toBeLessThan(500);
+  });
+
+  it('still reports the full catalog size in the header', () => {
+    const { container } = renderPanel(stubEngine());
+    expect(container.textContent).toContain(`${FEATURE_COUNT}/${FEATURE_COUNT} selected`);
+  });
+
+  it('sizes the scroll spacer to the whole list, so the scrollbar covers every feature', () => {
+    const { container } = renderPanel(stubEngine());
+    const spacer = container.querySelector<HTMLElement>('div[style*="position: relative"]');
+    expect(spacer).not.toBeNull();
+    // Row height × feature count — the scrollable extent of all 12,448 rows.
+    expect(Number.parseInt(spacer?.style.height ?? '0', 10)).toBeGreaterThan(FEATURE_COUNT * 20);
+  });
+
+  it('classifies the whole catalog once per input change, not once per render', () => {
+    const engine = stubEngine();
+    const residentCodes = engine.getResidentFeatureCodes(LAYER_KEY);
+    // Identity-stable reads are what let the panel memoise its O(features) pass;
+    // the real engine caches these on the row-code buffer for the same reason.
+    const getResident = vi.fn(() => residentCodes);
+    const stable = stubEngine({ getResidentFeatureCodes: getResident });
+    const { rerender } = renderPanel(stable);
+    const afterFirst = getResident.mock.calls.length;
+    const target = {
+      key: LAYER_KEY,
+      layerId: CONFIG.id,
+      element: {} as PointsLoadTarget['element'],
+    };
+    rerender(
+      <SpatialCanvasProvider>
+        <PointsFeatureStateProvider engine={stable} target={target}>
+          <PointsFeatureFilterPanel config={CONFIG} />
+        </PointsFeatureStateProvider>
+      </SpatialCanvasProvider>
+    );
+    // The read still happens per render (it is cheap); what must NOT happen is the
+    // catalog-wide reclassification behind it, which is why the reads must return a
+    // stable identity. Assert the contract this memoisation rests on.
+    expect(getResident.mock.calls.length).toBeGreaterThan(afterFirst);
+    expect(getResident.mock.results.every((r) => r.value === residentCodes)).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       '@spatialdata/react':
         specifier: workspace:*
         version: link:../react
+      '@tanstack/react-virtual':
+        specifier: ^3.14.10
+        version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3243,6 +3246,15 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -12601,6 +12613,14 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
Closes #172. Closes #175.

Two commits, one per issue. #175's issue notes the two are best done together — virtualizing the list is what makes the tick count stop mattering, and the iterable is the independent lever on the same cost.

## Virtualize the points feature list (#172)

The list rendered a row per catalog entry. Measured in the demo on the 12,448-feature Xenium transcripts element:

| | before | after |
| --- | --- | --- |
| DOM nodes | 91,107 | 745 |
| checkboxes | 12,453 | 22 |
| feature rows mounted | 12,448 | 17 |

Windowed with `@tanstack/react-virtual` — a new dependency of `@spatialdata/vis`, so MDV inherits it — at a fixed 22px row height. Rows are single lines, so nothing needs measuring and no `ResizeObserver` enters the path. Scroll extent, search, sorting, per-feature colour overrides and hover highlighting are unchanged.

That promoted the classification pass to the floor, as the issue predicted, so it goes too. The two summary lines count greyed and partly-loaded rows across the whole catalog however few rows render, and they ran on every engine notify — dozens of times during a streaming preload. That pass, the dataset-count index and the name→code selection resolve are now memoised; only mounted rows are classified per render.

One supporting change in `@spatialdata/core`: `PointsResolver`'s covered-codes set is memoised on the scan signature. It was re-parsing a 12k-entry string and returning a fresh `Set` per call, which defeated any memoisation downstream of it.

## Add `streamPoints()` (#175)

Additive, with `onProgress` deprecated rather than removed — the transitional option the issue names, since `PointsLoadOptions.onProgress` is consumed by MDV and `@spatialdata/vis`.

```ts
for await (const progress of element.streamPoints({ includeFeatureCodes: true })) {
  draw(progress.partialResult);
}
```

- `SpatialDataPointsSource.streamPoints` / `PointsElement.streamPoints` — an `AsyncGenerator<PointsLoadProgress, PointsLoadResult>`. It yields the growing result and *returns* the settled one, which `for await` discards.
- `streamPointsMatchingFeatureCodes` beside `loadPointsMatchingFeatureCodes`.
- `coalesceLatest`, `sampleByStep`, `drainStream` — generic combinators over async iterables. `coalesceLatest` is the rate lever: it drops superseded items when the consumer falls behind, sound here only because every points tick is a cumulative snapshot.

`onProgress` is implemented by draining the same generator, so the two cannot become separate code paths that drift. It also still selects the progressive read path, so a caller passing no callback takes the one-shot decode exactly as before — there is a test pinning that.

Internally `streamGeometryWithFeaturesInWorker` is a generator and `postRequest`'s `onChunk` option is gone; streaming requests go through `postStreamingRequest`, which owns the queue. The worker boundary stays push (`postMessage` is push), so the generator sits on top of the message plumbing rather than replacing it. Neither is on the published surface, so no consumer sees the signature change.

Writing the cancellation test caught a real bug: `break` out of `streamPoints` did not reach the worker stream, because the worker reader was hand-driven with `next()` rather than `for await`, which skips the automatic close. Fixed with an explicit `finally`.

## Not done, deliberately

`PointsResolver` keeps its existing `silent`-emit throttle rather than switching to a combinator. Its progress handler has to keep the partial buffer fresh on *every* tick — the buffer's identity drives the overlay resource — while notifying rarely, which is neither combinator's policy. Swapping a working, load-bearing mechanism for an equivalent one is worth doing on its own evidence, not as a rider here. So "emit fewer ticks" lands as a tested, exported tool rather than a wiring change.

## Verification

- Full monorepo suite green: 63 core files / 19 vis files, all packages.
- `pnpm build` clean; `biome ci packages/*/src` clean; `lint:react` at its two pre-existing warnings.
- New tests: virtualization windowing (`pointsFeatureListVirtualization.spec.tsx`), the combinators (`asyncStream.spec.ts`), the public stream surface (`pointsStreamApi.spec.ts`), and the worker streaming protocol rewritten against the generator API with two added cases — `break` cancels, and a consumer throw cancels.
- Exercised in the browser against the live 4.83M-row / 12,448-feature Xenium store: 4M rows preloaded and coloured through the generator path, 745 DOM nodes, 4 long tasks totalling 2.9s, list scrolling and feature selection both correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added async streaming APIs for progressively loading all points or feature-filtered points.
  - Added stream combinators for latest-item coalescing, step-based sampling, and draining.
  - Virtualized large point feature lists for smoother browsing and fewer rendered elements.

- **Bug Fixes**
  - Improved cancellation and error handling during streaming.
  - Preserved progress callbacks while recommending the newer streaming APIs.
  - Improved feature-row counts and classification for partially loaded catalogs.

- **Performance**
  - Reduced repeated processing and memory usage when handling large point catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->